### PR TITLE
docs(create-canvas-app): note deep-link support in README and site

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ general-purpose monorepo: each skill lives in its own folder under
 
 | Skill | What it does |
 |---|---|
-| [`create-canvas-app`](skills/create-canvas-app/) | Build GitHub Copilot App canvas extensions fast — a no-build Preact + htm kit with live SSE state, durable storage, Primer theming, official GitHub Lucide icons, a generator, and an installable skill. |
+| [`create-canvas-app`](skills/create-canvas-app/) | Build GitHub Copilot App canvas extensions fast — a no-build Preact + htm kit with live SSE state, durable storage, Primer theming, official GitHub Lucide icons, deep links into the app, a generator, and an installable skill. |
 | [`create-gh-pages-site`](skills/create-gh-pages-site/) | Scaffold a working GitHub Pages site from a vetted template (static, Astro, React + Vite, Eleventy, or Jekyll) into your current repo by default — injects the correct base path for the target repo, wires the official GitHub Actions Pages deploy workflow, sets the repo's Website link, and shows how to enable Pages. |
 
 A skill is invoked straight from the Copilot composer &mdash; here `create-canvas-app`

--- a/site/src/content/skills/create-canvas-app.md
+++ b/site/src/content/skills/create-canvas-app.md
@@ -1,6 +1,6 @@
 ---
 title: create-canvas-app
-tagline: "Build GitHub Copilot canvas extensions fast — a no-build Preact + htm kit with live SSE state, durable per-user storage, Primer theming, the official Lucide icon set, and a one-command generator."
+tagline: "Build GitHub Copilot canvas extensions fast — a no-build Preact + htm kit with live SSE state, durable per-user storage, Primer theming, the official Lucide icon set, a one-command generator, and deep links into the app."
 useWhen: "When you want to create, scaffold, or improve an interactive canvas — a side-panel UI the agent can open and drive: dashboards, editors, trackers, boards, or document/preview surfaces."
 repoPath: skills/create-canvas-app
 thumb: images/invoke-create-canvas-app.png
@@ -25,6 +25,8 @@ canvas needs already wired:
 - **Official GitHub Lucide icons** — the same icon set the product uses.
 - **Host AI, no API keys** — call the Copilot app's own model from an action with
   `ctx.ai(…)` (silent generation) or hand work to the main agent with `ctx.askAgent(…)`.
+- **Deep links into github-app:** open a session (or any documented app surface) from a
+  canvas with a validated `ghapp://` link that the app routes into its confirmation-gated pipeline.
 - **A generator** that stamps a working canvas in one command, plus tests.
 
 ## When to reach for it


### PR DESCRIPTION
## Summary
Surface the deep-link capability where users discover the skill. #22 added deep linking to the kit and demo; this updates the two places that advertise the skill but weren't touched by that PR.

## Changes
- `README.md`: add "deep links into the app" to the create-canvas-app row in the skills table.
- `site/src/content/skills/create-canvas-app.md`: add a deep-link bullet to "What it does" and note it in the tagline (the website card and skill page render from this).

## Related
Documents the feature merged in #22.

## Notes
Docs-only. Touches the root README and website content, disjoint from #22's files.
