### PR TITLE
feat: complete and document the canvas-kit host-AI API

### DIFF
--- a/site/src/content/skills/create-canvas-app.md
+++ b/site/src/content/skills/create-canvas-app.md
@@ -23,6 +23,8 @@ canvas needs already wired:
 - **Durable per-user storage** — state survives reloads and sessions.
 - **Primer theming** — matches GitHub light/dark out of the box.
 - **Official GitHub Lucide icons** — the same icon set the product uses.
+- **Host AI, no API keys** — call the Copilot app's own model from an action with
+  `ctx.ai(…)` (silent generation) or hand work to the main agent with `ctx.askAgent(…)`.
 - **A generator** that stamps a working canvas in one command, plus tests.
 
 ## When to reach for it

--- a/skills/create-canvas-app/README.md
+++ b/skills/create-canvas-app/README.md
@@ -52,7 +52,8 @@ to your request, and validates it visually before handing it back.
   `ctx.ai(question)` (silent, no keys, no history) or hand work to the main agent
   with `ctx.askAgent(prompt)`. No API keys, no model picker, no external `fetch`.
 - **A generator** — `node scripts/new-canvas.mjs <name>` stamps a working canvas
-  (add `--template data` for a fetch + auto-refresh canvas) with its own smoke test.
+  (`--template data` for a fetch + auto-refresh canvas, `--template ai` for a
+  host-AI canvas) with its own smoke test.
 - **Tests** — a standalone HTTP harness, a kit byte-parity check, a generator test, a
   kit-sync/freshness tooling check, and a Lucide re-vendor determinism test.
 
@@ -128,6 +129,9 @@ node scripts/new-canvas.mjs my-board --title "My Board" --dir .github/extensions
 
 # An external-data canvas (fetch + refresh + visibility-gated auto-refresh):
 node scripts/new-canvas.mjs market-feed --template data --dir .github/extensions/market-feed
+
+# A host-AI canvas (silent ctx.ai generation + ctx.askAgent handoff):
+node scripts/new-canvas.mjs ai-helper --template ai --dir .github/extensions/ai-helper
 ```
 
 Reload extensions, then open the canvas (`canvasId: "my-board"`). It works out of
@@ -174,8 +178,9 @@ kit/                          The canonical kit — copy into your extension as 
   version.mjs                 KIT_VERSION stamp — sync + freshness tooling
   vendor/                     Vendored Preact+htm and the Lucide glyph data
 reference/decision-log/       Complete working canvas in the real installed shape
+                              (CRUD + host AI: summarize via ctx.ai, hand-off via ctx.askAgent)
 scripts/
-  new-canvas.mjs              Generator — stamp a new canvas (--template list|data)
+  new-canvas.mjs              Generator — stamp a new canvas (--template list|data|ai)
   sync-kit.mjs                Copy kit/ into an extension as canvas-kit/ + stamp the version
   check-kit-freshness.mjs     Offline drift gate — fail if a vendored kit copy is stale
   vendor-lucide.mjs           Rebuild kit/vendor/lucide.mjs from a pinned lucide-react release
@@ -183,7 +188,7 @@ scripts/
 test/
   http.test.mjs               Boots the runtime over real HTTP and checks the contract
   kit-parity.test.mjs         Asserts kit/ == reference canvas-kit/ (no drift)
-  generator.test.mjs          Stamps both templates, runs their smoke tests, checks the kit API
+  generator.test.mjs          Stamps the list/data/ai templates, runs their smoke tests, checks the kit API
   tooling.test.mjs            Exercises the version stamp, sync-kit, and the freshness drift gate
   vendor-lucide.test.mjs      Checks the Lucide vendoring generator (sorting, key-strip, determinism)
 ```

--- a/skills/create-canvas-app/SKILL.md
+++ b/skills/create-canvas-app/SKILL.md
@@ -283,6 +283,10 @@ kit does not offer it. `ai` (ephemeralQuery) is the supported silent path.
 - Don't block the panel on a slow `ai()` — `await` it in the handler, write the
   result into state, and let SSE push the update, exactly like the data-fetch shape.
 
+Stamp this whole shape — an `ask_ai` handler (silent `ctx.ai`), a `hand_to_agent`
+handler (`ctx.askAgent`), model errors captured into state, and an offline smoke
+test that wires a stub host — with `node scripts/new-canvas.mjs <name> --template ai`.
+
 ## Domain strategy — shared board vs personal profile
 
 State is keyed by the domain id `resolveDomainId` returns. Two intents, identical
@@ -339,7 +343,9 @@ who shares what.
    throwaway canvas scoped to just the current session — it's discovered like the
    others (its `extensionId` is `session:<sessionId>:<name>`) and disappears when
    the session does. Add `--template data` for an external-data canvas (fetch +
-   `refresh` + visibility-gated polling) instead of the default user-entered list.
+   `refresh` + visibility-gated polling), or `--template ai` for a host-AI canvas
+   (`ctx.ai` silent generation + `ctx.askAgent` handoff), instead of the default
+   user-entered list.
 2. **Reload + open.** Run `extensions_reload`, then `open_canvas` with
    `canvasId: "<name>"`. The list canvas works immediately.
 3. **Shape your data.** In `canvas.mjs`, edit `createInitialState`, the action
@@ -415,14 +421,18 @@ A canvas isn't done because the server boots. Verify the UI:
 ## Reference + tests (study these)
 
 - `reference/decision-log/` — a complete, working canvas in the exact installed
-  shape (kit nested as `canvas-kit/`). Best example of every contract above.
+  shape (kit nested as `canvas-kit/`). Best example of every contract above —
+  including the host model: a `summarize` action (silent `ctx.ai`) and a
+  `hand_to_agent` action (`ctx.askAgent`), each capturing model errors into state.
 - `kit/` — the canonical kit you copy in. Source of truth.
 - `test/http.test.mjs` — boots the SDK-free runtime over real HTTP and checks
-  `/state`, `/events`, `/action`, static serving, and path-traversal safety.
+  `/state`, `/events`, `/action`, static serving, path-traversal safety, and the
+  host-model actions (offline-error capture + a wired-host stub).
 - `test/kit-parity.test.mjs` — guarantees `kit/` and the reference's bundled
   `canvas-kit/` stay byte-identical.
-- `test/generator.test.mjs` — stamps both templates, runs their smoke tests, and
-  checks the kit API surface (format helpers, poll helper, theme primitives).
+- `test/generator.test.mjs` — stamps the list, data, and ai templates, runs their
+  smoke tests, and checks the kit API surface (format helpers, poll helper, theme
+  primitives, host-model wiring).
 - `test/tooling.test.mjs` — exercises the version stamp (`kit/version.mjs`),
   `scripts/sync-kit.mjs`, and the offline `scripts/check-kit-freshness.mjs` drift gate.
 - `test/vendor-lucide.test.mjs` — checks the Lucide vendoring generator

--- a/skills/create-canvas-app/reference/decision-log/canvas.mjs
+++ b/skills/create-canvas-app/reference/decision-log/canvas.mjs
@@ -42,6 +42,10 @@ export const canvasConfig = {
   createInitialState: (ctx) => ({
     domain: ctx?.input?.domain ?? "default",
     decisions: [],
+    summary: "",
+    summaryAt: null,
+    summaryError: null,
+    agentError: null,
   }),
 
   loadState: async (domainId) => fileFor(domainId).load(null),
@@ -165,6 +169,97 @@ export const canvasConfig = {
           .map((d) => `- [${d.status}] ${d.title}${d.note ? ` — ${d.note}` : ""}`)
           .join("\n");
         return { count: items.length, summary };
+      },
+    },
+
+    // ---- host-model actions --------------------------------------------------
+    // The two capabilities below reach the COPILOT APP'S OWN model — the same
+    // model + auth the app is already running — with no API keys and no external
+    // fetch. They arrive on the handler context (`ai` / `askAgent`), wired once in
+    // extension.mjs (the only SDK file). Both are guarded: outside the Copilot
+    // host they throw, so each handler CAPTURES the failure into shared state and
+    // returns a result instead of throwing, letting the panel degrade gracefully.
+
+    summarize: {
+      description:
+        "Summarize the log with the host AI model (silent — not added to chat history) and store the result on the canvas.",
+      inputSchema: { type: "object", properties: {}, additionalProperties: false },
+      // `ai(question) -> Promise<string>` is the SILENT host-model call: no tools,
+      // not added to the conversation. It runs against the ambient conversation
+      // context, so the prompt is framed as a self-contained function with a
+      // pinned output shape to keep the live chat from bleeding into the answer.
+      handler: async ({ state, set, ai }) => {
+        if (!state.decisions.length) {
+          set({ ...state, summary: "", summaryAt: new Date().toISOString(), summaryError: null });
+          return { summary: "", count: 0 };
+        }
+        const log = state.decisions
+          .map((d) => `- [${d.status}] ${d.title}${d.note ? ` — ${d.note}` : ""}`)
+          .join("\n");
+        try {
+          const summary = (await ai(
+            `You are summarizing a shared decision log for a software team. From the ` +
+            `entries below, write a 1–2 sentence plain-text summary that highlights what ` +
+            `is still open and the recommended next step. Output ONLY the summary — no ` +
+            `preamble, no markdown, no surrounding quotes.\n\nDecisions:\n${log}`
+          )).trim();
+          // Functional set() merges into the LATEST state — a concurrent action
+          // (add/remove) may have run while the model call was in flight.
+          set((current) => ({
+            ...current,
+            summary,
+            summaryAt: new Date().toISOString(),
+            summaryError: null,
+          }));
+          return { summary, count: state.decisions.length };
+        } catch (err) {
+          // ai() throws (e.g. "ai_unavailable") when the canvas runs outside the
+          // Copilot host. Capture it so the panel shows a friendly message, and
+          // return (don't throw) so an agent-side call still gets a clean result.
+          const summaryError = String(err?.message ?? err);
+          set((current) => ({ ...current, summaryError }));
+          return { ok: false, error: summaryError };
+        }
+      },
+    },
+
+    hand_to_agent: {
+      description:
+        "Hand a decision to the MAIN agent (visible in chat, tool-capable) to act on or research it. Use for follow-up work, not silent text.",
+      inputSchema: {
+        type: "object",
+        properties: { id: { type: "string", description: "The decision to hand off." } },
+        required: ["id"],
+        additionalProperties: false,
+      },
+      // `askAgent(prompt)` hands a prompt to the MAIN agent in the user's chat —
+      // VISIBLE and TOOL-CAPABLE. Use it for "act in the repo / drive the agent"
+      // controls; use `ai` (above) for silent canvas-internal generation.
+      handler: async ({ state, set, input, askAgent }) => {
+        const decision = state.decisions.find((d) => d.id === input.id);
+        if (!decision) throw new Error(`No decision with id ${input.id}`);
+        const prompt =
+          `From a decision log, please act on this decision (research it, draft an ` +
+          `approach, or implement it as appropriate):\n\n` +
+          `Title: ${decision.title}\nStatus: ${decision.status}` +
+          (decision.note ? `\nNote: ${decision.note}` : "");
+        try {
+          await askAgent(prompt);
+          const now = new Date().toISOString();
+          // Write-back into the item so the UI can reflect that it was handed off.
+          set((current) => ({
+            ...current,
+            agentError: null,
+            decisions: current.decisions.map((d) =>
+              d.id === input.id ? { ...d, handedToAgentAt: now, updatedAt: now } : d
+            ),
+          }));
+          return { ok: true, status: `Handed “${decision.title}” to the agent` };
+        } catch (err) {
+          const agentError = String(err?.message ?? err);
+          set((current) => ({ ...current, agentError }));
+          return { ok: false, error: agentError };
+        }
       },
     },
   },

--- a/skills/create-canvas-app/reference/decision-log/web/app.mjs
+++ b/skills/create-canvas-app/reference/decision-log/web/app.mjs
@@ -73,6 +73,14 @@ function NewDecision({ invoke }) {
 
 function DecisionItem({ d, invoke }) {
   const others = ["open", "decided", "parked"].filter((s) => s !== d.status);
+  const [handing, setHanding] = useState(false);
+
+  async function handToAgent() {
+    if (handing) return;
+    setHanding(true);
+    try { await invoke("hand_to_agent", { id: d.id }); } finally { setHanding(false); }
+  }
+
   return html`
     <div class="ck-card">
       <div class="ck-spread">
@@ -83,7 +91,9 @@ function DecisionItem({ d, invoke }) {
         ? html`<div class="dl-item-note ck-muted">${d.note}</div>`
         : null}
       ${d.updatedAt
-        ? html`<div class="ck-caption" style="margin-top:6px">updated ${relativeTime(d.updatedAt)}</div>`
+        ? html`<div class="ck-caption" style="margin-top:6px">
+            updated ${relativeTime(d.updatedAt)}${d.handedToAgentAt ? " · handed to agent" : ""}
+          </div>`
         : null}
       <div class="ck-row dl-actions" style="margin-top:10px">
         ${others.map(
@@ -96,6 +106,9 @@ function DecisionItem({ d, invoke }) {
             </button>
           `
         )}
+        <button class="ck-btn ck-btn-sm" disabled=${handing} onClick=${handToAgent} title="Hand this decision to the main agent">
+          <${Icon} name=${handing ? "loader-circle" : "send"} size=${14} class=${handing ? "ck-spinner" : ""} />Hand to agent
+        </button>
         <span class="ck-grow"></span>
         <button
           class="ck-btn ck-btn-sm ck-btn-danger"
@@ -104,6 +117,54 @@ function DecisionItem({ d, invoke }) {
           <${Icon} name="trash-2" size=${14} />Delete
         </button>
       </div>
+    </div>
+  `;
+}
+
+// Host-AI summary panel. The model call lives in the "summarize" handler
+// (canvas.mjs) — this only TRIGGERS it and renders the derived state it writes
+// back (state.summary / state.summaryError), exactly like any shared field.
+function Summary({ state, invoke }) {
+  const [busy, setBusy] = useState(false);
+  const hasDecisions = (state.decisions ?? []).length > 0;
+
+  async function run() {
+    if (busy) return;
+    setBusy(true);
+    try { await invoke("summarize"); } finally { setBusy(false); }
+  }
+
+  return html`
+    <div class="ck-card dl-summary ck-col">
+      <div class="ck-spread">
+        <div class="ck-row" style="gap:6px">
+          <${Icon} name="sparkles" size=${16} />
+          <span class="dl-item-title">AI summary</span>
+        </div>
+        <button
+          class="ck-btn ck-btn-sm"
+          disabled=${busy || !hasDecisions}
+          onClick=${run}
+          title=${hasDecisions ? "Summarize with the host model" : "Add a decision first"}
+        >
+          <${Icon} name=${busy ? "loader-circle" : "sparkles"} size=${14} class=${busy ? "ck-spinner" : ""} />
+          ${busy ? "Summarizing…" : "Summarize"}
+        </button>
+      </div>
+      ${state.summaryError
+        ? html`<div class="ck-callout ck-error" style="margin-top:10px">
+            <${Icon} name="circle-x" size=${16} /><span>${state.summaryError}</span>
+          </div>`
+        : state.summary
+          ? html`<div style="margin-top:8px">
+              <div style="white-space:pre-wrap">${state.summary}</div>
+              ${state.summaryAt
+                ? html`<div class="ck-caption" style="margin-top:6px">summarized ${relativeTime(state.summaryAt)}</div>`
+                : null}
+            </div>`
+          : html`<div class="ck-muted" style="margin-top:8px">
+              ${hasDecisions ? "Summarize the log into a one-line recommendation." : "No decisions to summarize yet."}
+            </div>`}
     </div>
   `;
 }
@@ -130,6 +191,14 @@ function App({ state, invoke, connected }) {
       </div>
 
       <${NewDecision} invoke=${invoke} />
+
+      <${Summary} state=${state} invoke=${invoke} />
+
+      ${state.agentError
+        ? html`<div class="ck-callout ck-error" style="margin-bottom:10px">
+            <${Icon} name="circle-x" size=${16} /><span>${state.agentError}</span>
+          </div>`
+        : null}
 
       <div class="ck-spread" style="margin-bottom:10px">
         <div class="ck-tabs" role="tablist">

--- a/skills/create-canvas-app/reference/decision-log/web/index.html
+++ b/skills/create-canvas-app/reference/decision-log/web/index.html
@@ -8,6 +8,7 @@
     <style>
       .dl-head { margin-bottom: 14px; }
       .dl-add { margin: 12px 0 16px; }
+      .dl-summary { margin: 0 0 16px; }
       .dl-list { display: flex; flex-direction: column; gap: 10px; }
       .dl-item-title { font-weight: var(--ck-fw-semibold); }
       .dl-item-note { margin-top: 6px; }

--- a/skills/create-canvas-app/scripts/new-canvas.mjs
+++ b/skills/create-canvas-app/scripts/new-canvas.mjs
@@ -1,17 +1,21 @@
 // scripts/new-canvas.mjs — stamp a new, working canvas extension from the kit.
 //
 // Copies the canonical kit/ into <target>/canvas-kit/ and writes a minimal but
-// fully working canvas plus a per-canvas smoke test. Two templates:
+// fully working canvas plus a per-canvas smoke test. Three templates:
 //
 //   list (default)  one shared list (add/toggle/remove), Preact + htm, SSE live
 //                   state, durable per-user storage. Edit from there.
 //   data            an EXTERNAL-DATA canvas: fetch-in-handler (with a timeout),
 //                   a `refresh` action, captured error state, and visibility-
 //                   gated auto-refresh via the kit's pollWhileVisible helper.
+//   ai              a HOST-AI canvas: calls the Copilot app's own model from an
+//                   action with `ctx.ai(...)` (silent, no keys, no history) and
+//                   hands prompts to the main agent with `ctx.askAgent(...)`.
+//                   Model errors are captured into state and surfaced in the panel.
 //
 // Usage:
 //   node scripts/new-canvas.mjs <name> [--dir <path>] [--title "Display Name"]
-//                                       [--description "..."] [--template list|data]
+//                                       [--description "..."] [--template list|data|ai]
 //                                       [--force]
 //
 // Examples:
@@ -136,7 +140,7 @@ const MANIFEST = `{
 }
 `;
 
-// Per-canvas README — stamped for every generated canvas (both templates) so the
+// Per-canvas README — stamped for every generated canvas (all templates) so the
 // folder is self-documenting once copied into an extensions dir.
 const README_MD = `# {{titleText}}
 
@@ -189,6 +193,11 @@ const TEMPLATE_NOTES = {
     "an action handler (always with `AbortSignal.timeout`), captures failures into " +
     "state, and auto-refreshes on a visibility-gated timer via the kit's " +
     "`pollWhileVisible` helper.",
+  ai: "This is a **host-AI** canvas: it calls the Copilot app's own model from an " +
+    "action handler with `ctx.ai(...)` (silent, no API keys, not added to chat " +
+    "history) and can hand a prompt to the main agent with `ctx.askAgent(...)`. " +
+    "Model errors (e.g. running outside the Copilot host) are captured into state " +
+    "and surfaced in the panel.",
 };
 
 // ---- template: list (default) ----------------------------------------------
@@ -721,6 +730,285 @@ function App({ state, invoke, connected }) {
 mountCanvas({ view: (model) => html\`<\${App} ...\${model} />\` });
 `;
 
+// ---- template: ai (host model / agent handoff) -----------------------------
+
+const AI_CANVAS_MJS = `// canvas.mjs — {{titleText}} canvas definition (ai template; kit config; SDK-free).
+//
+// A HOST-AI canvas: action handlers call the COPILOT APP'S OWN model — the same
+// model + auth the app is already running — with no API keys, no model picker,
+// and no external fetch. Two capabilities arrive on the handler context,
+// wired once in extension.mjs (the only SDK file) and exposed by the kit:
+//
+//   * ctx.ai(question) -> Promise<string>  a SILENT, no-tools model query that is
+//       NOT added to the conversation. Use it for canvas-internal generation
+//       (summarize / suggest / rewrite / classify). It runs against the ambient
+//       conversation context, so frame prompts as self-contained functions and
+//       pin the output shape ("Output ONLY ...").
+//   * ctx.askAgent(prompt) -> Promise<unknown>  hand a prompt to the MAIN agent
+//       in the user's chat. It is VISIBLE in chat and TOOL-CAPABLE — use it for
+//       "act in the repo / drive the agent" controls, not silent text.
+//
+// ctx.ai() / ctx.askAgent() throw when the canvas runs OUTSIDE the Copilot host
+// (e.g. a standalone smoke test); this canvas captures that into state.error so
+// the panel degrades gracefully instead of dead-ending on a thrown action.
+
+import { fileURLToPath } from "node:url";
+import { userStore } from "./canvas-kit/storage.mjs";
+import { nid } from "./canvas-kit/format.mjs";
+
+const EXT_NAME = "{{name}}";
+
+function fileFor(domainId) {
+  const safe = String(domainId).replace(/[^A-Za-z0-9._-]/g, "_") || "default";
+  return userStore(EXT_NAME, \`\${safe}.json\`);
+}
+
+export const canvasConfig = {
+  id: "{{name}}",
+  displayName: {{titleJs}},
+  description: {{descriptionJs}},
+  assetsDir: fileURLToPath(new URL("./web/", import.meta.url)),
+
+  inputSchema: {
+    type: "object",
+    properties: {
+      domain: { type: "string", description: "Logical board to open. Omit for the default." },
+    },
+    additionalProperties: false,
+  },
+
+  resolveDomainId: (input) => (input?.domain ? String(input.domain) : "default"),
+  createInitialState: () => ({ entries: [], error: null }),
+  loadState: async (domainId) => fileFor(domainId).load(null),
+  saveState: async (domainId, state) => fileFor(domainId).save(state),
+  statusLine: (_ctx, state) => \`\${state.entries.length} entries\`,
+
+  actions: {
+    ask_ai: {
+      description: "Ask the host AI model a question silently (no tools, not added to chat history) and record the answer.",
+      inputSchema: {
+        type: "object",
+        properties: { prompt: { type: "string", description: "What to ask the model." } },
+        required: ["prompt"],
+        additionalProperties: false,
+      },
+      // The "ai" capability destructured off the handler context is the silent
+      // host-model call. Frame the prompt as a self-contained function so the live
+      // chat can't bleed into the answer, and pin the output shape.
+      handler: async ({ set, input, ai }) => {
+        const prompt = String(input.prompt ?? "").trim();
+        if (!prompt) throw new Error("prompt is required");
+        try {
+          const answer = (await ai(
+            \`You are a concise assistant embedded in a side-panel canvas. \` +
+            \`Answer the request directly in plain text. Output ONLY the answer — \` +
+            \`no preamble, no markdown headings, no surrounding quotes. Request: \${prompt}\`
+          )).trim();
+          const entry = { id: nid(), kind: "ai", prompt, answer, createdAt: new Date().toISOString() };
+          // Functional set() merges into the LATEST state — a concurrent action
+          // may have run while the model call was in flight.
+          set((current) => ({ ...current, error: null, entries: [entry, ...current.entries] }));
+          return { id: entry.id, answer };
+        } catch (err) {
+          // ai() throws "ai_unavailable" outside the Copilot host. Capture it into
+          // shared state so the panel shows a friendly message, and return (don't
+          // throw) so an agent-side call still gets a clean result.
+          const error = String(err?.message ?? err);
+          set((current) => ({ ...current, error }));
+          return { ok: false, error };
+        }
+      },
+    },
+
+    hand_to_agent: {
+      description: "Hand a prompt to the MAIN agent (visible in chat, tool-capable). Use for 'act in the repo' requests, not silent generation.",
+      inputSchema: {
+        type: "object",
+        properties: { prompt: { type: "string", description: "Instruction for the main agent." } },
+        required: ["prompt"],
+        additionalProperties: false,
+      },
+      handler: async ({ set, input, askAgent }) => {
+        const prompt = String(input.prompt ?? "").trim();
+        if (!prompt) throw new Error("prompt is required");
+        try {
+          await askAgent(prompt);
+          const entry = {
+            id: nid(),
+            kind: "agent",
+            prompt,
+            answer: "Handed to the agent — watch the conversation.",
+            createdAt: new Date().toISOString(),
+          };
+          set((current) => ({ ...current, error: null, entries: [entry, ...current.entries] }));
+          return { id: entry.id, ok: true };
+        } catch (err) {
+          const error = String(err?.message ?? err);
+          set((current) => ({ ...current, error }));
+          return { ok: false, error };
+        }
+      },
+    },
+
+    remove_entry: {
+      description: "Delete an entry from the log.",
+      inputSchema: {
+        type: "object",
+        properties: { id: { type: "string" } },
+        required: ["id"],
+        additionalProperties: false,
+      },
+      handler: ({ state, set, input }) => {
+        const entries = state.entries.filter((e) => e.id !== input.id);
+        set({ ...state, entries });
+        return { removed: state.entries.length - entries.length };
+      },
+    },
+
+    clear: {
+      description: "Clear the whole log.",
+      inputSchema: { type: "object", properties: {}, additionalProperties: false },
+      handler: ({ state, set }) => {
+        set({ ...state, entries: [], error: null });
+        return { ok: true };
+      },
+    },
+
+    list_entries: {
+      description: "Return a text summary of the log (for the agent).",
+      inputSchema: { type: "object", properties: {}, additionalProperties: false },
+      handler: ({ state }) => {
+        if (!state.entries.length) return { summary: "No entries yet.", count: 0 };
+        const summary = state.entries
+          .map((e) => \`- (\${e.kind}) \${e.prompt} -> \${e.answer}\`)
+          .join("\\n");
+        return { count: state.entries.length, summary };
+      },
+    },
+  },
+};
+`;
+
+const AI_APP_MJS = `// web/app.mjs — Preact view for the {{titleText}} ai canvas.
+//
+// The MODEL call never happens here — it lives in the "ask_ai" / "hand_to_agent"
+// action handlers (canvas.mjs), which reach the host model. The view only
+// TRIGGERS those actions and renders the shared log that arrives over /events.
+// LOCAL UI state (the draft prompt, the busy flag) lives in useState.
+
+import { html, mountCanvas, useState, Icon } from "/kit/client.mjs";
+
+const TITLE = {{titleJs}};
+
+function Composer({ invoke }) {
+  const [prompt, setPrompt] = useState("");
+  const [busy, setBusy] = useState(null); // "ai" | "agent" | null
+
+  async function run(action) {
+    const p = prompt.trim();
+    if (!p || busy) return;
+    setBusy(action === "ask_ai" ? "ai" : "agent");
+    try {
+      await invoke(action, { prompt: p });
+      setPrompt("");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return html\`
+    <div class="ck-card ck-col" style="margin:12px 0 16px">
+      <textarea
+        class="ck-textarea"
+        placeholder="Ask the model anything…"
+        value=\${prompt}
+        onInput=\${(e) => setPrompt(e.target.value)}
+        onKeyDown=\${(e) => { if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) run("ask_ai"); }}
+      ></textarea>
+      <div class="ck-row">
+        <button
+          class="ck-btn ck-btn-primary"
+          disabled=\${!prompt.trim() || !!busy}
+          onClick=\${() => run("ask_ai")}
+        >
+          <\${Icon} name=\${busy === "ai" ? "loader-circle" : "sparkles"} size=\${16} class=\${busy === "ai" ? "ck-spinner" : ""} />
+          \${busy === "ai" ? "Asking…" : "Ask AI"}
+        </button>
+        <button
+          class="ck-btn"
+          disabled=\${!prompt.trim() || !!busy}
+          onClick=\${() => run("hand_to_agent")}
+        >
+          <\${Icon} name=\${busy === "agent" ? "loader-circle" : "send"} size=\${16} class=\${busy === "agent" ? "ck-spinner" : ""} />
+          \${busy === "agent" ? "Sending…" : "Hand to agent"}
+        </button>
+      </div>
+      <span class="ck-caption">Cmd/Ctrl + Enter asks the AI silently. "Hand to agent" drives the main chat.</span>
+    </div>
+  \`;
+}
+
+function Entry({ entry, invoke }) {
+  const isAgent = entry.kind === "agent";
+  return html\`
+    <div class="ck-card ck-col" style="gap:8px">
+      <div class="ck-spread">
+        <span class=\${\`ck-badge \${isAgent ? "ck-badge-accent" : "ck-badge-success"}\`}>
+          <\${Icon} name=\${isAgent ? "send" : "sparkles"} size=\${12} />
+          \${isAgent ? "agent" : "ai"}
+        </span>
+        <button class="ck-btn ck-btn-sm ck-btn-danger" onClick=\${() => invoke("remove_entry", { id: entry.id })}>
+          <\${Icon} name="trash-2" size=\${14} />
+        </button>
+      </div>
+      <div style="font-weight:var(--ck-fw-semibold)">\${entry.prompt}</div>
+      <div class="ck-muted" style="white-space:pre-wrap">\${entry.answer}</div>
+    </div>
+  \`;
+}
+
+function App({ state, invoke, connected }) {
+  if (!state) return html\`<p class="ck-muted">Loading…</p>\`;
+  const entries = state.entries ?? [];
+
+  return html\`
+    <div>
+      <div class="ck-spread" style="margin-bottom:14px">
+        <div class="ck-row" style="gap:8px">
+          <\${Icon} name="wand-sparkles" size=\${20} />
+          <h1 style="margin:0">\${TITLE}</h1>
+        </div>
+        <span class="ck-status">
+          <span class=\${\`ck-dot \${connected ? "ck-dot-live" : "ck-dot-off"}\`}></span>
+          \${connected ? "live" : "reconnecting…"}
+        </span>
+      </div>
+
+      <\${Composer} invoke=\${invoke} />
+
+      \${state.error
+        ? html\`<div class="ck-callout ck-error" style="margin-bottom:12px">
+            <\${Icon} name="circle-x" size=\${16} /><span>\${state.error}</span>
+          </div>\`
+        : null}
+
+      <div class="ck-spread ck-caption" style="margin-bottom:8px">
+        <span>\${entries.length} entr\${entries.length === 1 ? "y" : "ies"}</span>
+        \${entries.length ? html\`<button class="ck-btn ck-btn-sm" onClick=\${() => invoke("clear")}>Clear</button>\` : null}
+      </div>
+
+      <div class="ck-col" style="gap:10px">
+        \${entries.length
+          ? entries.map((e) => html\`<\${Entry} key=\${e.id} entry=\${e} invoke=\${invoke} />\`)
+          : html\`<div class="ck-empty"><\${Icon} name="messages-square" size=\${20} />Ask the model to get started.</div>\`}
+      </div>
+    </div>
+  \`;
+}
+
+mountCanvas({ view: (model) => html\`<\${App} ...\${model} />\` });
+`;
+
 // ---- per-canvas smoke test -------------------------------------------------
 
 // Wrap template-specific test calls in a shared harness that boots the runtime
@@ -851,9 +1139,73 @@ const DATA_SMOKE_BODY = `  await test("GET /state has the initial data shape", a
     assert.equal(s.error, null);
   });`;
 
+const AI_SMOKE_BODY = `  await test("GET /state starts empty", async () => {
+    const s = await getState(open.url);
+    assert.deepEqual(s.entries, []);
+    assert.equal(s.error, null);
+  });
+
+  await test("ask_ai with no host wired captures a friendly error (offline)", async () => {
+    // No host is wired yet (a standalone smoke test never runs under the Copilot
+    // app), so ai() throws "ai_unavailable" and the handler captures it to state.
+    const { body } = await post(open.url, "ask_ai", { prompt: "hello" });
+    assert.equal(body.ok, true); // POST envelope ok; the result carries the error
+    assert.equal(body.result.ok, false);
+    assert.match(body.result.error, /unavailable/i);
+    const s = await getState(open.url);
+    assert.ok(s.error, "ai_unavailable should be captured into state.error");
+    assert.deepEqual(s.entries, [], "no entry is recorded when the model is unavailable");
+  });
+
+  // Wire a STUB host so the rest runs offline + deterministic. This mirrors what
+  // extension.mjs does with the real Copilot model: ai -> ephemeralQuery (silent),
+  // askAgent -> a main-conversation message.
+  const sentToAgent = [];
+  runtime.setHost({
+    ai: async (q) => "ECHO:" + q,
+    askAgent: async (p) => { sentToAgent.push(p); return "queued"; },
+  });
+
+  let aiId;
+  await test("ask_ai records the model's answer once a host is wired", async () => {
+    const { body } = await post(open.url, "ask_ai", { prompt: "ping" });
+    aiId = body.result.id;
+    assert.ok(aiId);
+    assert.match(body.result.answer, /ECHO:/);
+    const s = await getState(open.url);
+    assert.equal(s.entries.length, 1);
+    assert.equal(s.entries[0].kind, "ai");
+    assert.equal(s.error, null, "a successful call clears the prior error");
+  });
+
+  await test("hand_to_agent forwards the prompt to the main agent", async () => {
+    const { body } = await post(open.url, "hand_to_agent", { prompt: "do the thing" });
+    assert.equal(body.result.ok, true);
+    assert.deepEqual(sentToAgent, ["do the thing"]);
+    const s = await getState(open.url);
+    assert.equal(s.entries.length, 2);
+    assert.equal(s.entries[0].kind, "agent");
+  });
+
+  await test("list_entries summarizes for the agent", async () => {
+    const { body } = await post(open.url, "list_entries", {});
+    assert.equal(body.result.count, 2);
+  });
+
+  await test("remove_entry + clear empty the log", async () => {
+    await post(open.url, "remove_entry", { id: aiId });
+    let s = await getState(open.url);
+    assert.equal(s.entries.length, 1);
+    await post(open.url, "clear", {});
+    s = await getState(open.url);
+    assert.deepEqual(s.entries, []);
+    assert.equal(s.error, null);
+  });`;
+
 const TEMPLATES = {
   list: { canvas: LIST_CANVAS_MJS, app: LIST_APP_MJS, smokeBody: LIST_SMOKE_BODY },
   data: { canvas: DATA_CANVAS_MJS, app: DATA_APP_MJS, smokeBody: DATA_SMOKE_BODY },
+  ai: { canvas: AI_CANVAS_MJS, app: AI_APP_MJS, smokeBody: AI_SMOKE_BODY },
 };
 
 async function isNonEmptyDir(dir) {
@@ -871,7 +1223,7 @@ async function main() {
 
   if (!name || !/^[a-z][a-z0-9-]*$/.test(name)) {
     console.error(
-      "Usage: node scripts/new-canvas.mjs <name> [--dir <path>] [--title \"...\"] [--description \"...\"] [--template list|data] [--force]\n" +
+      "Usage: node scripts/new-canvas.mjs <name> [--dir <path>] [--title \"...\"] [--description \"...\"] [--template list|data|ai] [--force]\n" +
         "  <name> must be kebab-case: start with a letter, then lowercase letters, digits, or hyphens."
     );
     process.exit(1);
@@ -879,7 +1231,7 @@ async function main() {
 
   const template = args.template || "list";
   if (!TEMPLATES[template]) {
-    console.error(`Unknown --template "${template}". Use "list" (default) or "data".`);
+    console.error(`Unknown --template "${template}". Use "list" (default), "data", or "ai".`);
     process.exit(1);
   }
 

--- a/skills/create-canvas-app/test/generator.test.mjs
+++ b/skills/create-canvas-app/test/generator.test.mjs
@@ -199,12 +199,13 @@ async function main() {
     assert.ok(a.equals(b), "kit/format.mjs and reference copy differ");
   });
 
-  // ---- generator: both templates -------------------------------------------
+  // ---- generator: all templates --------------------------------------------
   const work = await mkdtemp(join(tmpdir(), "ck-gen-test-"));
   try {
     const cases = [
       { name: "gen-list", template: "list", dir: join(work, "gen-list") },
       { name: "gen-feed", template: "data", dir: join(work, "gen-feed") },
+      { name: "gen-ai", template: "ai", dir: join(work, "gen-ai") },
     ];
 
     for (const c of cases) {
@@ -228,7 +229,8 @@ async function main() {
         assert.match(readme, /canvas-kit\//);
         assert.match(readme, /node test\/smoke\.test\.mjs/);
         // template-specific note is injected
-        assert.match(readme, c.template === "data" ? /external-data/i : /list\b/i);
+        const noteRe = { list: /list\b/i, data: /external-data/i, ai: /host-AI/i }[c.template];
+        assert.match(readme, noteRe);
       });
 
       await test(`${c.template}: generated canvas passes check-kit-freshness`, () => {
@@ -275,6 +277,25 @@ async function main() {
       const app = await read(join(work, "gen-feed", "web", "app.mjs"));
       assert.match(app, /pollWhileVisible/);
       assert.match(app, /useEffect/);
+    });
+
+    // ai-template-specific contract: calls the host model from a handler, hands
+    // off to the main agent, and captures model errors into shared state.
+    await test("ai canvas.mjs calls ctx.ai and ctx.askAgent from handlers", async () => {
+      const canvas = await read(join(work, "gen-ai", "canvas.mjs"));
+      assert.match(canvas, /handler: async \(\{ set, input, ai \}\)/);
+      assert.match(canvas, /await ai\(/);
+      assert.match(canvas, /handler: async \(\{ set, input, askAgent \}\)/);
+      assert.match(canvas, /await askAgent\(/);
+      // model errors are captured into state, not thrown past the action
+      assert.match(canvas, /set\(\(current\) => \(\{ \.\.\.current, error \}\)\)/);
+    });
+
+    await test("ai smoke test exercises both the offline path and a wired host", async () => {
+      const smoke = await read(join(work, "gen-ai", "test", "smoke.test.mjs"));
+      assert.match(smoke, /no host wired captures a friendly error/);
+      assert.match(smoke, /runtime\.setHost\(/);
+      assert.match(smoke, /hand_to_agent forwards the prompt to the main agent/);
     });
 
     await test("generated extension.mjs wires the host-model capabilities", async () => {

--- a/skills/create-canvas-app/test/http.test.mjs
+++ b/skills/create-canvas-app/test/http.test.mjs
@@ -224,6 +224,64 @@ async function main() {
     assert.ok(res.status === 403 || res.status === 404, `expected 403/404, got ${res.status}`);
   });
 
+  // ---- host-model actions (ctx.ai / ctx.askAgent) --------------------------
+  // These reach the host's model in production (wired in extension.mjs). Here we
+  // first prove the OFFLINE path — no host wired, so the handlers capture the
+  // failure into shared state instead of throwing — then wire a STUB host and
+  // prove the success path, mirroring what extension.mjs does with the real model.
+  await test("summarize with no host wired captures summaryError (offline)", async () => {
+    await action(open.url, "add_decision", { title: "Adopt SSE for live state" });
+    const { status, body } = await action(open.url, "summarize", {});
+    assert.equal(status, 200);
+    assert.equal(body.ok, true);          // POST envelope ok; the result carries the error
+    assert.equal(body.result.ok, false);
+    assert.match(body.result.error, /unavailable/i);
+    const after = await get(open.url, "/state");
+    assert.ok(after.body.summaryError, "ai_unavailable should land in state.summaryError");
+    assert.equal(after.body.summary, "", "no summary text is written when the model is unavailable");
+  });
+
+  await test("hand_to_agent with no host wired captures agentError (offline)", async () => {
+    const { body: list } = (await get(open.url, "/state"));
+    const id = list.decisions[0].id;
+    const { body } = await action(open.url, "hand_to_agent", { id });
+    assert.equal(body.result.ok, false);
+    assert.match(body.result.error, /unavailable/i);
+    const after = await get(open.url, "/state");
+    assert.ok(after.body.agentError, "askAgent unavailable should land in state.agentError");
+    assert.ok(!after.body.decisions[0].handedToAgentAt, "no write-back when the agent is unavailable");
+  });
+
+  await test("summarize records state.summary once a host is wired", async () => {
+    // Wire a STUB host (extension.mjs does this with the real Copilot model:
+    // ai -> ephemeralQuery, askAgent -> a main-conversation message).
+    const sentToAgent = [];
+    runtime.setHost({
+      ai: async (q) => "SUMMARY of: " + q.split("Decisions:\n")[1],
+      askAgent: async (p) => { sentToAgent.push(p); return "queued"; },
+    });
+    runtime._sentToAgent = sentToAgent; // expose for the next test
+
+    const { body } = await action(open.url, "summarize", {});
+    assert.match(body.result.summary, /SUMMARY of:/);
+    const after = await get(open.url, "/state");
+    assert.match(after.body.summary, /Adopt SSE for live state/);
+    assert.ok(after.body.summaryAt, "a successful summary stamps summaryAt");
+    assert.equal(after.body.summaryError, null, "a successful summary clears the prior error");
+  });
+
+  await test("hand_to_agent forwards a decision prompt to the main agent", async () => {
+    const before = await get(open.url, "/state");
+    const id = before.body.decisions[0].id;
+    const { body } = await action(open.url, "hand_to_agent", { id });
+    assert.equal(body.result.ok, true);
+    assert.equal(runtime._sentToAgent.length, 1);
+    assert.match(runtime._sentToAgent[0], /Adopt SSE for live state/);
+    const after = await get(open.url, "/state");
+    assert.ok(after.body.decisions[0].handedToAgentAt, "a successful handoff is written back onto the item");
+    assert.equal(after.body.agentError, null, "a successful handoff clears the prior error");
+  });
+
   await runtime.shutdown();
   await rm(home, { recursive: true, force: true });
   console.log(`\n${passed} checks passed`);


### PR DESCRIPTION
## Summary

The canvas kit exposes a host-AI API (`ctx.ai` for silent model calls, `ctx.askAgent` to drive the main agent), but it was only half-shipped: the website never mentioned it, no runnable example used it, and the reference canvas wired the host yet never called it. This PR closes those gaps so the API is complete, documented, and demonstrated.

## What changed

- **New `ai` generator template** (`scripts/new-canvas.mjs`): stamps a runnable host-AI canvas (`canvas.mjs` + `app.mjs` + smoke test) with an `ask_ai` handler (silent `ctx.ai`) and a `hand_to_agent` handler (`ctx.askAgent`), both capturing model errors into state.
- **Reference now exercises the API** (`reference/decision-log/`): adds a `summarize` action (silent `ctx.ai` over the log) and a per-item `hand_to_agent` action (`ctx.askAgent`), plus a Summarize button and summary callout in the view.
- **Docs + website**: documents the capability on the catalog page and in `SKILL.md` / `README.md`.
- **Tests**: `http.test.mjs` now covers the offline-error and wired-host paths; `generator.test.mjs` covers the new `ai` template.

## Flow

```mermaid
sequenceDiagram
  participant UI as Canvas UI
  participant H as Action handler
  participant Host as Copilot host
  UI->>H: invoke("summarize")
  H->>Host: ctx.ai(prompt)
  Host-->>H: answer (silent, no chat history)
  H-->>UI: state.summary over SSE
  UI->>H: invoke("hand_to_agent")
  H->>Host: ctx.askAgent(prompt)
  Host-->>H: queued (visible in chat)
```

## Testing

- `create-canvas-app` suite: 95 checks across 5 files, all passing (http 19, generator 44, kit-parity 12, tooling 12, lucide 8).
- New coverage: offline model-unavailable capture plus a wired-host stub for both `summarize` and `hand_to_agent`; the `ai` template stamps, passes `node --check`, and its smoke test runs offline.
- Astro site builds clean (5 pages, including the `create-canvas-app` catalog page).
- Manually booted the decision-log runtime with a stub host and confirmed the summary renders.

## Type of change

Feature (additive). No breaking changes. Docs and tests included.

## Notes

No secrets. No new runtime dependencies. Touches only the `create-canvas-app` skill and its website catalog entry. The vendored `canvas-kit/` stays byte-identical to `kit/` (parity test green).