### PR TITLE
Link template gallery from create-gh-pages-site catalog page

### DIFF
--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -11,6 +11,7 @@ const skills = defineCollection({
     tagline: z.string(),
     useWhen: z.string(),
     repoPath: z.string(), // path within the repo, e.g. skills/create-canvas-app
+    gallery: z.string().url().optional(), // optional external gallery/demo link
     thumb: z.string(), // image under public/, base-relative (e.g. images/...)
     install: z.array(z.object({ label: z.string(), cmd: z.string() })),
     order: z.number().default(99),

--- a/site/src/content/skills/create-gh-pages-site.md
+++ b/site/src/content/skills/create-gh-pages-site.md
@@ -3,6 +3,7 @@ title: create-gh-pages-site
 tagline: "Scaffold a working GitHub Pages site from a vetted template (static, Astro, React + Vite, Eleventy, or Jekyll) — the correct base path, the official GitHub Actions deploy, and content authored from your repo."
 useWhen: "When you want to publish a static page, an Astro/Eleventy site, a React (Vite) SPA, or a Jekyll site to GitHub Pages — with the base path and deploy pipeline wired correctly."
 repoPath: skills/create-gh-pages-site
+gallery: https://jongio.github.io/gh-pages-templates/
 thumb: images/invoke-create-gh-pages-site.png
 order: 2
 install:

--- a/site/src/pages/catalog/[slug].astro
+++ b/site/src/pages/catalog/[slug].astro
@@ -21,8 +21,11 @@ const repoUrl = `https://github.com/jongio/skills/tree/main/${skill.data.repoPat
     <h1>{skill.data.title}</h1>
     <p class="muted lede">{skill.data.tagline}</p>
     <p class="usewhen"><strong>Use when:</strong> {skill.data.useWhen}</p>
-    <p>
+    <p class="actions">
       <a class="btn" href={repoUrl}>Source &amp; README</a>
+      {skill.data.gallery && (
+        <a class="btn" href={skill.data.gallery}>Template gallery</a>
+      )}
     </p>
   </header>
 
@@ -46,6 +49,7 @@ const repoUrl = `https://github.com/jongio/skills/tree/main/${skill.data.repoPat
 
 <style>
   .skill-head { margin-bottom: 1.5rem; }
+  .actions { display: flex; flex-wrap: wrap; gap: 0.6rem; }
   .skill-hero {
     width: 100%; aspect-ratio: 16 / 9; object-fit: contain;
     border: 1px solid var(--border); border-radius: var(--radius);


### PR DESCRIPTION
The create-gh-pages-site skill scaffolds from a registry of templates that has a live gallery with previews at https://jongio.github.io/gh-pages-templates/, but the skill's catalog page on the site never linked to it. This surfaces that gallery so visitors can browse the templates before installing.

## Approach

- Added an optional `gallery` URL field to the skills content schema (`site/src/content.config.ts`). It's optional, so existing skills like create-canvas-app are unaffected.
- On the catalog detail page (`site/src/pages/catalog/[slug].astro`), render a **Template gallery** button next to **Source & README** only when a skill defines `gallery`. The two buttons now sit in a flex `.actions` row so they space cleanly and wrap on narrow screens.
- Set `gallery: https://jongio.github.io/gh-pages-templates/` on create-gh-pages-site's content entry, matching the canonical URL already used in that skill's README.

## Verification

Ran `astro build` (passes) and confirmed the generated `catalog/create-gh-pages-site/index.html` contains the button linking to the gallery, while the create-canvas-app page is unchanged.