### PR TITLE
feat(create-canvas-kit): kit versioning, sync tooling, and a Vally eval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,11 @@ node_modules/
 dist/
 build/
 
+# Optional dev tooling (the Vally eval) pulls dev deps + writes results.
+# Shipped canvases stay dependency-free; these are skill-repo dev artifacts only.
+package-lock.json
+vally-results/
+
 # Local canvas state written by the reference extension / generated canvases.
 artifacts/
 

--- a/skills/create-canvas-kit/.vally.yaml
+++ b/skills/create-canvas-kit/.vally.yaml
@@ -1,0 +1,18 @@
+# .vally.yaml — Vally project config for the create-canvas-kit skill eval.
+#
+# Wires the skill into the built-in copilot-sdk executor: `vally eval --skill-dir .`
+# reads paths.skills below to discover this skill (node_modules is ignored) and
+# loads it into the agent session — without copying it into the agent's workspace,
+# so the file graders only ever see what the agent itself produced. Stimuli omit
+# `environment.skills` on purpose for exactly that reason.
+#
+# Run from this folder (skills/create-canvas-kit), after `npm install`:
+#   npx vally lint --eval-spec evals/create-canvas-kit/eval.yaml
+#   npx vally eval --eval-spec evals/create-canvas-kit/eval.yaml --skill-dir .
+
+paths:
+  # The skill lives at this folder's root (SKILL.md here). node_modules is
+  # ignored by discovery, so "." resolves to just the create-canvas-kit skill.
+  skills: "."
+  evals: "evals"
+  results: "vally-results"

--- a/skills/create-canvas-kit/SKILL.md
+++ b/skills/create-canvas-kit/SKILL.md
@@ -71,6 +71,23 @@ web/app.mjs     ── your Preact view
 - **Local UI state** (a draft input value, the active tab/filter) lives in
   `useState` and must never be pushed to the server until the user commits it.
 
+### Action results & errors — how failures surface
+
+Both callers (agent and UI) hit the same handler, and the runtime wraps every
+invocation in the same envelope, so model failures deliberately:
+
+- **Return** a small plain object for success (`{ id, status }`, `{ count }`).
+  `POST /action` answers `{ ok: true, result }`.
+- **Throw** for a hard failure (bad input, missing id). The runtime answers
+  `{ ok: false, code, message }` — HTTP **400** for a known kit error (e.g. an
+  unknown action) and **500** for a handler `throw` — and `mountCanvas`'s
+  `invoke` **rejects** with a `CanvasActionError` carrying that `code`/`message`,
+  so a button handler can `try/catch` it. On the agent side, `extension.mjs` maps
+  the same error to a `CanvasError`. A throw is *surfaced*, never a crash.
+- For an **expected, transient** failure (a flaky upstream fetch on a background
+  poll), don't throw — capture it into `state.error` and **return** so the error
+  card shows while the poll stays quiet (see the data template's `refresh`).
+
 ## Icons — official GitHub Lucide, always
 
 The kit vendors the **exact Lucide set github-app ships** (`lucide-react@1.14.0`,
@@ -135,6 +152,15 @@ percent(1.25);               // "+1.25%"
 
 `nid` is also importable server-side in `canvas.mjs` via
 `import { nid } from "./canvas-kit/format.mjs"` (the generator does this).
+
+**The formatters are locale-aware** — `relativeTime` ends in a
+`toLocaleDateString()`, and `compactNumber`/`percent` go through
+`Number.prototype.toLocaleString`, so their output depends on the host locale
+(`"1.5K"` vs `"1,5 K"`, `2025-01-31` vs `31/01/2025`). Keep the **raw** values in
+durable state (an ISO string, a `Number`) and format **in the view**. Never store
+a formatted string and never parse one back — formatting is a presentation
+concern, and a value formatted under one locale can't be reliably re-read under
+another.
 
 **`Fragment` is NOT exported.** To return sibling nodes without a wrapper, use
 htm's built-in empty-tag syntax — `` html`<><${A} /><${B} /></>` `` — or just
@@ -232,16 +258,22 @@ who shares what.
   count in `statusLine` goes stale. Show live counts **inside** the canvas body
   (which re-renders on every SSE push), and treat `statusLine` as an
   open-time-only summary.
-- **Rich-payload actions.** If the UI needs to hand the agent's handler a whole
-  object (e.g. the article being saved) rather than scalar fields, set
-  `additionalProperties: true` on that action's `inputSchema` (the generator
-  defaults to `false`). Denormalize what you need into durable state in the
-  handler.
+- **Rich-payload actions.** Action `inputSchema`s default to
+  `additionalProperties: false` on purpose: the schema is the contract the agent
+  fills, and a strict schema keeps the model from smuggling in unvalidated/typo'd
+  fields — only the properties you declare reach your handler. When the UI
+  genuinely needs to hand the handler a whole object (e.g. the article being
+  saved) rather than scalar fields, set `additionalProperties: true` on *that*
+  action's `inputSchema` and denormalize what you need into durable state in the
+  handler. Flip it deliberately, per-action — not as a blanket default.
 - **Install layout / SDK resolution.** A shipped extension folder contains only
   `copilot-extension.json` (`{ "name", "version": 1 }` — no `package.json`),
-  `extension.mjs`, `canvas.mjs`, `web/`, and the nested `canvas-kit/`. The host
-  resolves `@github/copilot-sdk/extension` for you; `extension.mjs` is the only
-  file that imports it. Don't add a `package.json` or a build step.
+  `extension.mjs`, `canvas.mjs`, `web/`, and the nested `canvas-kit/`. The kit is
+  plain ESM that Node runs directly — **no bundler, no transpile, no build step,
+  no `package.json`** in the extension (the stamped `test/smoke.test.mjs` runs
+  with bare `node`). The host resolves `@github/copilot-sdk/extension` for you;
+  `extension.mjs` is the only file that imports it. Don't add a `package.json` or
+  a build step to a shipped canvas.
 
 ## Build a canvas — fastest path
 

--- a/skills/create-canvas-kit/SKILL.md
+++ b/skills/create-canvas-kit/SKILL.md
@@ -268,14 +268,45 @@ If you prefer to hand-assemble instead of using the generator: copy `kit/` into
 your extension as `canvas-kit/`, then copy `reference/decision-log/extension.mjs`
 verbatim and adapt `canvas.mjs` + `web/` from the reference.
 
+## Keeping your vendored kit in sync
+
+A shipped extension vendors the kit **verbatim** as `canvas-kit/` — there's no npm
+package or build step, so nothing tells you whether the copy you shipped matches
+the current `kit/`. The kit is version-stamped to close that gap: `kit/version.mjs`
+exports `KIT_VERSION` (re-exported from `/kit/client.mjs`), and two scripts keep
+vendored copies honest.
+
+- **Re-sync after a kit change.** Bump `KIT_VERSION` when you change any kit file,
+  then refresh each vendored copy:
+  ```
+  node scripts/sync-kit.mjs <extension-dir>
+  ```
+  This makes `<extension-dir>/canvas-kit/` an exact mirror of `kit/` —
+  overwriting changed files **and pruning stale ones** (a file removed upstream
+  won't linger) — and records the version into
+  `<extension-dir>/canvas-kit/.kit-version.json`.
+
+- **Gate drift in CI (offline).** Fail the build if any vendored kit has drifted
+  from `kit/` — by file set, by file contents, or by recorded version:
+  ```
+  node scripts/check-kit-freshness.mjs <extensions-dir>
+  ```
+  Point it at a folder of extensions (e.g. `.github/extensions`), a single
+  extension dir, or a `canvas-kit/` dir. Exit 0 = all fresh; exit 1 = drift, with
+  the offending files listed. It runs no network and needs no dependencies.
+
+The `.kit-version.json` marker is metadata, **not** a kit file — the byte-parity
+test (`test/kit-parity.test.mjs`) and the freshness check both treat it as
+out-of-band, so it never counts against `kit/` ↔ `canvas-kit/` parity.
+
 ## Validate visually — don't claim done without looking
 
 A canvas isn't done because the server boots. Verify the UI:
 
 1. Run the standalone HTTP test to prove the runtime contract:
    `node test/http.test.mjs` (and `node test/kit-parity.test.mjs`,
-   `node test/generator.test.mjs`). A stamped canvas ships its own
-   `test/smoke.test.mjs` — run it from the canvas folder
+   `node test/generator.test.mjs`, `node test/tooling.test.mjs`). A stamped canvas
+   ships its own `test/smoke.test.mjs` — run it from the canvas folder
    (`node test/smoke.test.mjs`) to prove its actions over real HTTP.
 2. Open the canvas and **look at it** (Playwright or the browser canvas):
    navigate to the panel, assert key text/controls render, take a screenshot.
@@ -294,6 +325,8 @@ A canvas isn't done because the server boots. Verify the UI:
   `canvas-kit/` stay byte-identical.
 - `test/generator.test.mjs` — stamps both templates, runs their smoke tests, and
   checks the kit API surface (format helpers, poll helper, theme primitives).
+- `test/tooling.test.mjs` — exercises the version stamp (`kit/version.mjs`),
+  `scripts/sync-kit.mjs`, and the offline `scripts/check-kit-freshness.mjs` drift gate.
 
 ## Footguns
 

--- a/skills/create-canvas-kit/evals/README.md
+++ b/skills/create-canvas-kit/evals/README.md
@@ -1,0 +1,54 @@
+# create-canvas-kit eval
+
+A [Vally](https://aka.ms/vally) **capability** eval for the `create-canvas-kit`
+skill. It checks that, given a build request, the agent produces a canvas
+extension that honours the kit contract.
+
+It is **not** a per-PR gate — it drives a real LLM agent (the built-in
+`copilot-sdk` executor), so it costs tokens and time. Run it **on demand** or on a
+**nightly** schedule, not on every push. The deterministic file/parse graders are
+the backbone; the `prompt` rubric adds judgement.
+
+## Layout
+
+- `../../.vally.yaml` — project config; wires this skill into the executor
+  (`paths.skills: "."`) and points at `evals/`.
+- `eval.yaml` — the spec: two stimuli (a kanban board canvas; a data canvas that
+  fetches + auto-refreshes), each with deterministic graders and an LLM rubric.
+
+## Run it
+
+From the skill root (`skills/create-canvas-kit`):
+
+```bash
+npm install                 # one-time: pulls @microsoft/vally + @microsoft/vally-cli (dev only)
+
+# Static validation — fast, no agent, no tokens. This is the gate that must pass.
+npm run eval:lint           # = vally lint --eval-spec evals/create-canvas-kit/eval.yaml
+
+# Full run — drives the agent and grades the result (LLM cost/time; needs Copilot auth).
+# --skill-dir . loads this skill (via paths.skills in .vally.yaml) into the executor.
+npm run eval                # = vally eval --eval-spec evals/create-canvas-kit/eval.yaml --skill-dir .
+
+# Just one stimulus (cheaper):
+npx vally eval --eval-spec evals/create-canvas-kit/eval.yaml --skill-dir . --tag canvas=kanban
+```
+
+Results land in `vally-results/` (git-ignored). `npx vally serve vally-results`
+opens the analytics dashboard.
+
+## Graders
+
+Deterministic (no LLM):
+
+- `file-exists` — the canvas, the view, and the vendored `canvas-kit/` were created.
+- `file-contains` / `file-not-contains` / `file-not-matches` — SDK import only in
+  `extension.mjs`; the view uses `mountCanvas`; `canvas.mjs` uses the kit `nid`;
+  no `el.innerHTML =` repaint (the kit's `dangerouslySetInnerHTML` for SVG icons
+  is fine); the data canvas uses `pollWhileVisible` and `AbortSignal.timeout`, no
+  `fetch(` in the view.
+- `run-command` — `node --check` parses every generated `*.mjs` source.
+- `output-matches` — the agent's summary mentions refresh/poll (data stimulus).
+
+LLM rubric (`prompt`): kebab-case Lucide icons, `ck-*` theming, domain-keyed shared
+state, and the documented data-template contract.

--- a/skills/create-canvas-kit/evals/create-canvas-kit/eval.yaml
+++ b/skills/create-canvas-kit/evals/create-canvas-kit/eval.yaml
@@ -1,0 +1,229 @@
+name: create-canvas-kit
+description: >-
+  Capability eval for the create-canvas-kit skill. The agent must scaffold a
+  working Copilot App canvas extension that honours the kit contract: the SDK is
+  imported only in extension.mjs, the view renders through mountCanvas + Preact
+  (no innerHTML), icons are kebab-case Lucide names, and an external-data canvas
+  fetches inside a handler and auto-refreshes via the visibility-gated
+  pollWhileVisible helper. Deterministic graders inspect the produced files and
+  parse them; an LLM rubric judges contract adherence.
+type: capability
+
+defaults:
+  runs: 1
+  timeout: 12m
+  executor: copilot-sdk
+
+# Weights are keyed by grader TYPE (aggregated across a stimulus). run-command
+# (does it actually parse?) and the LLM rubric carry the most signal.
+scoring:
+  weights:
+    file-exists: 1
+    file-contains: 1
+    file-not-contains: 1
+    file-not-matches: 1
+    output-matches: 1
+    run-command: 2
+    prompt: 2
+  threshold: 0.8
+
+stimuli:
+  - name: kanban-board-canvas
+    prompt: >-
+      Build a kanban board canvas with the create-canvas-kit skill. Scaffold it
+      with the generator, keep the vendored canvas-kit folder, shape a small
+      board (columns / cards), and make sure it boots.
+    tags:
+      canvas: kanban
+      cost: high
+    graders:
+      - type: file-exists
+        name: canvas-scaffolded
+        config:
+          path: "**/canvas.mjs"
+      - type: file-exists
+        name: view-scaffolded
+        config:
+          path: "**/web/app.mjs"
+      - type: file-exists
+        name: kit-vendored
+        config:
+          path: "**/canvas-kit/server.mjs"
+      - type: file-contains
+        name: sdk-in-extension
+        config:
+          path: "**/extension.mjs"
+          value: "@github/copilot-sdk/extension"
+      - type: file-not-contains
+        name: no-sdk-in-canvas
+        config:
+          path: "**/canvas.mjs"
+          value: "@github/copilot-sdk"
+      - type: file-not-contains
+        name: no-sdk-in-view
+        config:
+          path: "**/web/app.mjs"
+          value: "@github/copilot-sdk"
+      - type: file-contains
+        name: uses-mountcanvas
+        config:
+          path: "**/web/app.mjs"
+          value: "mountCanvas"
+      - type: file-contains
+        name: uses-kit-nid
+        config:
+          path: "**/canvas.mjs"
+          value: "nid"
+      - type: file-not-matches
+        name: no-innerhtml-repaint
+        config:
+          # Flag the actual repaint anti-pattern (`el.innerHTML =` or `+=`), NOT the
+          # substring "innerHTML" — the kit legitimately uses Preact's
+          # `dangerouslySetInnerHTML` to render Lucide SVGs, and comments may
+          # mention innerHTML.
+          path: "**/web/app.mjs"
+          pattern: "\\.innerHTML\\s*\\+?="
+      - type: run-command
+        name: generated-sources-parse
+        config:
+          command: node
+          timeout: 120s
+          args:
+            - "-e"
+            - |
+              const { execFileSync } = require("node:child_process");
+              const { readdirSync } = require("node:fs");
+              const { join } = require("node:path");
+              const SKIP = new Set(["node_modules", ".git", "vendor"]);
+              const found = [];
+              (function walk(d) {
+                for (const e of readdirSync(d, { withFileTypes: true })) {
+                  if (SKIP.has(e.name)) continue;
+                  const p = join(d, e.name);
+                  if (e.isDirectory()) walk(p);
+                  else if (/(canvas|extension|app)\.mjs$/.test(e.name)) found.push(p);
+                }
+              })(process.cwd());
+              const norm = (f) => f.replace(/\\/g, "/");
+              const required = [
+                ["canvas.mjs", /canvas\.mjs$/],
+                ["extension.mjs", /extension\.mjs$/],
+                ["web/app.mjs", /web\/app\.mjs$/],
+              ];
+              for (const [label, re] of required) {
+                if (!found.some((f) => re.test(norm(f)))) {
+                  console.error("FAIL: no " + label + " was produced");
+                  process.exit(1);
+                }
+              }
+              for (const f of found) execFileSync(process.execPath, ["--check", f], { stdio: "inherit" });
+              console.log("node --check passed for " + found.length + " source file(s)");
+      - type: prompt
+        name: contract-rubric
+        config:
+          scoring: scale_1_5
+          threshold: 0.7
+          prompt: >-
+            Judge whether the agent built a canvas that follows the
+            create-canvas-kit contract in the rubric. Reward concrete evidence in
+            the produced files and the explanation; penalise hand-rolled SVGs,
+            CDN icons, innerHTML repaints, or SDK imports outside extension.mjs.
+    rubric:
+      - The agent used the create-canvas-kit skill / generator rather than hand-rolling a canvas from scratch.
+      - Icons use kebab-case Lucide names (e.g. "circle-check", "list-todo"), never hand-written SVG or a CDN.
+      - The theme builds on the kit's ck-* classes rather than restyling the primitives.
+      - State is shared and durable, keyed by domain, and the Copilot SDK import stays in extension.mjs only.
+      - The board renders through Preact (mountCanvas), not an innerHTML repaint loop.
+
+  - name: data-canvas-autorefresh
+    prompt: >-
+      Build a data canvas that fetches from an API and auto-refreshes, using the
+      create-canvas-kit skill's data template. Point it at a JSON API, fetch
+      inside an action handler with a timeout, and refresh on a visibility-gated
+      timer.
+    tags:
+      canvas: data
+      cost: high
+    graders:
+      - type: file-exists
+        name: canvas-scaffolded
+        config:
+          path: "**/canvas.mjs"
+      - type: file-exists
+        name: view-scaffolded
+        config:
+          path: "**/web/app.mjs"
+      - type: file-contains
+        name: uses-pollwhilevisible
+        config:
+          path: "**/web/app.mjs"
+          value: "pollWhileVisible"
+      - type: file-contains
+        name: fetch-timeout-in-handler
+        config:
+          path: "**/canvas.mjs"
+          value: "AbortSignal.timeout"
+      - type: file-not-contains
+        name: no-fetch-in-view
+        config:
+          path: "**/web/app.mjs"
+          value: "fetch("
+      - type: file-not-contains
+        name: no-sdk-in-view
+        config:
+          path: "**/web/app.mjs"
+          value: "@github/copilot-sdk"
+      - type: output-matches
+        name: mentions-refresh
+        config:
+          pattern: "[Rr]efresh|[Aa]uto-?[Rr]efresh|[Pp]oll"
+      - type: run-command
+        name: generated-sources-parse
+        config:
+          command: node
+          timeout: 120s
+          args:
+            - "-e"
+            - |
+              const { execFileSync } = require("node:child_process");
+              const { readdirSync } = require("node:fs");
+              const { join } = require("node:path");
+              const SKIP = new Set(["node_modules", ".git", "vendor"]);
+              const found = [];
+              (function walk(d) {
+                for (const e of readdirSync(d, { withFileTypes: true })) {
+                  if (SKIP.has(e.name)) continue;
+                  const p = join(d, e.name);
+                  if (e.isDirectory()) walk(p);
+                  else if (/(canvas|extension|app)\.mjs$/.test(e.name)) found.push(p);
+                }
+              })(process.cwd());
+              const norm = (f) => f.replace(/\\/g, "/");
+              const required = [
+                ["canvas.mjs", /canvas\.mjs$/],
+                ["extension.mjs", /extension\.mjs$/],
+                ["web/app.mjs", /web\/app\.mjs$/],
+              ];
+              for (const [label, re] of required) {
+                if (!found.some((f) => re.test(norm(f)))) {
+                  console.error("FAIL: no " + label + " was produced");
+                  process.exit(1);
+                }
+              }
+              for (const f of found) execFileSync(process.execPath, ["--check", f], { stdio: "inherit" });
+              console.log("node --check passed for " + found.length + " source file(s)");
+      - type: prompt
+        name: contract-rubric
+        config:
+          scoring: scale_1_5
+          threshold: 0.7
+          prompt: >-
+            Judge whether the data canvas follows the create-canvas-kit
+            external-data contract in the rubric. Reward fetch-in-handler with a
+            timeout, captured error state, and the visibility-gated poll helper.
+    rubric:
+      - The data canvas auto-refreshes with pollWhileVisible, not a raw setInterval.
+      - fetch() lives in an action handler (with AbortSignal.timeout), never in the view.
+      - A flaky fetch is captured into state.error and the refresh action returns instead of throwing.
+      - The view uses the kit's ck-* theme classes and kebab-case Lucide icon names.
+      - The agent followed the documented data-template contract end to end.

--- a/skills/create-canvas-kit/kit/client.mjs
+++ b/skills/create-canvas-kit/kit/client.mjs
@@ -23,6 +23,10 @@ export { Icon, lucideSVG, hasIcon, iconNames } from "./icons.mjs";
 // SDK-free canvas.mjs). Re-exported here so views have one import site.
 export { nid, relativeTime, compactNumber, percent } from "./format.mjs";
 
+// Kit version stamp — lets a canvas (or the sync/freshness tooling) report which
+// kit snapshot it was built from.
+export { KIT_VERSION } from "./version.mjs";
+
 /**
  * Run `tick` on an interval, but only while the panel is visible — so a
  * backgrounded canvas stops polling a (possibly rate-limited) upstream. Returns

--- a/skills/create-canvas-kit/kit/version.mjs
+++ b/skills/create-canvas-kit/kit/version.mjs
@@ -1,0 +1,13 @@
+// canvas-kit/version.mjs
+//
+// A single version stamp for the kit. A vendored copy (canvas-kit/) is a literal
+// snapshot of this folder, so there is no package manager to tell you whether the
+// copy you shipped is the one you think it is. This constant gives the sync +
+// freshness tooling (scripts/sync-kit.mjs, scripts/check-kit-freshness.mjs) a
+// stable value to record and compare against.
+//
+// Bump it whenever the kit's files or API surface change. An ISO date is the
+// convention (the skill ships as files, not an npm version); a commit short-sha
+// works too. Re-exported from client.mjs so a canvas can read it at runtime.
+
+export const KIT_VERSION = "2026-06-26";

--- a/skills/create-canvas-kit/package.json
+++ b/skills/create-canvas-kit/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "create-canvas-kit",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Dev tooling for the create-canvas-kit skill (tests + Vally eval). Shipped canvases never get a package.json — this is for the skill repo only.",
+  "license": "MIT",
+  "scripts": {
+    "test": "node test/http.test.mjs && node test/kit-parity.test.mjs && node test/generator.test.mjs && node test/tooling.test.mjs",
+    "eval:lint": "vally lint --eval-spec evals/create-canvas-kit/eval.yaml",
+    "eval": "vally eval --eval-spec evals/create-canvas-kit/eval.yaml --skill-dir ."
+  },
+  "devDependencies": {
+    "@microsoft/vally": "^0.6.0",
+    "@microsoft/vally-cli": "^0.6.0"
+  }
+}

--- a/skills/create-canvas-kit/reference/decision-log/canvas-kit/client.mjs
+++ b/skills/create-canvas-kit/reference/decision-log/canvas-kit/client.mjs
@@ -23,6 +23,10 @@ export { Icon, lucideSVG, hasIcon, iconNames } from "./icons.mjs";
 // SDK-free canvas.mjs). Re-exported here so views have one import site.
 export { nid, relativeTime, compactNumber, percent } from "./format.mjs";
 
+// Kit version stamp — lets a canvas (or the sync/freshness tooling) report which
+// kit snapshot it was built from.
+export { KIT_VERSION } from "./version.mjs";
+
 /**
  * Run `tick` on an interval, but only while the panel is visible — so a
  * backgrounded canvas stops polling a (possibly rate-limited) upstream. Returns

--- a/skills/create-canvas-kit/reference/decision-log/canvas-kit/version.mjs
+++ b/skills/create-canvas-kit/reference/decision-log/canvas-kit/version.mjs
@@ -1,0 +1,13 @@
+// canvas-kit/version.mjs
+//
+// A single version stamp for the kit. A vendored copy (canvas-kit/) is a literal
+// snapshot of this folder, so there is no package manager to tell you whether the
+// copy you shipped is the one you think it is. This constant gives the sync +
+// freshness tooling (scripts/sync-kit.mjs, scripts/check-kit-freshness.mjs) a
+// stable value to record and compare against.
+//
+// Bump it whenever the kit's files or API surface change. An ISO date is the
+// convention (the skill ships as files, not an npm version); a commit short-sha
+// works too. Re-exported from client.mjs so a canvas can read it at runtime.
+
+export const KIT_VERSION = "2026-06-26";

--- a/skills/create-canvas-kit/reference/decision-log/canvas.mjs
+++ b/skills/create-canvas-kit/reference/decision-log/canvas.mjs
@@ -68,12 +68,14 @@ export const canvasConfig = {
       handler: ({ state, set, input }) => {
         const title = String(input.title ?? "").trim();
         if (!title) throw new Error("title is required");
+        const now = new Date().toISOString();
         const d = {
           id: nid(),
           title,
           note: input.note ? String(input.note) : "",
           status: STATUSES.includes(input.status) ? input.status : "open",
-          createdAt: new Date().toISOString(),
+          createdAt: now,
+          updatedAt: now,
         };
         set({ ...state, decisions: [d, ...state.decisions] });
         return { id: d.id, status: `Added “${d.title}”` };
@@ -93,13 +95,15 @@ export const canvasConfig = {
       },
       handler: ({ state, set, input }) => {
         let found = false;
+        const now = new Date().toISOString();
         const decisions = state.decisions.map((d) => {
           if (d.id !== input.id) return d;
           found = true;
           return {
             ...d,
             status: input.status,
-            decidedAt: input.status === "decided" ? new Date().toISOString() : d.decidedAt,
+            decidedAt: input.status === "decided" ? now : d.decidedAt,
+            updatedAt: now,
           };
         });
         if (!found) throw new Error(`No decision with id ${input.id}`);
@@ -118,10 +122,11 @@ export const canvasConfig = {
       },
       handler: ({ state, set, input }) => {
         let found = false;
+        const now = new Date().toISOString();
         const decisions = state.decisions.map((d) => {
           if (d.id !== input.id) return d;
           found = true;
-          return { ...d, note: input.note ? String(input.note) : "" };
+          return { ...d, note: input.note ? String(input.note) : "", updatedAt: now };
         });
         if (!found) throw new Error(`No decision with id ${input.id}`);
         set({ ...state, decisions });

--- a/skills/create-canvas-kit/reference/decision-log/web/app.mjs
+++ b/skills/create-canvas-kit/reference/decision-log/web/app.mjs
@@ -8,7 +8,7 @@
 //     innerHTML, a live state push does NOT clobber the text you're typing or
 //     move your caret — the core fix over the hand-rolled innerHTML canvases.
 
-import { html, mountCanvas, useState, Icon } from "/kit/client.mjs";
+import { html, mountCanvas, useState, Icon, relativeTime } from "/kit/client.mjs";
 
 const FILTERS = ["all", "open", "decided", "parked"];
 
@@ -81,6 +81,9 @@ function DecisionItem({ d, invoke }) {
       </div>
       ${d.note
         ? html`<div class="dl-item-note ck-muted">${d.note}</div>`
+        : null}
+      ${d.updatedAt
+        ? html`<div class="ck-caption" style="margin-top:6px">updated ${relativeTime(d.updatedAt)}</div>`
         : null}
       <div class="ck-row dl-actions" style="margin-top:10px">
         ${others.map(

--- a/skills/create-canvas-kit/scripts/check-kit-freshness.mjs
+++ b/skills/create-canvas-kit/scripts/check-kit-freshness.mjs
@@ -1,0 +1,159 @@
+// scripts/check-kit-freshness.mjs — OFFLINE parity/freshness gate for vendored
+// kits. Point it at a directory that holds one or more extensions (or a single
+// extension / canvas-kit dir) and it fails if any vendored canvas-kit/ has
+// drifted from the canonical kit/ — by file set, by file contents, or by the
+// recorded version.
+//
+// Intended for CI: a consumer repo vendors the kit, then runs
+//   node scripts/check-kit-freshness.mjs .github/extensions
+// to guarantee nobody hand-edited the kit or forgot to re-sync after a bump.
+//
+// Usage:
+//   node scripts/check-kit-freshness.mjs <dir>
+//
+// Exit code 0 = all vendored kits fresh; 1 = drift found (or bad usage).
+
+import { readdir, readFile, stat } from "node:fs/promises";
+import { join, resolve, isAbsolute, basename, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { KIT_VERSION } from "../kit/version.mjs";
+import { VERSION_MARKER } from "./sync-kit.mjs";
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const KIT = join(ROOT, "kit");
+
+async function isDir(p) {
+  try {
+    return (await stat(p)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+async function walk(dir) {
+  const out = [];
+  for (const ent of await readdir(dir, { withFileTypes: true })) {
+    const abs = join(dir, ent.name);
+    if (ent.isDirectory()) out.push(...(await walk(abs)));
+    else out.push(abs);
+  }
+  return out.sort();
+}
+
+// Relative POSIX-style file list for a dir (so comparisons are OS-agnostic).
+async function relFiles(dir) {
+  return (await walk(dir)).map((p) => relative(dir, p).replace(/\\/g, "/")).sort();
+}
+
+// Find every vendored canvas-kit/ to check, given a root the user passed in.
+async function findVendoredKits(root) {
+  if (basename(root) === "canvas-kit" && (await isDir(root))) return [root];
+  if (await isDir(join(root, "canvas-kit"))) return [join(root, "canvas-kit")];
+
+  const found = [];
+  if (!(await isDir(root))) return found;
+  for (const ent of await readdir(root, { withFileTypes: true })) {
+    if (!ent.isDirectory()) continue;
+    const candidate = join(root, ent.name, "canvas-kit");
+    if (await isDir(candidate)) found.push(candidate);
+  }
+  return found.sort();
+}
+
+/**
+ * Compare one vendored canvas-kit/ against the canonical kit/.
+ * @returns {Promise<{dir:string, problems:string[]}>}
+ */
+export async function checkOne(canvasKitDir, kitDir = KIT) {
+  const problems = [];
+
+  const kitFiles = await relFiles(kitDir);
+  const vendoredFiles = (await relFiles(canvasKitDir)).filter((f) => f !== VERSION_MARKER);
+
+  const kitSet = new Set(kitFiles);
+  const vendoredSet = new Set(vendoredFiles);
+
+  for (const f of kitFiles) {
+    if (!vendoredSet.has(f)) {
+      problems.push(`missing file: ${f}`);
+      continue;
+    }
+    const [a, b] = await Promise.all([
+      readFile(join(kitDir, f)),
+      readFile(join(canvasKitDir, f)),
+    ]);
+    if (!a.equals(b)) problems.push(`content differs: ${f}`);
+  }
+  for (const f of vendoredFiles) {
+    if (!kitSet.has(f)) problems.push(`unexpected extra file: ${f}`);
+  }
+
+  // Version marker — distinguish a genuinely absent file from a corrupt one.
+  let raw = null;
+  try {
+    raw = await readFile(join(canvasKitDir, VERSION_MARKER), "utf8");
+  } catch {
+    problems.push(`missing ${VERSION_MARKER} (run scripts/sync-kit.mjs)`);
+  }
+  if (raw != null) {
+    let marker = null;
+    try {
+      marker = JSON.parse(raw);
+    } catch {
+      problems.push(`invalid ${VERSION_MARKER} (corrupt JSON; run scripts/sync-kit.mjs)`);
+    }
+    if (marker && marker.version !== KIT_VERSION) {
+      problems.push(`version drift: recorded ${JSON.stringify(marker.version)}, expected ${JSON.stringify(KIT_VERSION)}`);
+    }
+  }
+
+  return { dir: canvasKitDir, problems };
+}
+
+async function main() {
+  const arg = process.argv[2];
+  if (!arg) {
+    console.error(
+      "Usage: node scripts/check-kit-freshness.mjs <dir>\n" +
+        "  <dir> may be an extensions parent dir, a single extension dir, or a canvas-kit dir."
+    );
+    process.exit(1);
+  }
+
+  const root = isAbsolute(arg) ? arg : resolve(process.cwd(), arg);
+  if (!(await isDir(root))) {
+    console.error(`check-kit-freshness: path not found or not a directory: ${root}`);
+    process.exit(1);
+  }
+  const kits = await findVendoredKits(root);
+
+  if (kits.length === 0) {
+    console.log(`No vendored canvas-kit/ found under ${root} — nothing to check.`);
+    process.exit(0);
+  }
+
+  let drifted = 0;
+  for (const dir of kits) {
+    const { problems } = await checkOne(dir);
+    if (problems.length === 0) {
+      console.log(`  ok    ${dir} (kit ${KIT_VERSION})`);
+    } else {
+      drifted++;
+      console.error(`  DRIFT ${dir}`);
+      for (const p of problems) console.error(`        - ${p}`);
+    }
+  }
+
+  if (drifted > 0) {
+    console.error(`\n${drifted} vendored kit(s) drifted from kit/ ${KIT_VERSION}. Run: node scripts/sync-kit.mjs <dir>`);
+    process.exit(1);
+  }
+  console.log(`\nAll ${kits.length} vendored kit(s) are fresh (kit ${KIT_VERSION}).`);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+}

--- a/skills/create-canvas-kit/scripts/install-local.ps1
+++ b/skills/create-canvas-kit/scripts/install-local.ps1
@@ -25,7 +25,7 @@ $dest = Join-Path $SkillsDir $skillName
 New-Item -ItemType Directory -Force -Path $dest | Out-Null
 
 # Mirror the repo into the skill folder, excluding VCS + local state.
-robocopy $repoRoot $dest /MIR /XD ".git" "artifacts" /XF ".gitignore" /NFL /NDL /NJH /NJS /NP | Out-Null
+robocopy $repoRoot $dest /MIR /XD ".git" "artifacts" "node_modules" "vally-results" /XF ".gitignore" "package-lock.json" /NFL /NDL /NJH /NJS /NP | Out-Null
 if ($LASTEXITCODE -ge 8) { throw "install failed (robocopy exit $LASTEXITCODE)" }
 
 Write-Host "Installed '$skillName' skill to: $dest"

--- a/skills/create-canvas-kit/scripts/new-canvas.mjs
+++ b/skills/create-canvas-kit/scripts/new-canvas.mjs
@@ -19,12 +19,9 @@
 //   node scripts/new-canvas.mjs market-feed --template data --title "Market Feed" \
 //        --dir .github/extensions/market-feed
 
-import { cp, mkdir, readdir, writeFile, stat } from "node:fs/promises";
+import { mkdir, readdir, writeFile } from "node:fs/promises";
 import { join, resolve, isAbsolute } from "node:path";
-import { fileURLToPath } from "node:url";
-
-const ROOT = fileURLToPath(new URL("..", import.meta.url));
-const KIT = join(ROOT, "kit");
+import { syncKit } from "./sync-kit.mjs";
 
 function parseArgs(argv) {
   const args = { _: [] };
@@ -122,6 +119,59 @@ const MANIFEST = `{
   "version": 1
 }
 `;
+
+// Per-canvas README — stamped for every generated canvas (both templates) so the
+// folder is self-documenting once copied into an extensions dir.
+const README_MD = `# {{titleText}}
+
+{{descriptionText}}
+
+A GitHub Copilot App **canvas extension** generated with the \`create-canvas-kit\`
+skill ({{templateLabel}} template). The agent and the user share the same live
+state through the same action handlers; the view renders with Preact + htm and a
+vendored kit — no build step, no \`package.json\`.
+
+## Layout
+
+\`\`\`
+extension.mjs   the ONLY file that imports the Copilot SDK (thin adapter)
+canvas.mjs      canvas config: state load/save + action handlers (SDK-free)
+canvas-kit/     vendored kit (copied verbatim; do not edit)
+web/index.html  shell that loads /kit/theme.css and ./app.mjs
+web/app.mjs     your Preact view
+test/smoke.test.mjs  boots the runtime over HTTP and exercises the actions
+\`\`\`
+
+{{templateNote}}
+
+## Validate
+
+\`\`\`
+node test/smoke.test.mjs
+\`\`\`
+
+## Install
+
+Copy this folder into \`.github/extensions/{{name}}\` (in-repo) or
+\`$COPILOT_HOME/extensions/{{name}}\` (personal), then run \`extensions_reload\` and
+open it with \`open_canvas\` (\`canvasId: "{{name}}"\`).
+
+## Keeping the kit current
+
+\`canvas-kit/\` is a vendored snapshot of the create-canvas-kit \`kit/\`. Re-sync it
+with the skill's \`scripts/sync-kit.mjs\`, and gate drift in CI with
+\`scripts/check-kit-freshness.mjs\`.
+`;
+
+// Template-specific note injected into the stamped README.
+const TEMPLATE_NOTES = {
+  list: "This is a user-entered **list** canvas: add / toggle / remove items, " +
+    "persisted per user and shared live across every open panel.",
+  data: "This is an **external-data** canvas: it fetches from a source URL inside " +
+    "an action handler (always with `AbortSignal.timeout`), captures failures into " +
+    "state, and auto-refreshes on a visibility-gated timer via the kit's " +
+    "`pollWhileVisible` helper.",
+};
 
 // ---- template: list (default) ----------------------------------------------
 
@@ -718,6 +768,14 @@ const DATA_SMOKE_BODY = `  await test("GET /state has the initial data shape", a
     assert.ok(s.error, "the failed fetch should be captured in state.error");
   });
 
+  await test("relativeTime formats the captured lastRefresh", async () => {
+    const { relativeTime } = await import("../canvas-kit/format.mjs");
+    const s = await getState(open.url);
+    const rel = relativeTime(s.lastRefresh);
+    assert.equal(typeof rel, "string");
+    assert.ok(rel.length > 0, "relativeTime should format the lastRefresh timestamp");
+  });
+
   await test("clear empties items and error", async () => {
     await post(open.url, "clear", {});
     const s = await getState(open.url);
@@ -772,16 +830,22 @@ async function main() {
     descriptionJs: JSON.stringify(description),
     titleHtml: htmlEscape(title),
     titleText: String(title).replace(/[`\r\n]/g, " "),
+    descriptionText: String(description).replace(/[`\r\n]/g, " "),
+    templateLabel: template,
+    templateNote: TEMPLATE_NOTES[template],
   };
   const t = TEMPLATES[template];
 
   await mkdir(join(target, "web"), { recursive: true });
   await mkdir(join(target, "test"), { recursive: true });
-  await cp(KIT, join(target, "canvas-kit"), { recursive: true });
+  // Vendor the kit AND stamp .kit-version.json, so the generated canvas passes
+  // scripts/check-kit-freshness.mjs out of the box.
+  await syncKit(target);
 
   await writeFile(join(target, "extension.mjs"), EXTENSION_MJS);
   await writeFile(join(target, "canvas.mjs"), tpl(t.canvas, vars));
   await writeFile(join(target, "copilot-extension.json"), tpl(MANIFEST, vars));
+  await writeFile(join(target, "README.md"), tpl(README_MD, vars));
   await writeFile(join(target, "web", "index.html"), tpl(INDEX_HTML, vars));
   await writeFile(join(target, "web", "app.mjs"), tpl(t.app, vars));
   await writeFile(join(target, "test", "smoke.test.mjs"), smokeFile(name, t.smokeBody));
@@ -792,6 +856,7 @@ async function main() {
     "extension.mjs",
     "canvas.mjs",
     "copilot-extension.json",
+    "README.md",
     "web/index.html",
     "web/app.mjs",
     "test/smoke.test.mjs",

--- a/skills/create-canvas-kit/scripts/sync-kit.mjs
+++ b/skills/create-canvas-kit/scripts/sync-kit.mjs
@@ -1,0 +1,120 @@
+// scripts/sync-kit.mjs — copy the canonical kit/ into a consumer extension as
+// canvas-kit/, and stamp which kit version was written.
+//
+// A shipped/generated extension vendors the kit verbatim (no npm, no build), so
+// once it's copied there's nothing that tells you whether the copy is current.
+// Run this after bumping kit/version.mjs (or any kit file) to refresh a vendored
+// copy, then `node scripts/check-kit-freshness.mjs <dir>` in CI catches drift.
+//
+// Usage:
+//   node scripts/sync-kit.mjs <extension-dir>
+//
+//   <extension-dir>  the extension folder; the kit is written to
+//                    <extension-dir>/canvas-kit/. If the path already ends in
+//                    "canvas-kit", it is used directly.
+//
+// Examples:
+//   node scripts/sync-kit.mjs .github/extensions/market-feed
+//   node scripts/sync-kit.mjs reference/decision-log
+
+import { cp, mkdir, writeFile, readdir, rm, rmdir } from "node:fs/promises";
+import { join, resolve, isAbsolute, basename, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { KIT_VERSION } from "../kit/version.mjs";
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const KIT = join(ROOT, "kit");
+
+// Metadata marker sync writes alongside the vendored kit. It is intentionally
+// NOT part of the kit itself (kit/ has no such file), so the freshness check and
+// the parity test treat it as out-of-band metadata, not a kit file.
+export const VERSION_MARKER = ".kit-version.json";
+
+function parseArgs(argv) {
+  return { _: argv.filter((a) => !a.startsWith("--")) };
+}
+
+function resolveDest(dir) {
+  const abs = isAbsolute(dir) ? dir : resolve(process.cwd(), dir);
+  return basename(abs) === "canvas-kit" ? abs : join(abs, "canvas-kit");
+}
+
+// Relative POSIX-style file list under a dir.
+async function relFiles(dir) {
+  const out = [];
+  async function walk(d) {
+    for (const ent of await readdir(d, { withFileTypes: true })) {
+      const abs = join(d, ent.name);
+      if (ent.isDirectory()) await walk(abs);
+      else out.push(relative(dir, abs).replace(/\\/g, "/"));
+    }
+  }
+  await walk(dir);
+  return out;
+}
+
+// Make `dest` an EXACT mirror of kit/ (plus the version marker): remove any file
+// that isn't in the canonical kit, then drop the now-empty directories. Without
+// this, a file removed upstream would linger in a re-synced copy and trip the
+// freshness check with no way to repair it via sync.
+async function pruneToKit(dest) {
+  const keep = new Set(await relFiles(KIT));
+  const emptyDirs = [];
+  async function walk(d) {
+    for (const ent of await readdir(d, { withFileTypes: true })) {
+      const abs = join(d, ent.name);
+      if (ent.isDirectory()) {
+        await walk(abs);
+        emptyDirs.push(abs); // deepest-first (children pushed before parents)
+      } else {
+        const rel = relative(dest, abs).replace(/\\/g, "/");
+        if (rel !== VERSION_MARKER && !keep.has(rel)) await rm(abs, { force: true });
+      }
+    }
+  }
+  await walk(dest);
+  for (const d of emptyDirs) {
+    await rmdir(d).catch(() => {}); // ENOTEMPTY for dirs that still hold kit files
+  }
+}
+
+export async function syncKit(dir) {
+  const dest = resolveDest(dir);
+  // Copy every canonical kit file over (vendor/ included), then prune stale extras
+  // so the vendored copy is an exact mirror of kit/ plus the version marker.
+  await mkdir(dest, { recursive: true });
+  await cp(KIT, dest, { recursive: true, force: true });
+  await pruneToKit(dest);
+
+  const marker = {
+    version: KIT_VERSION,
+    syncedAt: new Date().toISOString(),
+    source: "create-canvas-kit/kit",
+  };
+  await writeFile(join(dest, VERSION_MARKER), JSON.stringify(marker, null, 2) + "\n", "utf8");
+  return { dest, version: KIT_VERSION };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const dir = args._[0];
+  if (!dir) {
+    console.error(
+      "Usage: node scripts/sync-kit.mjs <extension-dir>\n" +
+        "  Copies kit/ into <extension-dir>/canvas-kit/ and records the kit version."
+    );
+    process.exit(1);
+  }
+
+  const { dest, version } = await syncKit(dir);
+  console.log(`Synced kit ${version} -> ${dest}`);
+  console.log(`Wrote ${join(dest, VERSION_MARKER)}`);
+}
+
+// Only run the CLI when invoked directly (not when imported by a test/tool).
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+}

--- a/skills/create-canvas-kit/test/generator.test.mjs
+++ b/skills/create-canvas-kit/test/generator.test.mjs
@@ -11,6 +11,7 @@ import { fileURLToPath } from "node:url";
 
 const ROOT = fileURLToPath(new URL("..", import.meta.url));
 const GEN = join(ROOT, "scripts", "new-canvas.mjs");
+const FRESH = join(ROOT, "scripts", "check-kit-freshness.mjs");
 
 let passed = 0;
 async function test(name, fn) {
@@ -166,9 +167,23 @@ async function main() {
       });
 
       await test(`${c.template}: expected files exist (incl. stamped smoke test)`, async () => {
-        for (const f of ["canvas.mjs", "extension.mjs", "copilot-extension.json", "web/app.mjs", "web/index.html", "test/smoke.test.mjs"]) {
+        for (const f of ["canvas.mjs", "extension.mjs", "copilot-extension.json", "README.md", "web/app.mjs", "web/index.html", "test/smoke.test.mjs"]) {
           assert.ok(await exists(join(c.dir, f)), `missing ${f}`);
         }
+      });
+
+      await test(`${c.template}: stamped README documents the canvas`, async () => {
+        const readme = await read(join(c.dir, "README.md"));
+        assert.match(readme, /^# Gen Test/m);
+        assert.match(readme, /canvas-kit\//);
+        assert.match(readme, /node test\/smoke\.test\.mjs/);
+        // template-specific note is injected
+        assert.match(readme, c.template === "data" ? /external-data/i : /list\b/i);
+      });
+
+      await test(`${c.template}: generated canvas passes check-kit-freshness`, () => {
+        const out = run([FRESH, c.dir], work);
+        assert.equal(out.status, 0, out.stderr || out.stdout);
       });
 
       await test(`${c.template}: stamped canvas.mjs imports nid from the kit`, async () => {
@@ -203,6 +218,12 @@ async function main() {
       const app = await read(join(work, "gen-feed", "web", "app.mjs"));
       assert.match(app, /pollWhileVisible/);
       assert.match(app, /useEffect/);
+    });
+
+    await test("data smoke test exercises relativeTime against lastRefresh", async () => {
+      const smoke = await read(join(work, "gen-feed", "test", "smoke.test.mjs"));
+      assert.match(smoke, /relativeTime/);
+      assert.match(smoke, /canvas-kit\/format\.mjs/);
     });
 
     // Regression: a title with quotes / backtick / ${...} must still stamp a

--- a/skills/create-canvas-kit/test/http.test.mjs
+++ b/skills/create-canvas-kit/test/http.test.mjs
@@ -136,6 +136,7 @@ async function main() {
     assert.equal(after.body.decisions.length, 1);
     assert.equal(after.body.decisions[0].title, "Use Preact + htm");
     assert.equal(after.body.decisions[0].status, "open");
+    assert.ok(after.body.decisions[0].updatedAt, "add_decision should capture updatedAt");
   });
 
   await test("state persists durably to user artifacts", async () => {

--- a/skills/create-canvas-kit/test/kit-parity.test.mjs
+++ b/skills/create-canvas-kit/test/kit-parity.test.mjs
@@ -26,6 +26,10 @@ async function walk(dir) {
   return out.sort();
 }
 
+// scripts/sync-kit.mjs records the synced kit version in this out-of-band marker.
+// It is metadata, not a kit file, so it is excluded from the byte-parity contract.
+const VERSION_MARKER = ".kit-version.json";
+
 let passed = 0;
 async function test(name, fn) {
   await fn();
@@ -36,11 +40,26 @@ async function test(name, fn) {
 async function main() {
   console.log("kit/ <-> reference canvas-kit/ parity");
 
-  const aFiles = (await walk(A)).map((p) => relative(A, p).replace(/\\/g, "/"));
-  const bFiles = (await walk(B)).map((p) => relative(B, p).replace(/\\/g, "/"));
+  const aRaw = (await walk(A)).map((p) => relative(A, p).replace(/\\/g, "/"));
+  const bRaw = (await walk(B)).map((p) => relative(B, p).replace(/\\/g, "/"));
+
+  await test("canonical kit/ does not contain the vendored-only version marker", () => {
+    assert.ok(!aRaw.includes(VERSION_MARKER), `kit/ must not contain ${VERSION_MARKER} (it belongs only in vendored copies)`);
+  });
+
+  const aFiles = aRaw.filter((f) => f !== VERSION_MARKER);
+  const bFiles = bRaw.filter((f) => f !== VERSION_MARKER);
 
   await test("same file list in both kit copies", () => {
     assert.deepEqual(aFiles, bFiles);
+  });
+
+  await test("version.mjs is part of the kit and exports KIT_VERSION", async () => {
+    assert.ok(aFiles.includes("version.mjs"), "kit/version.mjs must exist");
+    assert.ok(bFiles.includes("version.mjs"), "reference canvas-kit/version.mjs must exist");
+    const { KIT_VERSION } = await import(new URL("../kit/version.mjs", import.meta.url));
+    assert.equal(typeof KIT_VERSION, "string");
+    assert.ok(KIT_VERSION.length > 0, "KIT_VERSION must be a non-empty string");
   });
 
   for (const rel of aFiles) {

--- a/skills/create-canvas-kit/test/tooling.test.mjs
+++ b/skills/create-canvas-kit/test/tooling.test.mjs
@@ -1,0 +1,179 @@
+// test/tooling.test.mjs — exercises the kit maintenance tooling: the version
+// stamp, scripts/sync-kit.mjs (copy + record version), and
+// scripts/check-kit-freshness.mjs (offline drift gate). No deps; Node 18+.
+// Run:  node test/tooling.test.mjs
+
+import assert from "node:assert/strict";
+import { mkdtemp, rm, readFile, writeFile, readdir, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, relative } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const KIT = join(ROOT, "kit");
+const SYNC = join(ROOT, "scripts", "sync-kit.mjs");
+const FRESH = join(ROOT, "scripts", "check-kit-freshness.mjs");
+
+let passed = 0;
+async function test(name, fn) {
+  try {
+    await fn();
+    passed++;
+    console.log(`  ok  ${name}`);
+  } catch (e) {
+    console.error(`FAIL  ${name}\n      ${e.message}`);
+    process.exitCode = 1;
+    throw e;
+  }
+}
+
+function run(args, cwd) {
+  return spawnSync(process.execPath, args, { cwd, encoding: "utf8" });
+}
+
+async function walk(dir) {
+  const out = [];
+  for (const ent of await readdir(dir, { withFileTypes: true })) {
+    const abs = join(dir, ent.name);
+    if (ent.isDirectory()) out.push(...(await walk(abs)));
+    else out.push(abs);
+  }
+  return out.sort();
+}
+async function relFiles(dir) {
+  return (await walk(dir)).map((p) => relative(dir, p).replace(/\\/g, "/")).sort();
+}
+async function exists(p) {
+  try { await stat(p); return true; } catch { return false; }
+}
+
+async function main() {
+  console.log("create-canvas-kit kit tooling tests");
+
+  const { KIT_VERSION } = await import("../kit/version.mjs");
+  const { VERSION_MARKER, syncKit } = await import("../scripts/sync-kit.mjs");
+
+  await test("version.mjs exports a non-empty KIT_VERSION", () => {
+    assert.equal(typeof KIT_VERSION, "string");
+    assert.ok(KIT_VERSION.length > 0);
+  });
+
+  await test("client.mjs re-exports KIT_VERSION", async () => {
+    const client = await import("../kit/client.mjs");
+    assert.equal(client.KIT_VERSION, KIT_VERSION);
+  });
+
+  const work = await mkdtemp(join(tmpdir(), "ck-tooling-"));
+  try {
+    const extDir = join(work, "my-ext");
+
+    // ---- sync-kit (CLI) ----------------------------------------------------
+    await test("sync-kit CLI copies kit/ into <dir>/canvas-kit and records version", async () => {
+      const out = run([SYNC, extDir], work);
+      assert.equal(out.status, 0, out.stderr || out.stdout);
+
+      const dest = join(extDir, "canvas-kit");
+      // every kit file is present and byte-identical
+      const kitFiles = await relFiles(KIT);
+      for (const f of kitFiles) {
+        const [a, b] = await Promise.all([readFile(join(KIT, f)), readFile(join(dest, f))]);
+        assert.ok(a.equals(b), `synced ${f} differs from kit/`);
+      }
+      // the marker is written with the current version
+      const marker = JSON.parse(await readFile(join(dest, VERSION_MARKER), "utf8"));
+      assert.equal(marker.version, KIT_VERSION);
+      assert.ok(marker.syncedAt, "marker should record syncedAt");
+    });
+
+    // ---- freshness: fresh = pass ------------------------------------------
+    await test("check-kit-freshness passes on a freshly synced dir (exit 0)", () => {
+      const out = run([FRESH, extDir], work);
+      assert.equal(out.status, 0, out.stderr || out.stdout);
+      assert.match(out.stdout, /fresh/i);
+    });
+
+    await test("check-kit-freshness also accepts an extensions parent dir", () => {
+      const out = run([FRESH, work], work); // work/ holds my-ext/canvas-kit
+      assert.equal(out.status, 0, out.stderr || out.stdout);
+    });
+
+    // ---- freshness: content drift = fail ----------------------------------
+    await test("freshness FAILS when a vendored kit file is hand-edited (exit 1)", async () => {
+      const f = join(extDir, "canvas-kit", "format.mjs");
+      await writeFile(f, (await readFile(f, "utf8")) + "\n// drift\n", "utf8");
+      const out = run([FRESH, extDir], work);
+      assert.equal(out.status, 1, "expected non-zero exit on content drift");
+      assert.match(out.stderr, /content differs/i);
+    });
+
+    // ---- freshness: version drift = fail ----------------------------------
+    await test("freshness FAILS when the recorded version is stale (exit 1)", async () => {
+      // re-sync to clean content, then corrupt only the version marker
+      run([SYNC, extDir], work);
+      const markerPath = join(extDir, "canvas-kit", VERSION_MARKER);
+      const m = JSON.parse(await readFile(markerPath, "utf8"));
+      m.version = "0000-00-00";
+      await writeFile(markerPath, JSON.stringify(m, null, 2) + "\n", "utf8");
+      const out = run([FRESH, extDir], work);
+      assert.equal(out.status, 1, "expected non-zero exit on version drift");
+      assert.match(out.stderr, /version drift/i);
+    });
+
+    // ---- freshness: missing marker = fail ---------------------------------
+    await test("freshness FAILS when the version marker is missing (exit 1)", async () => {
+      run([SYNC, extDir], work);
+      await rm(join(extDir, "canvas-kit", VERSION_MARKER));
+      const out = run([FRESH, extDir], work);
+      assert.equal(out.status, 1, "expected non-zero exit when marker missing");
+      assert.match(out.stderr, /missing .*kit-version/i);
+    });
+
+    // ---- freshness: corrupt marker = fail (distinct from missing) ----------
+    await test("freshness FAILS with 'invalid' when the marker is corrupt JSON (exit 1)", async () => {
+      run([SYNC, extDir], work);
+      await writeFile(join(extDir, "canvas-kit", VERSION_MARKER), "{ not json", "utf8");
+      const out = run([FRESH, extDir], work);
+      assert.equal(out.status, 1, "expected non-zero exit on corrupt marker");
+      assert.match(out.stderr, /invalid .*kit-version/i);
+    });
+
+    // ---- sync prunes stale extras so a re-sync repairs extra-file drift ----
+    await test("sync-kit prunes stale extras; re-sync brings extra-file drift back to green", async () => {
+      run([SYNC, extDir], work);
+      const stray = join(extDir, "canvas-kit", "stale.mjs");
+      await writeFile(stray, "// stale\n", "utf8");
+      let out = run([FRESH, extDir], work);
+      assert.equal(out.status, 1, "an extra vendored file should be drift");
+      assert.match(out.stderr, /unexpected extra file/i);
+      run([SYNC, extDir], work); // re-sync prunes the stray file
+      assert.equal(await exists(stray), false, "sync should prune the stale file");
+      out = run([FRESH, extDir], work);
+      assert.equal(out.status, 0, out.stderr || out.stdout);
+    });
+
+    // ---- freshness: a bad/typo path fails loudly (not a silent green) ------
+    await test("freshness FAILS on a non-existent path (exit 1)", () => {
+      const out = run([FRESH, join(work, "does-not-exist")], work);
+      assert.equal(out.status, 1, "a bad path must not silently pass the gate");
+    });
+
+    // ---- syncKit() importable API -----------------------------------------
+    await test("syncKit() returns the dest + version and is idempotent", async () => {
+      const ext2 = join(work, "ext2");
+      const res = await syncKit(ext2);
+      assert.equal(res.version, KIT_VERSION);
+      assert.ok(await exists(join(ext2, "canvas-kit", "server.mjs")));
+      assert.ok(await exists(join(ext2, "canvas-kit", VERSION_MARKER)));
+    });
+  } finally {
+    await rm(work, { recursive: true, force: true });
+  }
+
+  console.log(`\n${passed} checks passed`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Adds drift-prevention tooling and a skill-owned evaluation to the create-canvas-kit skill. The kit is now version-stamped with a single source of truth, a one-command sync mirrors it into any vendored copy, and an offline CI gate fails on drift. The reference canvas exercises the shared `relativeTime` helper, the generator stamps a per-canvas README, the docs spell out the runtime contract, and a lint-valid Vally eval checks that the agent builds a contract-correct canvas.

## Changes
- Versioning + drift prevention: `kit/version.mjs` (`KIT_VERSION`, re-exported from `kit/client.mjs`); `scripts/sync-kit.mjs` (mirror `kit/` into `<dir>/canvas-kit/`, prune stale files, record `.kit-version.json`); offline `scripts/check-kit-freshness.mjs` drift gate; mirrored into the reference `canvas-kit/`; `test/tooling.test.mjs`.
- Reference: decision-log captures `updatedAt` and renders it via `relativeTime`.
- Generator: stamps a per-canvas `README.md` for both templates and writes the version marker so generated canvases pass the freshness gate; data smoke test exercises `relativeTime`.
- Docs: SKILL.md documents the action error model, locale-aware formatters, the `additionalProperties` rationale, and the no-build / no-package.json layout.
- Eval: `package.json` dev deps (`@microsoft/vally` + `@microsoft/vally-cli`), `.vally.yaml`, `evals/create-canvas-kit/eval.yaml` (two capability stimuli with deterministic graders + an LLM rubric), `evals/README.md`. Runs on-demand/nightly, not a per-PR gate.

## Type of Change
- [x] New feature (non-breaking)
- [x] Documentation update
- [ ] Breaking change

## Testing
`node test/*.test.mjs`: http 14, kit-parity 12, generator 30, tooling 12 = 68 checks, all green (deterministic across re-runs). `npx vally lint` passes; one real single-stimulus `vally eval` ran end-to-end (copilot-sdk executor, 10/11, then the over-broad grader was fixed).

## Quality Gates
| Gate | Status | Notes |
|---|---|---|
| code-review | PASS | All findings fixed (folded into the relevant commits) |
| security-review | PASS | 0 findings (>80% confidence bar) |
| dependencies (npm audit) | PASS | 0 vulnerabilities; dev-only first-party deps |
| tests | PASS | 68/68 green |
| doc-check | PASS | Docs verified against code |

## Security
- [x] No secrets or credentials committed
- [x] Dependencies scanned (npm audit: 0 CRITICAL/HIGH)
- [x] No `eval()` / `innerHTML` / `shell=True` with user input (the eval grader uses `node --check`, which doesn't execute modules; `execFileSync` runs with explicit args and no shell)

## Notes
- Generated canvases now include `canvas-kit/.kit-version.json` (additive).
- `package-lock.json` is git-ignored (dev-tooling tradeoff); easy to commit if you'd prefer it pinned.
- Upstream transitive dep `prebuild-install@7.1.3` is deprecated (via vally-cli to better-sqlite3); not actionable here.