### PR TITLE
docs(create-canvas-app): document session-scoped extension install location

### DIFF
--- a/skills/create-canvas-app/README.md
+++ b/skills/create-canvas-app/README.md
@@ -131,6 +131,11 @@ the box: add, toggle, and remove items, live, shared between you and the agent.
 Each stamped canvas ships a `test/smoke.test.mjs` — run `node test/smoke.test.mjs`
 from the canvas folder to prove its actions over real HTTP.
 
+Target any extension scope with `--dir`: `.github/extensions/<name>` (in-repo,
+committed), `$COPILOT_HOME/extensions/<name>` (personal, local to you), or
+`$COPILOT_HOME/session-state/<sessionId>/extensions/<name>` (current session only —
+a throwaway canvas that disappears with the session).
+
 Then make it yours:
 
 1. **`canvas.mjs`** — edit `createInitialState`, the action handlers, and

--- a/skills/create-canvas-app/SKILL.md
+++ b/skills/create-canvas-app/SKILL.md
@@ -282,10 +282,13 @@ who shares what.
    ```
    node scripts/new-canvas.mjs <name> --dir <target> --title "Display Name"
    ```
-   For an in-repo extension, target `.github/extensions/<name>`. For a personal
-   one, target `$COPILOT_HOME/extensions/<name>`. Add `--template data` for an
-   external-data canvas (fetch + `refresh` + visibility-gated polling) instead of
-   the default user-entered list.
+   Target `.github/extensions/<name>` for an in-repo extension (committed, shared
+   with the team), `$COPILOT_HOME/extensions/<name>` for a personal one (local to
+   you), or `$COPILOT_HOME/session-state/<sessionId>/extensions/<name>` for a
+   throwaway canvas scoped to just the current session — it's discovered like the
+   others (its `extensionId` is `session:<sessionId>:<name>`) and disappears when
+   the session does. Add `--template data` for an external-data canvas (fetch +
+   `refresh` + visibility-gated polling) instead of the default user-entered list.
 2. **Reload + open.** Run `extensions_reload`, then `open_canvas` with
    `canvasId: "<name>"`. The list canvas works immediately.
 3. **Shape your data.** In `canvas.mjs`, edit `createInitialState`, the action

--- a/skills/create-canvas-app/scripts/new-canvas.mjs
+++ b/skills/create-canvas-app/scripts/new-canvas.mjs
@@ -152,9 +152,11 @@ node test/smoke.test.mjs
 
 ## Install
 
-Copy this folder into \`.github/extensions/{{name}}\` (in-repo) or
-\`$COPILOT_HOME/extensions/{{name}}\` (personal), then run \`extensions_reload\` and
-open it with \`open_canvas\` (\`canvasId: "{{name}}"\`).
+Copy this folder into \`.github/extensions/{{name}}\` (in-repo),
+\`$COPILOT_HOME/extensions/{{name}}\` (personal), or
+\`$COPILOT_HOME/session-state/<sessionId>/extensions/{{name}}\` (current session
+only — disappears with the session), then run \`extensions_reload\` and open it
+with \`open_canvas\` (\`canvasId: "{{name}}"\`).
 
 ## Keeping the kit current
 
@@ -915,7 +917,7 @@ async function main() {
     console.log("  " + f);
   }
   console.log("\nValidate it:   node test/smoke.test.mjs   (run from the canvas folder)");
-  console.log("Then install:  copy the folder into .github/extensions/ or $COPILOT_HOME/extensions/, then extensions_reload.");
+  console.log("Then install:  copy the folder into .github/extensions/ (in-repo), $COPILOT_HOME/extensions/ (personal), or $COPILOT_HOME/session-state/<sessionId>/extensions/ (this session only), then extensions_reload.");
 }
 
 main().catch((e) => {


### PR DESCRIPTION
## What
Documents the **session-scoped extension** install location in the `create-canvas-app` skill, so authored canvases can target the session scope the GitHub Copilot host app now supports.

A third scope now exists alongside project + user:
- **Session** — `$COPILOT_HOME/session-state/<sessionId>/extensions/<name>/`
- `extensionId`: `session:<sessionId>:<name>`
- Auto-discovered like the others; ephemeral (disappears with the session) — ideal for a throwaway canvas the agent spins up for one conversation.

## Changes (3 files, docs/generator text only)
- **`SKILL.md`** — "Build a canvas — fastest path" now lists all three `--dir` targets incl. the session path + resulting `extensionId`.
- **`scripts/new-canvas.mjs`** — generated extension's README "Install" section and the post-stamp console footer now mention the session scope.
- **`README.md`** — "Build without the agent" gains a concise three-scope note.

## Why no `KIT_VERSION` bump
Zero kit-byte changes — documentation + generator output text only, so `kit/ ↔ canvas-kit/` parity is untouched and no consumer re-sync is required.

## Out of scope / verified no-ops
- **copilot-extensions**: nothing to do — `origin/main` already has all 5 extensions at kit `2026-06-27`; `check-kit-freshness` reports all fresh. The drift seen on the stale `feat/wiki-discover` branch does not exist on main.

## Testing
- `npm test` → **70 checks pass** (http, kit-parity, generator, tooling).
- Stamped a canvas and confirmed the generated README + console footer render `$COPILOT_HOME/session-state/<sessionId>/extensions/<name>`.

Closes #7