### PR TITLE
feat: teach external-data canvases in create-canvas-kit

### DIFF
--- a/skills/create-canvas-kit/README.md
+++ b/skills/create-canvas-kit/README.md
@@ -48,8 +48,9 @@ to your request, and validates it visually before handing it back.
   GitHub-dark fallbacks.
 - **Official GitHub icons** — the exact Lucide set github-app ships
   (`lucide-react@1.14.0`), vendored and byte-identical.
-- **A generator** — `node scripts/new-canvas.mjs <name>` stamps a working canvas.
-- **Tests** — a standalone HTTP harness and a kit byte-parity check.
+- **A generator** — `node scripts/new-canvas.mjs <name>` stamps a working canvas
+  (add `--template data` for a fetch + auto-refresh canvas) with its own smoke test.
+- **Tests** — a standalone HTTP harness, a kit byte-parity check, and a generator test.
 
 ## Use it
 
@@ -120,10 +121,15 @@ skill uses:
 ```sh
 # A working list canvas, kit copied in for you:
 node scripts/new-canvas.mjs my-board --title "My Board" --dir .github/extensions/my-board
+
+# An external-data canvas (fetch + refresh + visibility-gated auto-refresh):
+node scripts/new-canvas.mjs market-feed --template data --dir .github/extensions/market-feed
 ```
 
 Reload extensions, then open the canvas (`canvasId: "my-board"`). It works out of
 the box: add, toggle, and remove items, live, shared between you and the agent.
+Each stamped canvas ships a `test/smoke.test.mjs` — run `node test/smoke.test.mjs`
+from the canvas folder to prove its actions over real HTTP.
 
 Then make it yours:
 
@@ -150,19 +156,21 @@ from jongio/copilot-extensions/extensions/stock-ticker."* No clone, no build.
 ```
 SKILL.md                      The Copilot skill (authoring contract + workflow)
 kit/                          The canonical kit — copy into your extension as canvas-kit/
-  client.mjs                  Browser runtime: html, mountCanvas, useState, Icon
+  client.mjs                  Browser runtime: html, mountCanvas, pollWhileVisible, hooks, Icon, formatters
   server.mjs                  SDK-free runtime: /state, /events (SSE), /action, static
   storage.mjs                 Durable per-user JSON store
+  format.mjs                  nid + relativeTime / compactNumber / percent helpers
   theme.css                   Primer-token styling (ck-* classes)
   icons.mjs                   Lucide Icon component + helpers
   vendor/                     Vendored Preact+htm and the Lucide glyph data
 reference/decision-log/       Complete working canvas in the real installed shape
 scripts/
-  new-canvas.mjs              Generator — stamp a new canvas
+  new-canvas.mjs              Generator — stamp a new canvas (--template list|data)
   install-local.ps1           Install this skill into $COPILOT_HOME/skills
 test/
   http.test.mjs               Boots the runtime over real HTTP and checks the contract
   kit-parity.test.mjs         Asserts kit/ == reference canvas-kit/ (no drift)
+  generator.test.mjs          Stamps both templates, runs their smoke tests, checks the kit API
 ```
 
 ## Run the tests
@@ -170,6 +178,7 @@ test/
 ```sh
 node test/http.test.mjs
 node test/kit-parity.test.mjs
+node test/generator.test.mjs
 ```
 
 No dependencies to install — everything is vendored. Node 18+ (developed on 24).

--- a/skills/create-canvas-kit/SKILL.md
+++ b/skills/create-canvas-kit/SKILL.md
@@ -96,14 +96,163 @@ They map to the Primer tokens the runtime injects onto the canvas document, each
 with a hardcoded GitHub-dark fallback, so a canvas looks right even if a token is
 missing. Add canvas-specific CSS on top; don't restyle the primitives.
 
+**Badges are generic.** Use the semantic variants `ck-badge-success`,
+`ck-badge-accent`, `ck-badge-muted`, `ck-badge-danger`, `ck-badge-attention` and
+map *your* statuses to them in the view (the reference does
+`open → success, decided → accent, parked → muted`). Don't add app-specific
+status class names to the shared theme.
+
+**Loading & error primitives** (don't hand-roll these):
+
+- `ck-spinner` — spin animation; pair with a Lucide loader, e.g.
+  `html\`<\${Icon} name="loader-circle" class="ck-spinner" />\``.
+- `ck-skeleton` — shimmering placeholder block for content that's still loading.
+- `ck-callout` / `ck-callout ck-error` — an inline notice / error surface for a
+  failed fetch, e.g. `html\`<div class="ck-callout ck-error"><\${Icon} name="circle-x" size=\${16} /><span>\${state.error}</span></div>\``.
+
+**Motion safety is global.** `theme.css` already ships a
+`@media (prefers-reduced-motion: reduce)` guard that neutralizes *all* animations
+and transitions (kit spinners/skeletons and any you add). You do **not** repeat
+it per canvas — but do keep motion decorative, never the only signal.
+
+## View API — hooks, helpers, fragments
+
+`/kit/client.mjs` re-exports the full vendored Preact hook set, not just
+`useState`: `useEffect`, `useRef`, `useMemo`, `useCallback`, `useReducer`,
+`useContext`, `useLayoutEffect`, `useImperativeHandle`. Call hooks
+unconditionally at the top of a component — **before** any early `return`
+(e.g. the `if (!state) return …` loading branch comes after your hooks).
+
+It also exports formatting + id helpers so you stop reinventing them:
+
+```js
+import { nid, relativeTime, compactNumber, percent } from "/kit/client.mjs";
+nid();                       // "lq3k9f2a" — short unique id
+relativeTime(iso);           // "5m ago" / "3h ago" / "2d ago" / a date
+compactNumber(2_300_000);    // "2.3M"
+percent(1.25);               // "+1.25%"
+```
+
+`nid` is also importable server-side in `canvas.mjs` via
+`import { nid } from "./canvas-kit/format.mjs"` (the generator does this).
+
+**`Fragment` is NOT exported.** To return sibling nodes without a wrapper, use
+htm's built-in empty-tag syntax — `` html`<><${A} /><${B} /></>` `` — or just
+return an array of vnodes. Don't `import { Fragment }`; it isn't there.
+
+## External-data canvases — fetch + auto-refresh
+
+Most real canvases aren't user-entered CRUD lists; they pull from the network and
+refresh. The shape:
+
+1. **`fetch()` lives in the action handler (or a helper it calls), never in the
+   view.** Always bound it with a timeout so a slow upstream can't hang the panel:
+
+   ```js
+   async function fetchItems(url) {
+     const res = await fetch(url, { signal: AbortSignal.timeout(12000) });
+     if (!res.ok) throw new Error(`HTTP ${res.status}`);
+     return mapItems(await res.json());
+   }
+   ```
+
+   The fetch runs server-side on the loopback runtime, so a caller-set
+   `sourceUrl` is an **unrestricted server-side fetch** (it can reach internal
+   hosts), and anything you feed back to the agent (e.g. via `list_items`) is
+   attacker-influenced text. That's acceptable for a local dev tool you point at
+   a source *you* choose — but don't let an untrusted party set the URL, and
+   treat fetched content as untrusted (render it as text, never `innerHTML`).
+
+2. **Expose a `refresh` action** that fetches and writes the result into shared
+   state. Capture failures into `state.error` and *return* (don't throw) so a
+   background poll tick stays quiet while the error card shows. Capture the input
+   **before** the `await`, and write back with a **functional `set`** so a
+   concurrent action (another poll, a `set_source`) isn't clobbered:
+
+   ```js
+   refresh: {
+     inputSchema: { type: "object", properties: {}, additionalProperties: false },
+     handler: async ({ state, set }) => {
+       const sourceUrl = state.sourceUrl;          // capture before await
+       try {
+         const items = await fetchItems(sourceUrl);
+         set((cur) => cur.sourceUrl !== sourceUrl  // drop a stale response
+           ? cur
+           : { ...cur, items, error: null, lastRefresh: new Date().toISOString() });
+         return { count: items.length };
+       } catch (err) {
+         set((cur) => ({ ...cur, error: `Couldn't load: ${err.message}`, lastRefresh: new Date().toISOString() }));
+         return { ok: false, error: String(err.message) };
+       }
+     },
+   },
+   ```
+
+3. **Poll with the kit, not a raw `setInterval`.** `pollWhileVisible(tick,
+   seconds)` runs `tick` on an interval **only while the panel is visible** (so a
+   backgrounded canvas stops hitting the network) and returns a cleanup function —
+   a drop-in `useEffect` return:
+
+   ```js
+   import { pollWhileVisible } from "/kit/client.mjs";
+   // interval bound to durable state; rebuilds when it changes:
+   useEffect(() => pollWhileVisible(() => invoke("refresh"), state.autoRefreshSec || 0),
+             [state.autoRefreshSec]);
+   ```
+
+   For a fixed interval you can skip the effect entirely:
+   `mountCanvas({ view, poll: { action: "refresh", seconds: 60, immediate: true } })`.
+
+Stamp this whole shape with `node scripts/new-canvas.mjs <name> --template data`.
+
+## Domain strategy — shared board vs personal profile
+
+State is keyed by the domain id `resolveDomainId` returns. Two intents, identical
+machinery (`fileFor` sanitizes the id to a filename — copy it verbatim):
+
+- **Shared board** (most canvases): key off a topic the agent and user both name.
+  `resolveDomainId: (input) => (input?.domain ? String(input.domain) : "default")`.
+  Anyone who opens `domain: "tech"` sees the same board.
+- **Personal store**: key off an identity, not a topic.
+  `resolveDomainId: (input) => (input?.profile ? String(input.profile) : "default")`,
+  with the input schema property named `profile`. Use this for per-learner /
+  per-user data that shouldn't bleed across topics.
+
+Pick the noun (`domain` vs `profile`) deliberately — it's the whole contract for
+who shares what.
+
+## Patterns & limitations (know these)
+
+- **Bundled catalog.** For curated seed data (courses, presets), ship a separate
+  `catalog.mjs`: plain data plus a `buildCourse(...)`-style builder that assigns
+  **deterministic positional ids** (`es-u1-l2`) so the same catalog always
+  produces the same ids. Keep the bulk data terse with tiny constructor helpers.
+- **`statusLine` is computed once, at open.** The panel's status string is set on
+  `openInstance` and is **not** re-pushed when an action mutates state, so a
+  count in `statusLine` goes stale. Show live counts **inside** the canvas body
+  (which re-renders on every SSE push), and treat `statusLine` as an
+  open-time-only summary.
+- **Rich-payload actions.** If the UI needs to hand the agent's handler a whole
+  object (e.g. the article being saved) rather than scalar fields, set
+  `additionalProperties: true` on that action's `inputSchema` (the generator
+  defaults to `false`). Denormalize what you need into durable state in the
+  handler.
+- **Install layout / SDK resolution.** A shipped extension folder contains only
+  `copilot-extension.json` (`{ "name", "version": 1 }` — no `package.json`),
+  `extension.mjs`, `canvas.mjs`, `web/`, and the nested `canvas-kit/`. The host
+  resolves `@github/copilot-sdk/extension` for you; `extension.mjs` is the only
+  file that imports it. Don't add a `package.json` or a build step.
+
 ## Build a canvas — fastest path
 
-1. **Stamp it** (one working list canvas, kit already nested):
+1. **Stamp it** (one working canvas, kit already nested, a smoke test included):
    ```
    node scripts/new-canvas.mjs <name> --dir <target> --title "Display Name"
    ```
    For an in-repo extension, target `.github/extensions/<name>`. For a personal
-   one, target `$COPILOT_HOME/extensions/<name>`.
+   one, target `$COPILOT_HOME/extensions/<name>`. Add `--template data` for an
+   external-data canvas (fetch + `refresh` + visibility-gated polling) instead of
+   the default user-entered list.
 2. **Reload + open.** Run `extensions_reload`, then `open_canvas` with
    `canvasId: "<name>"`. The list canvas works immediately.
 3. **Shape your data.** In `canvas.mjs`, edit `createInitialState`, the action
@@ -124,7 +273,10 @@ verbatim and adapt `canvas.mjs` + `web/` from the reference.
 A canvas isn't done because the server boots. Verify the UI:
 
 1. Run the standalone HTTP test to prove the runtime contract:
-   `node test/http.test.mjs` (and `node test/kit-parity.test.mjs`).
+   `node test/http.test.mjs` (and `node test/kit-parity.test.mjs`,
+   `node test/generator.test.mjs`). A stamped canvas ships its own
+   `test/smoke.test.mjs` — run it from the canvas folder
+   (`node test/smoke.test.mjs`) to prove its actions over real HTTP.
 2. Open the canvas and **look at it** (Playwright or the browser canvas):
    navigate to the panel, assert key text/controls render, take a screenshot.
 3. Drive an action from the UI **and** invoke the same action as the agent;
@@ -140,6 +292,8 @@ A canvas isn't done because the server boots. Verify the UI:
   `/state`, `/events`, `/action`, static serving, and path-traversal safety.
 - `test/kit-parity.test.mjs` — guarantees `kit/` and the reference's bundled
   `canvas-kit/` stay byte-identical.
+- `test/generator.test.mjs` — stamps both templates, runs their smoke tests, and
+  checks the kit API surface (format helpers, poll helper, theme primitives).
 
 ## Footguns
 
@@ -149,3 +303,8 @@ A canvas isn't done because the server boots. Verify the UI:
 - **Never** hand-roll or CDN-load icons — use `/kit/client.mjs`'s `Icon`.
 - **Never** put SDK imports outside `extension.mjs`.
 - **Never** pass `strokeWidth` to `Icon` or invent pixel sizes off the scale.
+- **Never** `fetch()` in the view — network I/O belongs in an action handler,
+  always with `AbortSignal.timeout(...)`.
+- **Never** hand-roll a polling `setInterval` — use `pollWhileVisible` so a
+  hidden panel stops hammering the network.
+- **Never** `import { Fragment }` — it isn't exported; use htm's `<>…</>`.

--- a/skills/create-canvas-kit/kit/client.mjs
+++ b/skills/create-canvas-kit/kit/client.mjs
@@ -19,6 +19,48 @@ export { html };
 // `lucideSVG` is the string helper for vanilla canvases.
 export { Icon, lucideSVG, hasIcon, iconNames } from "./icons.mjs";
 
+// Formatting + id helpers (also importable directly from /kit/format.mjs in
+// SDK-free canvas.mjs). Re-exported here so views have one import site.
+export { nid, relativeTime, compactNumber, percent } from "./format.mjs";
+
+/**
+ * Run `tick` on an interval, but only while the panel is visible — so a
+ * backgrounded canvas stops polling a (possibly rate-limited) upstream. Returns
+ * a cleanup function, which makes it a drop-in `useEffect` return value:
+ *
+ *   useEffect(
+ *     () => pollWhileVisible(() => invoke("refresh"), state.autoRefreshSec),
+ *     [state.autoRefreshSec]
+ *   );
+ *
+ * This is the single primitive behind every data canvas's auto-refresh; it
+ * replaces the hand-rolled `setInterval` + `document.visibilityState` checks.
+ * @param {()=>any} tick                 called each interval (promise rejections are swallowed)
+ * @param {number} seconds               interval in seconds; <=0 disables (returns a no-op cleanup)
+ * @param {object} [opts]
+ * @param {boolean} [opts.whenVisible=true]  skip ticks while the panel is hidden
+ * @param {boolean} [opts.immediate=false]   fire one tick immediately
+ * @returns {()=>void} cleanup
+ */
+export function pollWhileVisible(tick, seconds, { whenVisible = true, immediate = false } = {}) {
+  if (!seconds || seconds <= 0) return () => {};
+  let inFlight = false;
+  const run = async () => {
+    if (inFlight) return; // don't stack ticks if a slow one is still running
+    if (whenVisible && typeof document !== "undefined" && document.visibilityState !== "visible") return;
+    inFlight = true;
+    try {
+      await tick();
+    } catch { /* keep the interval alive */ }
+    finally {
+      inFlight = false;
+    }
+  };
+  if (immediate) run();
+  const id = setInterval(run, seconds * 1000);
+  return () => clearInterval(id);
+}
+
 /**
  * Mount a canvas view and keep it live.
  * @param {object} opts
@@ -26,9 +68,11 @@ export { Icon, lucideSVG, hasIcon, iconNames } from "./icons.mjs";
  *        Returns an htm/Preact vnode. Re-invoked on every state push.
  * @param {HTMLElement} [opts.mount]   defaults to #app or <body>
  * @param {(state:any)=>void} [opts.onState]
- * @returns {{invoke:Function, refresh:Function, get state():any}}
+ * @param {PollOptions} [opts.poll]   built-in fixed-interval visibility-gated auto-refresh.
+ *        For an interval bound to live state, use `pollWhileVisible` in a useEffect instead.
+ * @returns {{invoke:Function, refresh:Function, stopPoll:Function, get state():any}}
  */
-export function mountCanvas({ view, mount, onState } = {}) {
+export function mountCanvas({ view, mount, onState, poll } = {}) {
   const root = mount || document.getElementById("app") || document.body;
   // Preact's render() diffs against — but does not clear — pre-existing DOM in
   // the container, so a static no-JS placeholder (e.g. <p>Loading…</p> in the
@@ -80,9 +124,30 @@ export function mountCanvas({ view, mount, onState } = {}) {
   refresh();
   connect();
 
+  // Built-in fixed-interval auto-refresh, delegating to the shared
+  // visibility-gated primitive. Pass `poll: { action, seconds, immediate }`.
+  //
+  // @typedef {object} PollOptions
+  // @property {string} [action]        action to invoke each tick; omit to call refresh()
+  // @property {number} seconds         interval in seconds; <=0 disables polling
+  // @property {object} [input]         input passed to the action
+  // @property {boolean} [whenVisible=true]  skip ticks while the panel is hidden
+  // @property {boolean} [immediate=false]   fire one tick right after mount
+  function startPoll({ action, seconds, input, whenVisible = true, immediate = false } = {}) {
+    return pollWhileVisible(
+      () => (action ? invoke(action, input) : refresh()),
+      seconds,
+      { whenVisible, immediate }
+    );
+  }
+
+  let stopPoll = () => {};
+  if (poll) stopPoll = startPoll(poll);
+
   return {
     invoke,
     refresh,
+    stopPoll: () => stopPoll(),
     get state() { return state; },
   };
 }

--- a/skills/create-canvas-kit/kit/format.mjs
+++ b/skills/create-canvas-kit/kit/format.mjs
@@ -1,0 +1,82 @@
+// canvas-kit/format.mjs
+//
+// Tiny, dependency-free formatting + id helpers shared by canvas views and
+// handlers. Pure JS (no Node, no DOM) so it is safe to import from BOTH the
+// browser view (web/app.mjs, via /kit/client.mjs) and the SDK-free server
+// (canvas.mjs). These exist because every real data canvas was reinventing the
+// same number/percent/relative-time formatters and copy-pasting `nid` verbatim.
+
+/**
+ * Short, collision-resistant id. Verbatim the generator every shipped canvas
+ * used: a base-36 timestamp plus 4 random base-36 chars.
+ * @returns {string}
+ */
+export function nid() {
+  return Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
+}
+
+// Accept an epoch-ms number, a Date, or an ISO/parseable date string.
+function toMillis(when) {
+  if (when == null) return null;
+  if (typeof when === "number") return Number.isFinite(when) ? when : null;
+  if (when instanceof Date) return when.getTime();
+  const ms = Date.parse(String(when));
+  return Number.isNaN(ms) ? null : ms;
+}
+
+/**
+ * Human "time ago" string: "just now", "5m ago", "3h ago", "2d ago", then a
+ * locale date. Mirrors the relTime helper data canvases kept reimplementing.
+ * @param {number|string|Date} when  epoch ms, Date, or ISO string
+ * @param {object} [opts]
+ * @param {number|string|Date} [opts.now=Date.now()]  reference point (testable)
+ * @param {string} [opts.fallback=""]  returned when `when` is missing/invalid
+ * @returns {string}
+ */
+export function relativeTime(when, { now = Date.now(), fallback = "" } = {}) {
+  const ms = toMillis(when);
+  const ref = toMillis(now) ?? Date.now();
+  if (ms == null) return fallback;
+  const s = Math.max(0, Math.floor((ref - ms) / 1000));
+  if (s < 60) return "just now";
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  if (d < 7) return `${d}d ago`;
+  return new Date(ms).toLocaleDateString();
+}
+
+/**
+ * Compact number: 1500 -> "1.5K", 2.3e9 -> "2.3B". Wraps Intl compact notation.
+ * @param {number|null|undefined} v
+ * @param {object} [opts]
+ * @param {number} [opts.digits=2]   max fraction digits
+ * @param {string} [opts.fallback="—"]
+ * @returns {string}
+ */
+export function compactNumber(v, { digits = 2, fallback = "—" } = {}) {
+  if (v == null || !Number.isFinite(Number(v))) return fallback;
+  return Number(v).toLocaleString(undefined, {
+    notation: "compact",
+    maximumFractionDigits: digits,
+  });
+}
+
+/**
+ * Percent string: 1.2345 -> "+1.23%". Input is already a percentage value
+ * (not a 0..1 ratio), matching the shipped fmtPct.
+ * @param {number|null|undefined} v
+ * @param {object} [opts]
+ * @param {boolean} [opts.signed=true]  prefix "+" for non-negative values
+ * @param {number} [opts.digits=2]
+ * @param {string} [opts.fallback="—"]
+ * @returns {string}
+ */
+export function percent(v, { signed = true, digits = 2, fallback = "—" } = {}) {
+  if (v == null || !Number.isFinite(Number(v))) return fallback;
+  const n = Number(v);
+  const sign = signed && n >= 0 ? "+" : "";
+  return `${sign}${n.toFixed(digits)}%`;
+}

--- a/skills/create-canvas-kit/kit/theme.css
+++ b/skills/create-canvas-kit/kit/theme.css
@@ -141,9 +141,14 @@ h3 { font-size: var(--text-title-small, 1rem); font-weight: var(--ck-fw-semibold
   border: 1px solid var(--ck-border);
   color: var(--ck-muted);
 }
-.ck-badge-open { color: var(--text-color-open, #3fb950); border-color: var(--border-color-success-emphasis, #238636); }
-.ck-badge-decided { color: var(--text-color-done, #a371f7); border-color: var(--border-color-accent-emphasis, #8957e5); }
-.ck-badge-parked { color: var(--text-color-muted, #8b949e); border-color: var(--ck-border); }
+/* Generic semantic badge variants — map your own statuses to these in the view
+   (e.g. open -> ck-badge-success, decided -> ck-badge-accent). Do NOT add
+   app-specific status names here; this is the shared kit theme. */
+.ck-badge-success { color: var(--ck-success); border-color: var(--border-color-success-emphasis, #238636); }
+.ck-badge-accent { color: var(--text-color-accent, #a371f7); border-color: var(--border-color-accent-emphasis, #8957e5); }
+.ck-badge-danger { color: var(--ck-danger); border-color: var(--border-color-danger-emphasis, #da3633); }
+.ck-badge-attention { color: var(--ck-attention); border-color: var(--border-color-attention-emphasis, #9e6a03); }
+.ck-badge-muted { color: var(--ck-muted); border-color: var(--ck-border); }
 
 /* ---- segmented tabs ------------------------------------------------------ */
 .ck-tabs { display: inline-flex; gap: 2px; background: var(--ck-bg-inset); padding: 2px; border-radius: var(--ck-radius); border: 1px solid var(--ck-border); }
@@ -162,7 +167,61 @@ h3 { font-size: var(--text-title-small, 1rem); font-weight: var(--ck-fw-semibold
 
 .ck-empty { color: var(--ck-muted); text-align: center; padding: 28px 0; }
 
+/* ---- loading: spinner + skeleton ----------------------------------------- */
+/* Spinner: pair with a Lucide "loader-circle" icon —
+   html`<${Icon} name="loader-circle" class="ck-spinner" />`. */
+.ck-spinner { animation: ck-spin 0.9s linear infinite; transform-origin: center; }
+@keyframes ck-spin { to { transform: rotate(360deg); } }
+
+/* Skeleton: a shimmering placeholder block while data loads. */
+.ck-skeleton {
+  position: relative;
+  overflow: hidden;
+  background: var(--ck-bg-muted);
+  border-radius: var(--ck-radius);
+  min-height: 14px;
+}
+.ck-skeleton::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.06), transparent);
+  animation: ck-shimmer 1.2s ease-in-out infinite;
+}
+@keyframes ck-shimmer { to { transform: translateX(100%); } }
+
+/* ---- callout / error surface --------------------------------------------- */
+.ck-callout {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 8px 12px;
+  border: 1px solid var(--ck-border);
+  border-left: 3px solid var(--ck-accent);
+  border-radius: var(--ck-radius);
+  background: var(--ck-bg-muted);
+  color: var(--ck-fg);
+}
+.ck-callout .ck-icon { margin-top: 2px; color: var(--ck-accent); }
+.ck-error { border-left-color: var(--ck-danger); }
+.ck-error .ck-icon { color: var(--ck-danger); }
+
 /* ---- icons (Lucide) ------------------------------------------------------ */
 /* Inline SVGs inherit text color via stroke="currentColor". */
 .ck-icon { flex: none; vertical-align: text-bottom; }
 .ck-empty .ck-icon { display: block; margin: 0 auto 8px; color: var(--ck-muted); }
+
+/* ---- motion safety ------------------------------------------------------- */
+/* Global guard: respect the OS "reduce motion" setting for every animation a
+   canvas adds (kit spinners/skeletons included). Author-added keyframes inherit
+   this automatically — you do not need to repeat it per canvas. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+  }
+}

--- a/skills/create-canvas-kit/reference/decision-log/canvas-kit/client.mjs
+++ b/skills/create-canvas-kit/reference/decision-log/canvas-kit/client.mjs
@@ -19,6 +19,48 @@ export { html };
 // `lucideSVG` is the string helper for vanilla canvases.
 export { Icon, lucideSVG, hasIcon, iconNames } from "./icons.mjs";
 
+// Formatting + id helpers (also importable directly from /kit/format.mjs in
+// SDK-free canvas.mjs). Re-exported here so views have one import site.
+export { nid, relativeTime, compactNumber, percent } from "./format.mjs";
+
+/**
+ * Run `tick` on an interval, but only while the panel is visible — so a
+ * backgrounded canvas stops polling a (possibly rate-limited) upstream. Returns
+ * a cleanup function, which makes it a drop-in `useEffect` return value:
+ *
+ *   useEffect(
+ *     () => pollWhileVisible(() => invoke("refresh"), state.autoRefreshSec),
+ *     [state.autoRefreshSec]
+ *   );
+ *
+ * This is the single primitive behind every data canvas's auto-refresh; it
+ * replaces the hand-rolled `setInterval` + `document.visibilityState` checks.
+ * @param {()=>any} tick                 called each interval (promise rejections are swallowed)
+ * @param {number} seconds               interval in seconds; <=0 disables (returns a no-op cleanup)
+ * @param {object} [opts]
+ * @param {boolean} [opts.whenVisible=true]  skip ticks while the panel is hidden
+ * @param {boolean} [opts.immediate=false]   fire one tick immediately
+ * @returns {()=>void} cleanup
+ */
+export function pollWhileVisible(tick, seconds, { whenVisible = true, immediate = false } = {}) {
+  if (!seconds || seconds <= 0) return () => {};
+  let inFlight = false;
+  const run = async () => {
+    if (inFlight) return; // don't stack ticks if a slow one is still running
+    if (whenVisible && typeof document !== "undefined" && document.visibilityState !== "visible") return;
+    inFlight = true;
+    try {
+      await tick();
+    } catch { /* keep the interval alive */ }
+    finally {
+      inFlight = false;
+    }
+  };
+  if (immediate) run();
+  const id = setInterval(run, seconds * 1000);
+  return () => clearInterval(id);
+}
+
 /**
  * Mount a canvas view and keep it live.
  * @param {object} opts
@@ -26,9 +68,11 @@ export { Icon, lucideSVG, hasIcon, iconNames } from "./icons.mjs";
  *        Returns an htm/Preact vnode. Re-invoked on every state push.
  * @param {HTMLElement} [opts.mount]   defaults to #app or <body>
  * @param {(state:any)=>void} [opts.onState]
- * @returns {{invoke:Function, refresh:Function, get state():any}}
+ * @param {PollOptions} [opts.poll]   built-in fixed-interval visibility-gated auto-refresh.
+ *        For an interval bound to live state, use `pollWhileVisible` in a useEffect instead.
+ * @returns {{invoke:Function, refresh:Function, stopPoll:Function, get state():any}}
  */
-export function mountCanvas({ view, mount, onState } = {}) {
+export function mountCanvas({ view, mount, onState, poll } = {}) {
   const root = mount || document.getElementById("app") || document.body;
   // Preact's render() diffs against — but does not clear — pre-existing DOM in
   // the container, so a static no-JS placeholder (e.g. <p>Loading…</p> in the
@@ -80,9 +124,30 @@ export function mountCanvas({ view, mount, onState } = {}) {
   refresh();
   connect();
 
+  // Built-in fixed-interval auto-refresh, delegating to the shared
+  // visibility-gated primitive. Pass `poll: { action, seconds, immediate }`.
+  //
+  // @typedef {object} PollOptions
+  // @property {string} [action]        action to invoke each tick; omit to call refresh()
+  // @property {number} seconds         interval in seconds; <=0 disables polling
+  // @property {object} [input]         input passed to the action
+  // @property {boolean} [whenVisible=true]  skip ticks while the panel is hidden
+  // @property {boolean} [immediate=false]   fire one tick right after mount
+  function startPoll({ action, seconds, input, whenVisible = true, immediate = false } = {}) {
+    return pollWhileVisible(
+      () => (action ? invoke(action, input) : refresh()),
+      seconds,
+      { whenVisible, immediate }
+    );
+  }
+
+  let stopPoll = () => {};
+  if (poll) stopPoll = startPoll(poll);
+
   return {
     invoke,
     refresh,
+    stopPoll: () => stopPoll(),
     get state() { return state; },
   };
 }

--- a/skills/create-canvas-kit/reference/decision-log/canvas-kit/format.mjs
+++ b/skills/create-canvas-kit/reference/decision-log/canvas-kit/format.mjs
@@ -1,0 +1,82 @@
+// canvas-kit/format.mjs
+//
+// Tiny, dependency-free formatting + id helpers shared by canvas views and
+// handlers. Pure JS (no Node, no DOM) so it is safe to import from BOTH the
+// browser view (web/app.mjs, via /kit/client.mjs) and the SDK-free server
+// (canvas.mjs). These exist because every real data canvas was reinventing the
+// same number/percent/relative-time formatters and copy-pasting `nid` verbatim.
+
+/**
+ * Short, collision-resistant id. Verbatim the generator every shipped canvas
+ * used: a base-36 timestamp plus 4 random base-36 chars.
+ * @returns {string}
+ */
+export function nid() {
+  return Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
+}
+
+// Accept an epoch-ms number, a Date, or an ISO/parseable date string.
+function toMillis(when) {
+  if (when == null) return null;
+  if (typeof when === "number") return Number.isFinite(when) ? when : null;
+  if (when instanceof Date) return when.getTime();
+  const ms = Date.parse(String(when));
+  return Number.isNaN(ms) ? null : ms;
+}
+
+/**
+ * Human "time ago" string: "just now", "5m ago", "3h ago", "2d ago", then a
+ * locale date. Mirrors the relTime helper data canvases kept reimplementing.
+ * @param {number|string|Date} when  epoch ms, Date, or ISO string
+ * @param {object} [opts]
+ * @param {number|string|Date} [opts.now=Date.now()]  reference point (testable)
+ * @param {string} [opts.fallback=""]  returned when `when` is missing/invalid
+ * @returns {string}
+ */
+export function relativeTime(when, { now = Date.now(), fallback = "" } = {}) {
+  const ms = toMillis(when);
+  const ref = toMillis(now) ?? Date.now();
+  if (ms == null) return fallback;
+  const s = Math.max(0, Math.floor((ref - ms) / 1000));
+  if (s < 60) return "just now";
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  if (d < 7) return `${d}d ago`;
+  return new Date(ms).toLocaleDateString();
+}
+
+/**
+ * Compact number: 1500 -> "1.5K", 2.3e9 -> "2.3B". Wraps Intl compact notation.
+ * @param {number|null|undefined} v
+ * @param {object} [opts]
+ * @param {number} [opts.digits=2]   max fraction digits
+ * @param {string} [opts.fallback="—"]
+ * @returns {string}
+ */
+export function compactNumber(v, { digits = 2, fallback = "—" } = {}) {
+  if (v == null || !Number.isFinite(Number(v))) return fallback;
+  return Number(v).toLocaleString(undefined, {
+    notation: "compact",
+    maximumFractionDigits: digits,
+  });
+}
+
+/**
+ * Percent string: 1.2345 -> "+1.23%". Input is already a percentage value
+ * (not a 0..1 ratio), matching the shipped fmtPct.
+ * @param {number|null|undefined} v
+ * @param {object} [opts]
+ * @param {boolean} [opts.signed=true]  prefix "+" for non-negative values
+ * @param {number} [opts.digits=2]
+ * @param {string} [opts.fallback="—"]
+ * @returns {string}
+ */
+export function percent(v, { signed = true, digits = 2, fallback = "—" } = {}) {
+  if (v == null || !Number.isFinite(Number(v))) return fallback;
+  const n = Number(v);
+  const sign = signed && n >= 0 ? "+" : "";
+  return `${sign}${n.toFixed(digits)}%`;
+}

--- a/skills/create-canvas-kit/reference/decision-log/canvas-kit/theme.css
+++ b/skills/create-canvas-kit/reference/decision-log/canvas-kit/theme.css
@@ -141,9 +141,14 @@ h3 { font-size: var(--text-title-small, 1rem); font-weight: var(--ck-fw-semibold
   border: 1px solid var(--ck-border);
   color: var(--ck-muted);
 }
-.ck-badge-open { color: var(--text-color-open, #3fb950); border-color: var(--border-color-success-emphasis, #238636); }
-.ck-badge-decided { color: var(--text-color-done, #a371f7); border-color: var(--border-color-accent-emphasis, #8957e5); }
-.ck-badge-parked { color: var(--text-color-muted, #8b949e); border-color: var(--ck-border); }
+/* Generic semantic badge variants — map your own statuses to these in the view
+   (e.g. open -> ck-badge-success, decided -> ck-badge-accent). Do NOT add
+   app-specific status names here; this is the shared kit theme. */
+.ck-badge-success { color: var(--ck-success); border-color: var(--border-color-success-emphasis, #238636); }
+.ck-badge-accent { color: var(--text-color-accent, #a371f7); border-color: var(--border-color-accent-emphasis, #8957e5); }
+.ck-badge-danger { color: var(--ck-danger); border-color: var(--border-color-danger-emphasis, #da3633); }
+.ck-badge-attention { color: var(--ck-attention); border-color: var(--border-color-attention-emphasis, #9e6a03); }
+.ck-badge-muted { color: var(--ck-muted); border-color: var(--ck-border); }
 
 /* ---- segmented tabs ------------------------------------------------------ */
 .ck-tabs { display: inline-flex; gap: 2px; background: var(--ck-bg-inset); padding: 2px; border-radius: var(--ck-radius); border: 1px solid var(--ck-border); }
@@ -162,7 +167,61 @@ h3 { font-size: var(--text-title-small, 1rem); font-weight: var(--ck-fw-semibold
 
 .ck-empty { color: var(--ck-muted); text-align: center; padding: 28px 0; }
 
+/* ---- loading: spinner + skeleton ----------------------------------------- */
+/* Spinner: pair with a Lucide "loader-circle" icon —
+   html`<${Icon} name="loader-circle" class="ck-spinner" />`. */
+.ck-spinner { animation: ck-spin 0.9s linear infinite; transform-origin: center; }
+@keyframes ck-spin { to { transform: rotate(360deg); } }
+
+/* Skeleton: a shimmering placeholder block while data loads. */
+.ck-skeleton {
+  position: relative;
+  overflow: hidden;
+  background: var(--ck-bg-muted);
+  border-radius: var(--ck-radius);
+  min-height: 14px;
+}
+.ck-skeleton::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.06), transparent);
+  animation: ck-shimmer 1.2s ease-in-out infinite;
+}
+@keyframes ck-shimmer { to { transform: translateX(100%); } }
+
+/* ---- callout / error surface --------------------------------------------- */
+.ck-callout {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 8px 12px;
+  border: 1px solid var(--ck-border);
+  border-left: 3px solid var(--ck-accent);
+  border-radius: var(--ck-radius);
+  background: var(--ck-bg-muted);
+  color: var(--ck-fg);
+}
+.ck-callout .ck-icon { margin-top: 2px; color: var(--ck-accent); }
+.ck-error { border-left-color: var(--ck-danger); }
+.ck-error .ck-icon { color: var(--ck-danger); }
+
 /* ---- icons (Lucide) ------------------------------------------------------ */
 /* Inline SVGs inherit text color via stroke="currentColor". */
 .ck-icon { flex: none; vertical-align: text-bottom; }
 .ck-empty .ck-icon { display: block; margin: 0 auto 8px; color: var(--ck-muted); }
+
+/* ---- motion safety ------------------------------------------------------- */
+/* Global guard: respect the OS "reduce motion" setting for every animation a
+   canvas adds (kit spinners/skeletons included). Author-added keyframes inherit
+   this automatically — you do not need to repeat it per canvas. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+  }
+}

--- a/skills/create-canvas-kit/reference/decision-log/canvas.mjs
+++ b/skills/create-canvas-kit/reference/decision-log/canvas.mjs
@@ -6,12 +6,9 @@
 
 import { fileURLToPath } from "node:url";
 import { userStore } from "./canvas-kit/storage.mjs";
+import { nid } from "./canvas-kit/format.mjs";
 
 const EXT_NAME = "decision-log";
-
-function nid() {
-  return Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
-}
 
 function fileFor(domainId) {
   const safe = String(domainId).replace(/[^A-Za-z0-9._-]/g, "_") || "default";

--- a/skills/create-canvas-kit/reference/decision-log/web/app.mjs
+++ b/skills/create-canvas-kit/reference/decision-log/web/app.mjs
@@ -16,8 +16,13 @@ const FILTERS = ["all", "open", "decided", "parked"];
 // IssueOpenIcon=CircleDot, CheckCircleIcon=CircleCheck, BookmarkIcon=Bookmark).
 const STATUS_ICON = { open: "circle-dot", decided: "circle-check", parked: "bookmark" };
 
+// Map this canvas's statuses to the kit's generic badge variants. The kit theme
+// ships semantic classes (ck-badge-success/accent/muted/…), not app-specific
+// status names, so each canvas owns its own status -> variant mapping here.
+const STATUS_BADGE = { open: "success", decided: "accent", parked: "muted" };
+
 function Badge({ status }) {
-  return html`<span class=${`ck-badge ck-badge-${status}`}>
+  return html`<span class=${`ck-badge ck-badge-${STATUS_BADGE[status] ?? "muted"}`}>
     <${Icon} name=${STATUS_ICON[status]} size=${12} />${status}
   </span>`;
 }

--- a/skills/create-canvas-kit/scripts/new-canvas.mjs
+++ b/skills/create-canvas-kit/scripts/new-canvas.mjs
@@ -1,17 +1,23 @@
 // scripts/new-canvas.mjs — stamp a new, working canvas extension from the kit.
 //
 // Copies the canonical kit/ into <target>/canvas-kit/ and writes a minimal but
-// fully working canvas (one shared list, Preact + htm view, Lucide icons, SSE
-// live state, durable per-user storage). Edit from there.
+// fully working canvas plus a per-canvas smoke test. Two templates:
+//
+//   list (default)  one shared list (add/toggle/remove), Preact + htm, SSE live
+//                   state, durable per-user storage. Edit from there.
+//   data            an EXTERNAL-DATA canvas: fetch-in-handler (with a timeout),
+//                   a `refresh` action, captured error state, and visibility-
+//                   gated auto-refresh via the kit's pollWhileVisible helper.
 //
 // Usage:
 //   node scripts/new-canvas.mjs <name> [--dir <path>] [--title "Display Name"]
-//                                       [--description "..."] [--force]
+//                                       [--description "..."] [--template list|data]
+//                                       [--force]
 //
 // Examples:
 //   node scripts/new-canvas.mjs my-notes
-//   node scripts/new-canvas.mjs release-board --dir .github/extensions/release-board \
-//        --title "Release Board" --description "Track release readiness items."
+//   node scripts/new-canvas.mjs market-feed --template data --title "Market Feed" \
+//        --dir .github/extensions/market-feed
 
 import { cp, mkdir, readdir, writeFile, stat } from "node:fs/promises";
 import { join, resolve, isAbsolute } from "node:path";
@@ -39,6 +45,15 @@ function toTitle(name) {
 
 const tpl = (s, vars) => s.replace(/\{\{(\w+)\}\}/g, (_, k) => vars[k] ?? "");
 
+function htmlEscape(s) {
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+// extension.mjs is identical for every canvas — the thin SDK adapter.
 const EXTENSION_MJS = `// extension.mjs — the ONLY file that talks to the Copilot SDK.
 // It adapts the SDK canvas lifecycle onto the SDK-free kit runtime so the
 // runtime can also be booted and tested standalone. Keep behavior in canvas.mjs.
@@ -87,7 +102,30 @@ const canvas = createCanvas({
 await joinSession({ canvases: [canvas] });
 `;
 
-const CANVAS_MJS = `// canvas.mjs — {{title}} canvas definition (kit config; SDK-free).
+const INDEX_HTML = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{{titleHtml}}</title>
+    <link rel="stylesheet" href="/kit/theme.css" />
+  </head>
+  <body>
+    <div id="app"><p class="ck-muted">Loading…</p></div>
+    <script type="module" src="./app.mjs"></script>
+  </body>
+</html>
+`;
+
+const MANIFEST = `{
+  "name": "{{name}}",
+  "version": 1
+}
+`;
+
+// ---- template: list (default) ----------------------------------------------
+
+const LIST_CANVAS_MJS = `// canvas.mjs — {{titleText}} canvas definition (kit config; SDK-free).
 //
 // Shared state: the agent and the user read/write the SAME state through the
 // SAME action handlers. State is durable per-user and keyed by a "domain"
@@ -95,12 +133,9 @@ const CANVAS_MJS = `// canvas.mjs — {{title}} canvas definition (kit config; S
 
 import { fileURLToPath } from "node:url";
 import { userStore } from "./canvas-kit/storage.mjs";
+import { nid } from "./canvas-kit/format.mjs";
 
 const EXT_NAME = "{{name}}";
-
-function nid() {
-  return Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
-}
 
 function fileFor(domainId) {
   const safe = String(domainId).replace(/[^A-Za-z0-9._-]/g, "_") || "default";
@@ -109,8 +144,8 @@ function fileFor(domainId) {
 
 export const canvasConfig = {
   id: "{{name}}",
-  displayName: "{{title}}",
-  description: "{{description}}",
+  displayName: {{titleJs}},
+  description: {{descriptionJs}},
   assetsDir: fileURLToPath(new URL("./web/", import.meta.url)),
 
   inputSchema: {
@@ -196,28 +231,15 @@ export const canvasConfig = {
 };
 `;
 
-const INDEX_HTML = `<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>{{title}}</title>
-    <link rel="stylesheet" href="/kit/theme.css" />
-  </head>
-  <body>
-    <div id="app"><p class="ck-muted">Loading…</p></div>
-    <script type="module" src="./app.mjs"></script>
-  </body>
-</html>
-`;
-
-const APP_MJS = `// web/app.mjs — Preact view for the {{title}} canvas.
+const LIST_APP_MJS = `// web/app.mjs — Preact view for the {{titleText}} canvas.
 //
 // SHARED state arrives over /events (SSE); the agent mutates the same data.
 // LOCAL UI state (the draft input) lives in useState. Because Preact DIFFS the
 // DOM (no innerHTML repaint), live pushes never clobber what you're typing.
 
 import { html, mountCanvas, useState, Icon } from "/kit/client.mjs";
+
+const TITLE = {{titleJs}};
 
 function NewItem({ invoke }) {
   const [text, setText] = useState("");
@@ -274,7 +296,7 @@ function App({ state, invoke, connected }) {
       <div class="ck-spread" style="margin-bottom:14px">
         <div class="ck-row" style="gap:8px">
           <\${Icon} name="layout-list" size=\${20} />
-          <h1 style="margin:0">{{title}}</h1>
+          <h1 style="margin:0">\${TITLE}</h1>
         </div>
         <span class="ck-status">
           <span class=\${\`ck-dot \${connected ? "ck-dot-live" : "ck-dot-off"}\`}></span>
@@ -296,11 +318,417 @@ function App({ state, invoke, connected }) {
 mountCanvas({ view: (model) => html\`<\${App} ...\${model} />\` });
 `;
 
-const MANIFEST = `{
-  "name": "{{name}}",
-  "version": 1
+// ---- template: data (external-data / auto-refresh) -------------------------
+
+const DATA_CANVAS_MJS = `// canvas.mjs — {{titleText}} canvas definition (data template; kit config; SDK-free).
+//
+// An EXTERNAL-DATA canvas: it fetches from the network inside an action handler,
+// captures any error into shared state, and is auto-refreshed by the view. The
+// agent and the user share the same state and the same handlers.
+//
+// Where things live:
+//   * fetch() goes in the HANDLER/helper here — NEVER in the view.
+//   * always set a timeout (AbortSignal.timeout) so a slow upstream can't hang.
+//   * the view polls a "refresh" action on a visibility-gated timer (app.mjs).
+
+import { fileURLToPath } from "node:url";
+import { userStore } from "./canvas-kit/storage.mjs";
+import { nid } from "./canvas-kit/format.mjs";
+
+const EXT_NAME = "{{name}}";
+
+// A stable, no-auth demo JSON API (returns an array). Swap for your real source
+// and reshape mapItems() to match its payload.
+const DEFAULT_SOURCE = "https://jsonplaceholder.typicode.com/posts?_limit=10";
+
+function fileFor(domainId) {
+  const safe = String(domainId).replace(/[^A-Za-z0-9._-]/g, "_") || "default";
+  return userStore(EXT_NAME, \`\${safe}.json\`);
 }
+
+async function fetchItems(url) {
+  // NOTE: this runs server-side, so \`url\` is an unrestricted fetch (it can
+  // reach internal hosts) and the response flows back to the agent — keep the
+  // source one you trust, and render fetched fields as TEXT (never innerHTML).
+  const res = await fetch(url, {
+    headers: { Accept: "application/json", "User-Agent": "copilot-canvas" },
+    signal: AbortSignal.timeout(12000),
+  });
+  if (!res.ok) throw new Error(\`HTTP \${res.status}\`);
+  return mapItems(await res.json());
+}
+
+// Reshape the upstream payload into this canvas's item shape. Edit for your API.
+function mapItems(data) {
+  const rows = Array.isArray(data) ? data : data?.items ?? [];
+  return rows.slice(0, 50).map((row, i) => ({
+    id: String(row.id ?? nid()),
+    title: String(row.title ?? row.name ?? \`Item \${i + 1}\`),
+    note: String(row.body ?? row.description ?? "").slice(0, 280),
+  }));
+}
+
+export const canvasConfig = {
+  id: "{{name}}",
+  displayName: {{titleJs}},
+  description: {{descriptionJs}},
+  assetsDir: fileURLToPath(new URL("./web/", import.meta.url)),
+
+  inputSchema: {
+    type: "object",
+    properties: {
+      domain: { type: "string", description: "Logical board to open. Omit for the default." },
+    },
+    additionalProperties: false,
+  },
+
+  resolveDomainId: (input) => (input?.domain ? String(input.domain) : "default"),
+  createInitialState: () => ({
+    items: [],
+    error: null,
+    lastRefresh: null,
+    autoRefreshSec: 60,
+    sourceUrl: DEFAULT_SOURCE,
+  }),
+  loadState: async (domainId) => fileFor(domainId).load(null),
+  saveState: async (domainId, state) => fileFor(domainId).save(state),
+  statusLine: (_ctx, state) => \`\${state.items.length} items\`,
+
+  actions: {
+    refresh: {
+      description: "Fetch the latest items from the source URL and update the canvas.",
+      inputSchema: { type: "object", properties: {}, additionalProperties: false },
+      handler: async ({ state, set }) => {
+        // Capture the input BEFORE awaiting; use a functional set() afterward so
+        // we merge into the LATEST state (a concurrent action may have run while
+        // the fetch was in flight) and drop the response if the source changed.
+        const sourceUrl = state.sourceUrl;
+        try {
+          const items = await fetchItems(sourceUrl);
+          set((current) => {
+            if (current.sourceUrl !== sourceUrl) return current; // stale response
+            return {
+              ...current,
+              items,
+              error: items.length ? null : "No items returned.",
+              lastRefresh: new Date().toISOString(),
+            };
+          });
+          return { count: items.length, summary: \`Loaded \${items.length} item(s).\` };
+        } catch (err) {
+          // Capture the failure into shared state so the view can surface it,
+          // and still return a result (don't throw) so a poll tick stays quiet.
+          const error = \`Couldn't load: \${String(err?.message ?? err)}\`;
+          set((current) =>
+            current.sourceUrl !== sourceUrl ? current : { ...current, error, lastRefresh: new Date().toISOString() }
+          );
+          return { ok: false, error };
+        }
+      },
+    },
+
+    set_source: {
+      description: "Change the upstream source URL.",
+      inputSchema: {
+        type: "object",
+        properties: { url: { type: "string", description: "JSON endpoint returning a list." } },
+        required: ["url"],
+        additionalProperties: false,
+      },
+      handler: ({ state, set, input }) => {
+        const url = String(input.url ?? "").trim();
+        if (!url) throw new Error("url is required");
+        set({ ...state, sourceUrl: url });
+        return { sourceUrl: url };
+      },
+    },
+
+    set_auto_refresh: {
+      description: "Set the auto-refresh interval in seconds (0 turns it off).",
+      inputSchema: {
+        type: "object",
+        properties: { seconds: { type: "number", description: "Interval in seconds; 0 disables." } },
+        required: ["seconds"],
+        additionalProperties: false,
+      },
+      handler: ({ state, set, input }) => {
+        const seconds = Math.max(0, Number(input.seconds) || 0);
+        set({ ...state, autoRefreshSec: seconds });
+        return { autoRefreshSec: seconds };
+      },
+    },
+
+    clear: {
+      description: "Remove all loaded items.",
+      inputSchema: { type: "object", properties: {}, additionalProperties: false },
+      handler: ({ state, set }) => {
+        set({ ...state, items: [], error: null });
+        return { ok: true };
+      },
+    },
+
+    list_items: {
+      description: "Return a text summary of the current items (for the agent).",
+      inputSchema: { type: "object", properties: {}, additionalProperties: false },
+      handler: ({ state }) => {
+        if (!state.items.length) return { summary: "No items loaded.", count: 0 };
+        const summary = state.items.map((i) => \`- \${i.title}\`).join("\\n");
+        return { count: state.items.length, summary };
+      },
+    },
+  },
+};
 `;
+
+const DATA_APP_MJS = `// web/app.mjs — Preact view for the {{titleText}} data canvas.
+//
+// EXTERNAL-DATA shape: items arrive over /events (SSE) like any shared state;
+// the network fetch lives in the "refresh" action handler, not here. The view
+// only TRIGGERS refresh — on a button and on a visibility-gated timer via the
+// kit's pollWhileVisible helper, with the interval bound to durable state.
+
+import { html, mountCanvas, useState, useEffect, Icon, pollWhileVisible, relativeTime } from "/kit/client.mjs";
+
+const TITLE = {{titleJs}};
+
+const INTERVALS = [
+  { v: 0, label: "Off" },
+  { v: 30, label: "30s" },
+  { v: 60, label: "1m" },
+  { v: 300, label: "5m" },
+];
+
+function Toolbar({ state, invoke }) {
+  const [url, setUrl] = useState(state.sourceUrl ?? "");
+  const [busy, setBusy] = useState(false);
+
+  async function refresh() {
+    if (busy) return;
+    setBusy(true);
+    try { await invoke("refresh"); } finally { setBusy(false); }
+  }
+  async function applySource() {
+    const u = url.trim();
+    if (!u) return;
+    await invoke("set_source", { url: u });
+    refresh();
+  }
+
+  return html\`
+    <div class="ck-card ck-col" style="margin:12px 0 16px">
+      <div class="ck-row">
+        <input
+          class="ck-input ck-grow"
+          placeholder="Source URL…"
+          value=\${url}
+          onInput=\${(e) => setUrl(e.target.value)}
+          onKeyDown=\${(e) => { if (e.key === "Enter") applySource(); }}
+        />
+        <button class="ck-btn" onClick=\${applySource}>Set</button>
+      </div>
+      <div class="ck-row">
+        <button class="ck-btn ck-btn-primary" disabled=\${busy} onClick=\${refresh}>
+          <\${Icon} name=\${busy ? "loader-circle" : "refresh-cw"} size=\${16} class=\${busy ? "ck-spinner" : ""} />
+          \${busy ? "Refreshing…" : "Refresh"}
+        </button>
+        <span class="ck-grow"></span>
+        <label class="ck-caption">Auto</label>
+        <select
+          class="ck-select"
+          style="width:auto"
+          value=\${String(state.autoRefreshSec ?? 0)}
+          onChange=\${(e) => invoke("set_auto_refresh", { seconds: Number(e.target.value) })}
+        >
+          \${INTERVALS.map((o) => html\`<option value=\${String(o.v)}>\${o.label}</option>\`)}
+        </select>
+      </div>
+    </div>
+  \`;
+}
+
+function App({ state, invoke, connected }) {
+  // Hooks run unconditionally (before any early return). Two effects:
+  //   1) initial load once state arrives and nothing has been fetched yet;
+  //   2) visibility-gated auto-refresh, rebuilt when the interval changes.
+  useEffect(() => {
+    if (state && !state.lastRefresh) invoke("refresh").catch(() => {});
+  }, [state?.lastRefresh]);
+  useEffect(
+    () => pollWhileVisible(() => invoke("refresh"), state?.autoRefreshSec || 0),
+    [state?.autoRefreshSec]
+  );
+
+  if (!state) return html\`<p class="ck-muted">Loading…</p>\`;
+  const items = state.items ?? [];
+
+  return html\`
+    <div>
+      <div class="ck-spread" style="margin-bottom:14px">
+        <div class="ck-row" style="gap:8px">
+          <\${Icon} name="rss" size=\${20} />
+          <h1 style="margin:0">\${TITLE}</h1>
+        </div>
+        <span class="ck-status">
+          <span class=\${\`ck-dot \${connected ? "ck-dot-live" : "ck-dot-off"}\`}></span>
+          \${connected ? "live" : "reconnecting…"}
+        </span>
+      </div>
+
+      <\${Toolbar} state=\${state} invoke=\${invoke} />
+
+      \${state.error
+        ? html\`<div class="ck-callout ck-error" style="margin-bottom:12px">
+            <\${Icon} name="circle-x" size=\${16} /><span>\${state.error}</span>
+          </div>\`
+        : null}
+
+      <div class="ck-spread ck-caption" style="margin-bottom:8px">
+        <span>\${items.length} item\${items.length === 1 ? "" : "s"}</span>
+        <span>\${state.lastRefresh ? \`updated \${relativeTime(state.lastRefresh)}\` : "not loaded yet"}</span>
+      </div>
+
+      <div class="ck-col" style="gap:10px">
+        \${items.length
+          ? items.map((it) => html\`
+              <div class="ck-card" key=\${it.id}>
+                <div style="font-weight:var(--ck-fw-semibold)">\${it.title}</div>
+                \${it.note ? html\`<div class="ck-muted" style="margin-top:6px">\${it.note}</div>\` : null}
+              </div>\`)
+          : html\`<div class="ck-empty"><\${Icon} name="inbox" size=\${20} />Nothing loaded yet. Hit Refresh.</div>\`}
+      </div>
+    </div>
+  \`;
+}
+
+mountCanvas({ view: (model) => html\`<\${App} ...\${model} />\` });
+`;
+
+// ---- per-canvas smoke test -------------------------------------------------
+
+// Wrap template-specific test calls in a shared harness that boots the runtime
+// over real HTTP against an isolated temp COPILOT_HOME.
+function smokeFile(name, body) {
+  return `// test/smoke.test.mjs — boots this canvas's runtime over HTTP and exercises
+// its actions. Generated by create-canvas-kit. Run:  node test/smoke.test.mjs
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const home = await mkdtemp(join(tmpdir(), "${name}-smoke-"));
+process.env.COPILOT_HOME = home;
+
+const { canvasConfig } = await import("../canvas.mjs");
+const { createCanvasRuntime } = await import("../canvas-kit/server.mjs");
+const runtime = createCanvasRuntime(canvasConfig);
+
+let passed = 0;
+async function test(label, fn) {
+  try {
+    await fn();
+    passed++;
+    console.log(\`  ok  \${label}\`);
+  } catch (e) {
+    console.error(\`FAIL  \${label}\\n      \${e.message}\`);
+    process.exitCode = 1;
+    throw e;
+  }
+}
+const post = (url, actionName, input) =>
+  fetch(new URL("/action", url), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ actionName, input }),
+  }).then(async (r) => ({ status: r.status, body: await r.json() }));
+const getState = (url) => fetch(new URL("/state", url)).then((r) => r.json());
+
+try {
+  const open = await runtime.openInstance({
+    instanceId: "smoke",
+    input: {},
+    ctx: { instanceId: "smoke", input: {} },
+  });
+  await test("opens on a loopback url", () =>
+    assert.match(open.url, /^http:\\/\\/127\\.0\\.0\\.1:\\d+\\/$/));
+${body}
+} finally {
+  await runtime.shutdown();
+  await rm(home, { recursive: true, force: true });
+}
+
+console.log(\`\\n\${passed} checks passed\`);
+`;
+}
+
+const LIST_SMOKE_BODY = `  await test("GET /state starts empty", async () => {
+    const s = await getState(open.url);
+    assert.deepEqual(s.items, []);
+  });
+
+  let id;
+  await test("add_item adds an item", async () => {
+    const { body } = await post(open.url, "add_item", { text: "first" });
+    assert.equal(body.ok, true);
+    id = body.result.id;
+    assert.ok(id);
+    const s = await getState(open.url);
+    assert.equal(s.items.length, 1);
+    assert.equal(s.items[0].text, "first");
+  });
+
+  await test("toggle_item flips done", async () => {
+    await post(open.url, "toggle_item", { id });
+    const s = await getState(open.url);
+    assert.equal(s.items[0].done, true);
+  });
+
+  await test("list_items summarizes for the agent", async () => {
+    const { body } = await post(open.url, "list_items", {});
+    assert.equal(body.result.count, 1);
+  });
+
+  await test("remove_item removes it", async () => {
+    const { body } = await post(open.url, "remove_item", { id });
+    assert.equal(body.result.removed, 1);
+    const s = await getState(open.url);
+    assert.deepEqual(s.items, []);
+  });`;
+
+const DATA_SMOKE_BODY = `  await test("GET /state has the initial data shape", async () => {
+    const s = await getState(open.url);
+    assert.ok(Array.isArray(s.items));
+    assert.equal(s.lastRefresh, null);
+  });
+
+  await test("set_source + set_auto_refresh mutate state", async () => {
+    // Point at an unreachable local URL so refresh fails fast and offline —
+    // the smoke test never touches the network.
+    await post(open.url, "set_source", { url: "http://127.0.0.1:1/none" });
+    await post(open.url, "set_auto_refresh", { seconds: 0 });
+    const s = await getState(open.url);
+    assert.equal(s.sourceUrl, "http://127.0.0.1:1/none");
+    assert.equal(s.autoRefreshSec, 0);
+  });
+
+  await test("refresh records lastRefresh and captures the error (offline)", async () => {
+    const { body } = await post(open.url, "refresh", {});
+    assert.equal(body.ok, true); // POST envelope ok; the result carries the error
+    const s = await getState(open.url);
+    assert.ok(s.lastRefresh, "lastRefresh should be set after a refresh attempt");
+    assert.ok(s.error, "the failed fetch should be captured in state.error");
+  });
+
+  await test("clear empties items and error", async () => {
+    await post(open.url, "clear", {});
+    const s = await getState(open.url);
+    assert.deepEqual(s.items, []);
+    assert.equal(s.error, null);
+  });`;
+
+const TEMPLATES = {
+  list: { canvas: LIST_CANVAS_MJS, app: LIST_APP_MJS, smokeBody: LIST_SMOKE_BODY },
+  data: { canvas: DATA_CANVAS_MJS, app: DATA_APP_MJS, smokeBody: DATA_SMOKE_BODY },
+};
 
 async function isNonEmptyDir(dir) {
   try {
@@ -317,9 +745,15 @@ async function main() {
 
   if (!name || !/^[a-z][a-z0-9-]*$/.test(name)) {
     console.error(
-      "Usage: node scripts/new-canvas.mjs <name> [--dir <path>] [--title \"...\"] [--description \"...\"] [--force]\n" +
+      "Usage: node scripts/new-canvas.mjs <name> [--dir <path>] [--title \"...\"] [--description \"...\"] [--template list|data] [--force]\n" +
         "  <name> must be kebab-case: start with a letter, then lowercase letters, digits, or hyphens."
     );
+    process.exit(1);
+  }
+
+  const template = args.template || "list";
+  if (!TEMPLATES[template]) {
+    console.error(`Unknown --template "${template}". Use "list" (default) or "data".`);
     process.exit(1);
   }
 
@@ -332,23 +766,41 @@ async function main() {
     process.exit(1);
   }
 
-  const vars = { name, title, description };
+  const vars = {
+    name,
+    titleJs: JSON.stringify(title),
+    descriptionJs: JSON.stringify(description),
+    titleHtml: htmlEscape(title),
+    titleText: String(title).replace(/[`\r\n]/g, " "),
+  };
+  const t = TEMPLATES[template];
 
   await mkdir(join(target, "web"), { recursive: true });
+  await mkdir(join(target, "test"), { recursive: true });
   await cp(KIT, join(target, "canvas-kit"), { recursive: true });
 
   await writeFile(join(target, "extension.mjs"), EXTENSION_MJS);
-  await writeFile(join(target, "canvas.mjs"), tpl(CANVAS_MJS, vars));
+  await writeFile(join(target, "canvas.mjs"), tpl(t.canvas, vars));
   await writeFile(join(target, "copilot-extension.json"), tpl(MANIFEST, vars));
   await writeFile(join(target, "web", "index.html"), tpl(INDEX_HTML, vars));
-  await writeFile(join(target, "web", "app.mjs"), tpl(APP_MJS, vars));
+  await writeFile(join(target, "web", "app.mjs"), tpl(t.app, vars));
+  await writeFile(join(target, "test", "smoke.test.mjs"), smokeFile(name, t.smokeBody));
 
-  console.log(`Created canvas "${name}" at: ${target}`);
+  console.log(`Created ${template} canvas "${name}" at: ${target}`);
   console.log("Files:");
-  for (const f of ["extension.mjs", "canvas.mjs", "copilot-extension.json", "web/index.html", "web/app.mjs", "canvas-kit/"]) {
+  for (const f of [
+    "extension.mjs",
+    "canvas.mjs",
+    "copilot-extension.json",
+    "web/index.html",
+    "web/app.mjs",
+    "test/smoke.test.mjs",
+    "canvas-kit/",
+  ]) {
     console.log("  " + f);
   }
-  console.log("\nNext: install it (copy the folder into .github/extensions/ or $COPILOT_HOME/extensions/), then extensions_reload.");
+  console.log("\nValidate it:   node test/smoke.test.mjs   (run from the canvas folder)");
+  console.log("Then install:  copy the folder into .github/extensions/ or $COPILOT_HOME/extensions/, then extensions_reload.");
 }
 
 main().catch((e) => {

--- a/skills/create-canvas-kit/test/generator.test.mjs
+++ b/skills/create-canvas-kit/test/generator.test.mjs
@@ -1,0 +1,232 @@
+// test/generator.test.mjs — exercises the generator, the stamped smoke tests,
+// the new kit API surface (format helpers, the poll helper), and the theme
+// primitives. No deps; Node 18+.  Run: node test/generator.test.mjs
+
+import assert from "node:assert/strict";
+import { mkdtemp, rm, readFile, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const GEN = join(ROOT, "scripts", "new-canvas.mjs");
+
+let passed = 0;
+async function test(name, fn) {
+  try {
+    await fn();
+    passed++;
+    console.log(`  ok  ${name}`);
+  } catch (e) {
+    console.error(`FAIL  ${name}\n      ${e.message}`);
+    process.exitCode = 1;
+    throw e;
+  }
+}
+
+function run(args, cwd) {
+  return spawnSync(process.execPath, args, { cwd, encoding: "utf8" });
+}
+async function exists(p) {
+  try { await stat(p); return true; } catch { return false; }
+}
+const read = (p) => readFile(p, "utf8");
+
+async function main() {
+  console.log("create-canvas-kit generator + kit API tests");
+
+  // ---- format.mjs behavior (the reinvented utilities, now shared) ----------
+  const fmt = await import("../kit/format.mjs");
+
+  await test("nid() returns distinct base-36 ids", () => {
+    const a = fmt.nid();
+    const b = fmt.nid();
+    assert.equal(typeof a, "string");
+    assert.ok(a.length >= 6);
+    assert.notEqual(a, b);
+  });
+
+  await test("relativeTime buckets with an explicit now", () => {
+    const base = 1_700_000_000_000;
+    assert.equal(fmt.relativeTime(base - 5_000, { now: base }), "just now");
+    assert.equal(fmt.relativeTime(base - 5 * 60_000, { now: base }), "5m ago");
+    assert.equal(fmt.relativeTime(base - 3 * 3_600_000, { now: base }), "3h ago");
+    assert.equal(fmt.relativeTime(base - 2 * 86_400_000, { now: base }), "2d ago");
+    assert.equal(fmt.relativeTime(null), "");
+    assert.equal(fmt.relativeTime(undefined, { fallback: "—" }), "—");
+  });
+
+  await test("compactNumber + percent format as expected", () => {
+    assert.match(fmt.compactNumber(1500), /1\.5\s?K/i);
+    assert.match(fmt.compactNumber(2.3e9), /2\.3\s?B/i);
+    assert.equal(fmt.compactNumber(null), "—");
+    assert.equal(fmt.percent(1.2345), "+1.23%");
+    assert.equal(fmt.percent(-2), "-2.00%");
+    assert.equal(fmt.percent(null), "—");
+  });
+
+  // ---- pollWhileVisible behavior (the auto-refresh primitive) --------------
+  const { pollWhileVisible } = await import("../kit/client.mjs");
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+  await test("pollWhileVisible: seconds<=0 is a no-op", () => {
+    let n = 0;
+    const stop = pollWhileVisible(() => n++, 0);
+    assert.equal(typeof stop, "function");
+    assert.equal(n, 0);
+    stop();
+  });
+
+  await test("pollWhileVisible: immediate fires one tick synchronously", () => {
+    let n = 0;
+    const stop = pollWhileVisible(() => n++, 100, { immediate: true });
+    assert.equal(n, 1);
+    stop();
+  });
+
+  await test("pollWhileVisible: ticks on the interval and the cleanup stops it", async () => {
+    let n = 0;
+    const stop = pollWhileVisible(() => n++, 0.03); // 30ms
+    await sleep(80);
+    assert.ok(n >= 2, `expected >=2 ticks, got ${n}`);
+    stop();
+    const after = n;
+    await sleep(80);
+    assert.equal(n, after, "no ticks should fire after cleanup");
+  });
+
+  await test("pollWhileVisible: a throwing/rejecting tick keeps the interval alive", async () => {
+    let n = 0;
+    const stop = pollWhileVisible(() => { n++; return Promise.reject(new Error("boom")); }, 0.03);
+    await sleep(80);
+    assert.ok(n >= 2, `interval should survive rejections, got ${n}`);
+    stop();
+  });
+
+  await test("pollWhileVisible: does not overlap a slow async tick", async () => {
+    let started = 0;
+    const stop = pollWhileVisible(() => { started++; return sleep(200); }, 0.03); // 30ms interval, 200ms work
+    await sleep(120); // ~4 intervals would fire, but the first tick is still in flight
+    assert.equal(started, 1, `slow tick must not stack, got ${started}`);
+    stop();
+    await sleep(220); // let the in-flight tick settle
+  });
+
+  // ---- kit API surface -----------------------------------------------------
+  await test("client.mjs exports pollWhileVisible + re-exports format helpers", async () => {
+    const src = await read(join(ROOT, "kit", "client.mjs"));
+    assert.match(src, /export function pollWhileVisible/);
+    assert.match(src, /document\.visibilityState/);
+    assert.match(src, /nid, relativeTime, compactNumber, percent/);
+    assert.match(src, /poll\b/); // mountCanvas accepts a poll option
+  });
+
+  await test("theme.css ships loading/error primitives + reduced-motion guard", async () => {
+    const css = await read(join(ROOT, "kit", "theme.css"));
+    for (const cls of ["ck-spinner", "ck-skeleton", "ck-callout", "ck-error"]) {
+      assert.ok(css.includes(`.${cls}`), `missing .${cls}`);
+    }
+    assert.match(css, /@media \(prefers-reduced-motion: reduce\)/);
+  });
+
+  await test("theme.css badges are generic, not decision-log-specific", async () => {
+    const css = await read(join(ROOT, "kit", "theme.css"));
+    for (const cls of ["ck-badge-success", "ck-badge-accent", "ck-badge-muted", "ck-badge-danger", "ck-badge-attention"]) {
+      assert.ok(css.includes(`.${cls}`), `missing .${cls}`);
+    }
+    for (const leaked of ["ck-badge-open", "ck-badge-decided", "ck-badge-parked"]) {
+      assert.ok(!css.includes(`.${leaked}`), `leaked app-specific class .${leaked}`);
+    }
+  });
+
+  await test("format.mjs is byte-mirrored into the reference canvas-kit", async () => {
+    const [a, b] = await Promise.all([
+      readFile(join(ROOT, "kit", "format.mjs")),
+      readFile(join(ROOT, "reference", "decision-log", "canvas-kit", "format.mjs")),
+    ]);
+    assert.ok(a.equals(b), "kit/format.mjs and reference copy differ");
+  });
+
+  // ---- generator: both templates -------------------------------------------
+  const work = await mkdtemp(join(tmpdir(), "ck-gen-test-"));
+  try {
+    const cases = [
+      { name: "gen-list", template: "list", dir: join(work, "gen-list") },
+      { name: "gen-feed", template: "data", dir: join(work, "gen-feed") },
+    ];
+
+    for (const c of cases) {
+      const args = [GEN, c.name, "--dir", c.dir, "--title", "Gen Test"];
+      if (c.template !== "list") args.push("--template", c.template);
+      const gen = run(args, work);
+
+      await test(`generator stamps the ${c.template} template`, () => {
+        assert.equal(gen.status, 0, gen.stderr || gen.stdout);
+      });
+
+      await test(`${c.template}: expected files exist (incl. stamped smoke test)`, async () => {
+        for (const f of ["canvas.mjs", "extension.mjs", "copilot-extension.json", "web/app.mjs", "web/index.html", "test/smoke.test.mjs"]) {
+          assert.ok(await exists(join(c.dir, f)), `missing ${f}`);
+        }
+      });
+
+      await test(`${c.template}: stamped canvas.mjs imports nid from the kit`, async () => {
+        const canvas = await read(join(c.dir, "canvas.mjs"));
+        assert.match(canvas, /import \{ nid \} from "\.\/canvas-kit\/format\.mjs"/);
+        assert.ok(!/function nid\(\)/.test(canvas), "should not redefine nid locally");
+      });
+
+      await test(`${c.template}: node --check passes on stamped sources`, async () => {
+        for (const f of ["canvas.mjs", "extension.mjs", "web/app.mjs", "test/smoke.test.mjs"]) {
+          const chk = run(["--check", join(c.dir, f)], c.dir);
+          assert.equal(chk.status, 0, `${f}: ${chk.stderr}`);
+        }
+      });
+
+      await test(`${c.template}: stamped smoke test boots the runtime and passes`, async () => {
+        const smoke = run(["test/smoke.test.mjs"], c.dir);
+        assert.equal(smoke.status, 0, smoke.stderr || smoke.stdout);
+        assert.match(smoke.stdout, /checks passed/);
+      });
+    }
+
+    // data-template-specific contract: fetch-in-handler + refresh + poll helper
+    await test("data canvas.mjs fetches in a handler with a timeout + refresh action", async () => {
+      const canvas = await read(join(work, "gen-feed", "canvas.mjs"));
+      assert.match(canvas, /await fetch\(/);
+      assert.match(canvas, /AbortSignal\.timeout\(/);
+      assert.match(canvas, /refresh:\s*\{/);
+    });
+
+    await test("data app.mjs uses the visibility-gated poll helper", async () => {
+      const app = await read(join(work, "gen-feed", "web", "app.mjs"));
+      assert.match(app, /pollWhileVisible/);
+      assert.match(app, /useEffect/);
+    });
+
+    // Regression: a title with quotes / backtick / ${...} must still stamp a
+    // VALID, working canvas (escaping, not broken source).
+    await test("hostile --title still stamps a valid, runnable canvas", async () => {
+      const nastyTitle = 'Danger " ' + "`" + " " + "${x}" + " <b>tag</b>";
+      const dir = join(work, "gen-nasty");
+      const gen = run([GEN, "gen-nasty", "--dir", dir, "--title", nastyTitle], work);
+      assert.equal(gen.status, 0, gen.stderr || gen.stdout);
+      for (const f of ["canvas.mjs", "web/app.mjs"]) {
+        const chk = run(["--check", join(dir, f)], dir);
+        assert.equal(chk.status, 0, `${f} should parse: ${chk.stderr}`);
+      }
+      const smoke = run(["test/smoke.test.mjs"], dir);
+      assert.equal(smoke.status, 0, smoke.stderr || smoke.stdout);
+    });
+  } finally {
+    await rm(work, { recursive: true, force: true });
+  }
+
+  console.log(`\n${passed} checks passed`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Most real Copilot canvases pull from the network and auto-refresh, but the skill only modeled a user-entered CRUD list. This PR makes the external-data canvas a first-class, runnable shape and closes the 10 prioritized gaps from the review against the four shipped canvases (stock-ticker, news-aggregator, language-tutor, random-animal).

## Flow Diagram
```mermaid
flowchart LR
  A[poll tick / button] -->|invoke refresh| B[refresh action]
  B -->|fetch + AbortSignal.timeout| C[upstream JSON]
  C --> D[set: items / error / lastRefresh]
  D -->|SSE push| E[panel re-render]
```

## Changes
- New `kit/format.mjs`: shared `nid`, `relativeTime`, `compactNumber`, `percent` so canvases stop reinventing them.
- `kit/client.mjs`: exported `pollWhileVisible(tick, seconds)` (visibility-gated, in-flight-guarded) plus a `mountCanvas({ poll })` convenience; re-exports the format helpers.
- `kit/theme.css`: adds `ck-spinner` (reduced-motion safe), `ck-skeleton`, `ck-callout`/`ck-error`; replaces decision-log-specific badges with generic `ck-badge-success/accent/muted/danger/attention`; adds a global `prefers-reduced-motion` guard.
- `scripts/new-canvas.mjs`: `--template data` (fetch-in-handler + timeout + `refresh` + poll + error UI), stamps a per-canvas `test/smoke.test.mjs` for both templates, and escapes `--title`/`--description` per context so a hostile title can't produce broken output.
- `reference/decision-log`: maps its statuses to the generic badges; uses the kit `nid`.
- New `test/generator.test.mjs`; docs in `SKILL.md` and `README.md` (external-data shape, hooks + `Fragment` note, domain strategy, bundled catalog, statusLine staleness, rich payloads, install layout).

Byte-parity between `kit/` and `reference/decision-log/canvas-kit/` is preserved (`format.mjs` mirrored).

## Type of Change
- [x] New feature (non-breaking)
- [x] Documentation update
- [ ] Breaking change

## Testing
- [x] Tests added/updated
- [x] Manual (visual) testing completed

### Test Results
```
node test/http.test.mjs         14/14
node test/kit-parity.test.mjs    9/9
node test/generator.test.mjs    25/25
node --check (all sources)       0 failures
```
Playwright-validated the stamped data canvas (live fetch/refresh, relativeTime, error callout) and the decision-log reference (generic badges).

### Quality Gates
| Gate | Status | Notes |
|---|---|---|
| review pipeline | PASS | code-review + security-review + design review; all findings fixed |
| code-review | PASS | 1 MEDIUM (generator escaping) fixed + regression test |
| preflight | PASS | `node --check` 0 failures; 48-check suite green |
| secops | PASS | 0 findings; added an SSRF/XPIA doc note on the data template's caller-set `sourceUrl` |
| test-health | PASS | added `pollWhileVisible` behavioral + overlap tests |

No `mq`/`pf` tooling exists in this no-build, zero-dependency skill, so the gates above are the equivalent.

## Security
- [x] No secrets committed
- [x] No new external dependencies (everything stays vendored)
- [x] Fetched content renders as text (no `innerHTML` / `dangerouslySetInnerHTML` on untrusted data)
- [x] Documented the data template's `sourceUrl` as an unrestricted server-side fetch (SSRF/XPIA) appropriate for a local dev tool

## Additional Notes
No tracking issue was filed, so there's nothing to close. Scope is limited to `skills/create-canvas-kit/` in this repo; the bundled kit copies inside jongio/copilot-extensions are a separate follow-up.