### PR TITLE
docs: describe skills as cross-agent; add version.mjs to kit layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # jongio/skills
 
-Jon Gallant's collection of [GitHub Copilot](https://docs.github.com/copilot)
-skills — a general-purpose monorepo. Each skill lives in its own folder under
-[`skills/`](skills/) with a `SKILL.md` authoring contract, and can be installed
-individually or all at once.
+Jon Gallant's collection of skills for AI coding agents — works with
+[GitHub Copilot](https://docs.github.com/copilot), Claude, Codex, and any agent
+that supports the [`SKILL.md`](https://github.com/vercel-labs/skills) format. A
+general-purpose monorepo: each skill lives in its own folder under
+[`skills/`](skills/) and can be installed individually or all at once.
 
 ## Skills
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jongio-skills",
-  "description": "Jon Gallant's collection of GitHub Copilot skills. Browse and install individual skills from the skills/ directory.",
+  "description": "Jon Gallant's collection of cross-agent skills for AI coding agents — GitHub Copilot, Claude, and Codex. Browse and install individual skills from the skills/ directory.",
   "version": "1.0.0",
   "author": {
     "name": "Jon Gallant",

--- a/skills/create-canvas-app/README.md
+++ b/skills/create-canvas-app/README.md
@@ -170,6 +170,7 @@ kit/                          The canonical kit — copy into your extension as 
   format.mjs                  nid + relativeTime / compactNumber / percent helpers
   theme.css                   Primer-token styling (ck-* classes)
   icons.mjs                   Lucide Icon component + helpers
+  version.mjs                 KIT_VERSION stamp — sync + freshness tooling
   vendor/                     Vendored Preact+htm and the Lucide glyph data
 reference/decision-log/       Complete working canvas in the real installed shape
 scripts/


### PR DESCRIPTION
## Summary
Reconciles the collection's description so it reflects reality: these skills work in any coding agent that supports the SKILL.md format (GitHub Copilot, Claude, Codex), not just Copilot. Also fills one gap in the kit layout listing.

## Changes
- `README.md`: reframe the intro from "GitHub Copilot skills" to cross-agent.
- `plugin.json`: align the `description` with the cross-agent framing.
- `skills/create-canvas-app/README.md`: add the missing `version.mjs` row to the kit layout.

## Notes
Found during a documentation audit. `marketplace.json` already described the collection as cross-agent, so this brings the other two in line. The `create-canvas-app` skill still builds Copilot-app canvases; only the collection-level framing changed. Docs-only, no code or behavior changes.