### PR TITLE
fix(create-canvas-kit): resync data template source URL on agent change

### DIFF
--- a/skills/create-canvas-kit/scripts/new-canvas.mjs
+++ b/skills/create-canvas-kit/scripts/new-canvas.mjs
@@ -537,7 +537,7 @@ const DATA_APP_MJS = `// web/app.mjs — Preact view for the {{titleText}} data 
 // only TRIGGERS refresh — on a button and on a visibility-gated timer via the
 // kit's pollWhileVisible helper, with the interval bound to durable state.
 
-import { html, mountCanvas, useState, useEffect, Icon, pollWhileVisible, relativeTime } from "/kit/client.mjs";
+import { html, mountCanvas, useState, useEffect, useRef, Icon, pollWhileVisible, relativeTime } from "/kit/client.mjs";
 
 const TITLE = {{titleJs}};
 
@@ -551,6 +551,14 @@ const INTERVALS = [
 function Toolbar({ state, invoke }) {
   const [url, setUrl] = useState(state.sourceUrl ?? "");
   const [busy, setBusy] = useState(false);
+  const inputRef = useRef(null);
+
+  // Reflect an agent-driven source change back into the field, but never clobber
+  // what the user is mid-edit — only resync the draft when the input isn't focused.
+  useEffect(() => {
+    if (inputRef.current && document.activeElement === inputRef.current) return;
+    setUrl(state.sourceUrl ?? "");
+  }, [state.sourceUrl]);
 
   async function refresh() {
     if (busy) return;
@@ -568,6 +576,7 @@ function Toolbar({ state, invoke }) {
     <div class="ck-card ck-col" style="margin:12px 0 16px">
       <div class="ck-row">
         <input
+          ref=\${inputRef}
           class="ck-input ck-grow"
           placeholder="Source URL…"
           value=\${url}


### PR DESCRIPTION
## Summary
The `data` canvas template's Source URL input seeded its draft from `state.sourceUrl` only once (via `useState`), so an agent-driven `set_source` left the field showing a stale URL while the actual fetches used the new one. This adds a focus-guarded resync so the field reflects agent changes without clobbering what the user is typing.

## Changes
- Import `useRef` in the data template's generated `web/app.mjs`.
- Add a `useEffect` keyed on `state.sourceUrl` that resyncs the input draft when the source changes upstream.
- Guard the resync on focus (`document.activeElement`) so an in-progress edit isn't overwritten.

## Type of Change
- [x] Bug fix (non-breaking)

## Testing
Validated by dogfooding both generated templates live (installed, reloaded, opened):
- Not focused: field resynced to the agent-set source on reopen.
- Focused: the user's in-progress draft survived an agent `set_source` (keystroke preservation intact).

## Quality Gates
| Gate | Status | Notes |
|---|---|---|
| `mq` (full pipeline) | SKIPPED | devx mq infra not wired in this repo (no DEVX_WS); repo test suite used instead |
| `cr` (code-review) | self | single-file generator change, +10/-1; self-reviewed |
| `pf` (preflight) | PASS 68/68 | `npm test`: http + kit-parity + generator + tooling, at 4457bc9 |
| `secops` (security) | N/A | generator template-string edit only; no runtime/security surface |
| `th` (test-health) | PASS | full suite green; no flaky tests |

## Notes
Generator-only change. No kit file touched, so the canonical `kit/` and the reference `canvas-kit/` stay byte-identical (parity test still green).