### PR TITLE
feat(create-canvas-app): host-model access for canvas handlers (ctx.ai / ctx.askAgent)

### DIFF
--- a/skills/create-canvas-app/README.md
+++ b/skills/create-canvas-app/README.md
@@ -48,6 +48,9 @@ to your request, and validates it visually before handing it back.
   GitHub-dark fallbacks.
 - **Official GitHub icons** — the exact Lucide set github-app ships
   (`lucide-react@1.14.0`), vendored and byte-identical.
+- **Host AI in a handler** — call the Copilot app's own model from an action with
+  `ctx.ai(question)` (silent, no keys, no history) or hand work to the main agent
+  with `ctx.askAgent(prompt)`. No API keys, no model picker, no external `fetch`.
 - **A generator** — `node scripts/new-canvas.mjs <name>` stamps a working canvas
   (add `--template data` for a fetch + auto-refresh canvas) with its own smoke test.
 - **Tests** — a standalone HTTP harness, a kit byte-parity check, and a generator test.

--- a/skills/create-canvas-app/SKILL.md
+++ b/skills/create-canvas-app/SKILL.md
@@ -44,7 +44,7 @@ use repaints the whole tree and loses keystrokes on every push. Don't do that.
 ## The model (read this before coding)
 
 ```
-extension.mjs   ── the ONLY file that imports the Copilot SDK (thin adapter)
+extension.mjs   ── the ONLY file that imports the Copilot SDK (thin adapter; also wires host AI)
 canvas.mjs      ── your canvas: id, schema, state load/save, action handlers (SDK-free)
 canvas-kit/     ── the kit (copied in verbatim; do not edit)
 web/index.html  ── shell: loads /kit/theme.css and ./app.mjs
@@ -232,6 +232,57 @@ refresh. The shape:
 
 Stamp this whole shape with `node scripts/new-canvas.mjs <name> --template data`.
 
+## Host AI — call the model from an action handler
+
+Canvases can use the **host's** AI model — the same model + auth the Copilot app is
+already running — with **no API keys, no model picker, no external `fetch`**. Action
+handlers get two capabilities on their context, wired once in `extension.mjs` (the
+only SDK file) and exposed by the kit:
+
+- **`ai(question) → Promise<string>`** — a **silent** model query. No tools, and it
+  is **not** added to the conversation history. This is the primitive for
+  canvas-internal AI: summarize, suggest, rewrite, classify, extract. It runs
+  against the **ambient conversation context**, so write self-contained,
+  function-style prompts and pin the output shape — otherwise the live chat can
+  bleed into the answer.
+
+  ```js
+  ai_suggest: {
+    inputSchema: { type: "object", properties: { topic: { type: "string" } }, required: ["topic"], additionalProperties: false },
+    handler: async ({ state, set, input, ai }) => {
+      const text = (await ai(
+        `You are an idea generator. Output ONLY one concise to-do (max 8 words) ` +
+        `about "${input.topic}". No quotes, no numbering, no extra text.`
+      )).trim().split("\n")[0];
+      set({ ...state, items: [{ id: nid(), text }, ...state.items] });
+      return { text };
+    },
+  },
+  ```
+
+- **`askAgent(prompt)`** — hand a prompt to the **main agent** in the user's
+  conversation. It is **visible in chat** and **tool-capable**. Use it for
+  "act in the repo / drive the agent" controls (e.g. an *Apply changes* button),
+  **not** for silent text generation — that's `ai`.
+
+Under the hood `ai` is the host's `ephemeralQuery` (a transient, no-tools,
+no-history model call, e2e-tested in the Copilot SDK) and `askAgent` is a normal
+session message. Both reach the host's selected model + auth.
+
+**Why not a sub-session?** Creating an isolated `client.createSession()` from inside
+an extension **hangs** — the host doesn't service a child-created session — so the
+kit does not offer it. `ai` (ephemeralQuery) is the supported silent path.
+
+**Footguns:**
+
+- `ai()` sees the live conversation. Treat it as ambient context; for a pure
+  transform, frame the prompt as a function and say "Output ONLY …".
+- `ai()` throws `ai_unavailable` when the canvas runs outside the Copilot host
+  (e.g. a standalone smoke test). Call it from an **action** (button- or
+  agent-invoked), never from `createInitialState`/`open`.
+- Don't block the panel on a slow `ai()` — `await` it in the handler, write the
+  result into state, and let SSE push the update, exactly like the data-fetch shape.
+
 ## Domain strategy — shared board vs personal profile
 
 State is keyed by the domain id `resolveDomainId` returns. Two intents, identical
@@ -377,3 +428,6 @@ A canvas isn't done because the server boots. Verify the UI:
 - **Never** hand-roll a polling `setInterval` — use `pollWhileVisible` so a
   hidden panel stops hammering the network.
 - **Never** `import { Fragment }` — it isn't exported; use htm's `<>…</>`.
+- **Never** reach for the model with `fetch`/API keys or a `client.createSession()`
+  sub-session (it hangs from an extension) — use `ctx.ai(...)` for silent
+  generation, `ctx.askAgent(...)` to drive the main agent.

--- a/skills/create-canvas-app/kit/server.mjs
+++ b/skills/create-canvas-app/kit/server.mjs
@@ -65,6 +65,15 @@ export function createCanvasRuntime(config) {
   const loading = new Map(); // domainId -> Promise<{ state }>  (in-flight cold loads)
   const instances = new Map(); // instanceId -> { server, url, domainId, clients:Set<res> }
 
+  // Host-model capabilities, injected by extension.mjs after it joins the
+  // session (see `setHost`). Kept here so server.mjs stays SDK-free: it never
+  // imports the Copilot SDK, it just forwards to whatever `host` provides.
+  // Null until wired (e.g. standalone HTTP tests), so the api guards below.
+  let host = null;
+  function setHost(h) {
+    host = h ?? null;
+  }
+
   async function getDomain(domainId, ctx) {
     const existing = domains.get(domainId);
     if (existing) return existing;
@@ -120,6 +129,35 @@ export function createCanvasRuntime(config) {
       },
       input: input ?? {},
       ctx: ctx ?? {},
+      // ---- host model access (wired by extension.mjs via setHost) ----------
+      // ai(question) -> Promise<string>: a silent, no-tools host-model query
+      // that is NOT added to the conversation history. It DOES run against the
+      // ambient conversation context, so frame prompts as self-contained
+      // functions ("You are X. Output ONLY ...") to avoid context bleed.
+      ai: (question) => {
+        if (typeof host?.ai !== "function") {
+          throw new CanvasKitError(
+            "ai_unavailable",
+            "ai() is unavailable: the canvas runtime has no host model wired " +
+              "(running standalone, or extension.mjs didn't call runtime.setHost). " +
+              "Host-model calls only work when the canvas runs under the Copilot app.",
+          );
+        }
+        return host.ai(question);
+      },
+      // askAgent(prompt) -> Promise<unknown>: hand a prompt to the MAIN agent in
+      // the user's conversation. Visible in chat and tool-capable — use for
+      // "do X in the repo" actions, NOT silent canvas text generation (use ai).
+      askAgent: (prompt) => {
+        if (typeof host?.askAgent !== "function") {
+          throw new CanvasKitError(
+            "agent_unavailable",
+            "askAgent() is unavailable: the canvas runtime has no host agent wired " +
+              "(running standalone, or extension.mjs didn't call runtime.setHost).",
+          );
+        }
+        return host.askAgent(prompt);
+      },
     };
     const result = await action.handler(api);
     if (mutated) {
@@ -312,6 +350,7 @@ export function createCanvasRuntime(config) {
 
   return {
     config,
+    setHost,
     openInstance,
     closeInstance,
     shutdown,

--- a/skills/create-canvas-app/kit/version.mjs
+++ b/skills/create-canvas-app/kit/version.mjs
@@ -10,4 +10,4 @@
 // convention (the skill ships as files, not an npm version); a commit short-sha
 // works too. Re-exported from client.mjs so a canvas can read it at runtime.
 
-export const KIT_VERSION = "2026-06-27";
+export const KIT_VERSION = "2026-06-27.1";

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/.kit-version.json
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/.kit-version.json
@@ -1,5 +1,5 @@
 {
-  "version": "2026-06-27",
-  "syncedAt": "2026-06-27T09:28:43.924Z",
+  "version": "2026-06-27.1",
+  "syncedAt": "2026-06-28T03:29:49.617Z",
   "source": "create-canvas-app/kit"
 }

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/server.mjs
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/server.mjs
@@ -65,6 +65,15 @@ export function createCanvasRuntime(config) {
   const loading = new Map(); // domainId -> Promise<{ state }>  (in-flight cold loads)
   const instances = new Map(); // instanceId -> { server, url, domainId, clients:Set<res> }
 
+  // Host-model capabilities, injected by extension.mjs after it joins the
+  // session (see `setHost`). Kept here so server.mjs stays SDK-free: it never
+  // imports the Copilot SDK, it just forwards to whatever `host` provides.
+  // Null until wired (e.g. standalone HTTP tests), so the api guards below.
+  let host = null;
+  function setHost(h) {
+    host = h ?? null;
+  }
+
   async function getDomain(domainId, ctx) {
     const existing = domains.get(domainId);
     if (existing) return existing;
@@ -120,6 +129,35 @@ export function createCanvasRuntime(config) {
       },
       input: input ?? {},
       ctx: ctx ?? {},
+      // ---- host model access (wired by extension.mjs via setHost) ----------
+      // ai(question) -> Promise<string>: a silent, no-tools host-model query
+      // that is NOT added to the conversation history. It DOES run against the
+      // ambient conversation context, so frame prompts as self-contained
+      // functions ("You are X. Output ONLY ...") to avoid context bleed.
+      ai: (question) => {
+        if (typeof host?.ai !== "function") {
+          throw new CanvasKitError(
+            "ai_unavailable",
+            "ai() is unavailable: the canvas runtime has no host model wired " +
+              "(running standalone, or extension.mjs didn't call runtime.setHost). " +
+              "Host-model calls only work when the canvas runs under the Copilot app.",
+          );
+        }
+        return host.ai(question);
+      },
+      // askAgent(prompt) -> Promise<unknown>: hand a prompt to the MAIN agent in
+      // the user's conversation. Visible in chat and tool-capable — use for
+      // "do X in the repo" actions, NOT silent canvas text generation (use ai).
+      askAgent: (prompt) => {
+        if (typeof host?.askAgent !== "function") {
+          throw new CanvasKitError(
+            "agent_unavailable",
+            "askAgent() is unavailable: the canvas runtime has no host agent wired " +
+              "(running standalone, or extension.mjs didn't call runtime.setHost).",
+          );
+        }
+        return host.askAgent(prompt);
+      },
     };
     const result = await action.handler(api);
     if (mutated) {
@@ -312,6 +350,7 @@ export function createCanvasRuntime(config) {
 
   return {
     config,
+    setHost,
     openInstance,
     closeInstance,
     shutdown,

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/version.mjs
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/version.mjs
@@ -10,4 +10,4 @@
 // convention (the skill ships as files, not an npm version); a commit short-sha
 // works too. Re-exported from client.mjs so a canvas can read it at runtime.
 
-export const KIT_VERSION = "2026-06-27";
+export const KIT_VERSION = "2026-06-27.1";

--- a/skills/create-canvas-app/reference/decision-log/extension.mjs
+++ b/skills/create-canvas-app/reference/decision-log/extension.mjs
@@ -54,4 +54,20 @@ const canvas = createCanvas({
   },
 });
 
-await joinSession({ canvases: [canvas] });
+const session = await joinSession({ canvases: [canvas] });
+
+// Give canvas action handlers access to the host's AI model via ctx.ai /
+// ctx.askAgent. This is the ONLY place the SDK is touched; keep canvas.mjs
+// SDK-free and just call ctx.ai(...) / ctx.askAgent(...) from a handler.
+runtime.setHost({
+  // ctx.ai(question) -> Promise<string>: a silent, no-tools model query that is
+  // NOT added to the conversation. It runs against the ambient conversation
+  // context, so write self-contained prompts ("You are X. Output ONLY ...").
+  ai: async (question) => {
+    const { answer } = await session.rpc.ui.ephemeralQuery({ question: String(question) });
+    return answer ?? "";
+  },
+  // ctx.askAgent(prompt): hand a prompt to the MAIN agent (visible in chat,
+  // tool-capable). Use for "act in the repo" requests, not silent generation.
+  askAgent: async (prompt) => session.send({ prompt: String(prompt) }),
+});

--- a/skills/create-canvas-app/scripts/new-canvas.mjs
+++ b/skills/create-canvas-app/scripts/new-canvas.mjs
@@ -96,7 +96,23 @@ const canvas = createCanvas({
   },
 });
 
-await joinSession({ canvases: [canvas] });
+const session = await joinSession({ canvases: [canvas] });
+
+// Give canvas action handlers access to the host's AI model via ctx.ai /
+// ctx.askAgent. This is the ONLY place the SDK is touched; keep canvas.mjs
+// SDK-free and just call ctx.ai(...) / ctx.askAgent(...) from a handler.
+runtime.setHost({
+  // ctx.ai(question) -> Promise<string>: a silent, no-tools model query that is
+  // NOT added to the conversation. It runs against the ambient conversation
+  // context, so write self-contained prompts ("You are X. Output ONLY ...").
+  ai: async (question) => {
+    const { answer } = await session.rpc.ui.ephemeralQuery({ question: String(question) });
+    return answer ?? "";
+  },
+  // ctx.askAgent(prompt): hand a prompt to the MAIN agent (visible in chat,
+  // tool-capable). Use for "act in the repo" requests, not silent generation.
+  askAgent: async (prompt) => session.send({ prompt: String(prompt) }),
+});
 `;
 
 const INDEX_HTML = `<!doctype html>

--- a/skills/create-canvas-app/test/generator.test.mjs
+++ b/skills/create-canvas-app/test/generator.test.mjs
@@ -130,6 +130,43 @@ async function main() {
     assert.match(src, /poll\b/); // mountCanvas accepts a poll option
   });
 
+  // ---- host-model capability (ai / askAgent) -------------------------------
+  await test("server.mjs stays SDK-free and exposes setHost", async () => {
+    const src = await read(join(ROOT, "kit", "server.mjs"));
+    assert.ok(!/@github\/copilot-sdk/.test(src), "server.mjs must not import the SDK");
+    assert.match(src, /function setHost/);
+  });
+
+  await test("runtime guards ai()/askAgent() until a host is wired, then forwards", async () => {
+    const { createCanvasRuntime } = await import("../kit/server.mjs");
+    const rt = createCanvasRuntime({
+      id: "t",
+      displayName: "T",
+      description: "t",
+      assetsDir: ROOT,
+      actions: {
+        sum: { handler: async ({ ai }) => ({ answer: await ai("q") }) },
+        act: { handler: async ({ askAgent }) => ({ r: await askAgent("p") }) },
+      },
+    });
+    assert.equal(typeof rt.setHost, "function");
+
+    // No host wired -> documented error codes (handlers reach the host model
+    // only when the canvas runs under the Copilot app, not in a plain test).
+    await assert.rejects(() => rt.invoke("sum", {}, {}), (e) => e.code === "ai_unavailable");
+    await assert.rejects(() => rt.invoke("act", {}, {}), (e) => e.code === "agent_unavailable");
+
+    // Wired -> the handler api forwards to the host stub.
+    const calls = [];
+    rt.setHost({
+      ai: async (qn) => { calls.push(["ai", qn]); return "ANSWER:" + qn; },
+      askAgent: async (pr) => { calls.push(["askAgent", pr]); return "SENT:" + pr; },
+    });
+    assert.equal((await rt.invoke("sum", {}, {})).answer, "ANSWER:q");
+    assert.equal((await rt.invoke("act", {}, {})).r, "SENT:p");
+    assert.deepEqual(calls, [["ai", "q"], ["askAgent", "p"]]);
+  });
+
   await test("theme.css ships loading/error primitives + reduced-motion guard", async () => {
     const css = await read(join(ROOT, "kit", "theme.css"));
     for (const cls of ["ck-spinner", "ck-skeleton", "ck-callout", "ck-error"]) {
@@ -232,6 +269,14 @@ async function main() {
       const app = await read(join(work, "gen-feed", "web", "app.mjs"));
       assert.match(app, /pollWhileVisible/);
       assert.match(app, /useEffect/);
+    });
+
+    await test("generated extension.mjs wires the host-model capabilities", async () => {
+      const ext = await read(join(work, "gen-list", "extension.mjs"));
+      assert.match(ext, /const session = await joinSession\(/);
+      assert.match(ext, /runtime\.setHost\(/);
+      assert.match(ext, /ephemeralQuery/);
+      assert.match(ext, /askAgent/);
     });
 
     await test("data smoke test exercises relativeTime against lastRefresh", async () => {


### PR DESCRIPTION
## What

Gives Copilot **canvas** action handlers access to the host's AI model — no API keys, no model picker, no external `fetch`. Two capabilities are injected into every handler's context:

- **`ctx.ai(question) → Promise<string>`** — a **silent** model query via the host's `ephemeralQuery`. No tools, and **not** added to the conversation history. The primitive for canvas-internal AI (summarize, suggest, rewrite, classify, extract).
- **`ctx.askAgent(prompt)`** — hand a prompt to the **main agent** (visible in chat, tool-capable). For "act in the repo" controls, not silent generation.

## How

- `kit/server.mjs` stays **SDK-free**: it exposes `setHost()` and guards `ai()` / `askAgent()` (throw `ai_unavailable` / `agent_unavailable` until wired). No SDK import, no new injection/eval surface — pure guarded forwarders.
- `extension.mjs` (the only SDK file) captures the joined session and wires `ai → session.rpc.ui.ephemeralQuery`, `askAgent → session.send`. Threaded through the generator template + the reference canvas.
- Rejected approach: an isolated `client.createSession()` from inside an extension **hangs** (the host doesn't service a child-created session), so the kit doesn't offer it. `ephemeralQuery` is the supported silent path and is inherently **no-tools** (safe by construction).

## Why it's safe

`ctx.ai` rides the host's `ephemeralQuery`, which runs with **no tools** and never mutates the conversation. The capability is just a guarded forwarder; there's no `eval`, no child-process spawn, no new attacker-reachable sink in the kit.

## Tests

- `node test/http.test.mjs`, `test/kit-parity.test.mjs`, `test/generator.test.mjs`, `test/tooling.test.mjs` — **all green**.
- Added generator assertions: `server.mjs` stays SDK-free + exposes `setHost`; `ai()/askAgent()` guard then forward; generated `extension.mjs` wires the capability.
- Validated end-to-end with a generated canvas: an `ai_suggest` action → `ctx.ai` → `ephemeralQuery` → host model returned a clean, on-topic result.

## Notes

- Documented in `SKILL.md` + `README.md`, including the context-bleed caveat (frame prompts as self-contained functions).
- Optional future ergonomic: a first-class `session.ephemeralQuery()` in `@github/copilot-sdk` so canvases don't reach into the `@experimental` `session.rpc.ui.ephemeralQuery` (no app change until the SDK is rebuilt/published).

Reviewed via `mq` (code-review + security-review): no findings against the kit changes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>