### PR TITLE
create-canvas-app: harden canvas-kit runtime (SSRF guard, schema validation, safe storage)

### DIFF
--- a/skills/create-canvas-app/README.md
+++ b/skills/create-canvas-app/README.md
@@ -174,8 +174,10 @@ from jongio/copilot-extensions/extensions/stock-ticker."* No clone, no build.
 SKILL.md                      The Copilot skill (authoring contract + workflow)
 kit/                          The canonical kit — copy into your extension as canvas-kit/
   client.mjs                  Browser runtime: html, mountCanvas, pollWhileVisible, hooks, Icon, formatters, deep-link builders
-  server.mjs                  SDK-free runtime: /state, /events (SSE), /action, static
-  storage.mjs                 Durable per-user JSON store
+  server.mjs                  SDK-free runtime: /state, /events (SSE), /action, static, inputSchema/stateSchema validation
+  storage.mjs                 Durable JSON store — userStore / sessionStore / workspaceStore (atomic, concurrency-safe writes)
+  validate.mjs                Dependency-free JSON-Schema-subset validator (enforces action inputSchema + stateSchema)
+  net.mjs                     Server-side egress guard: assertPublicUrl / isBlockedAddress / safeFetch (SSRF-safe fetch + timeout)
   format.mjs                  nid + relativeTime / compactNumber / percent helpers
   deeplinks.mjs               github-app deep-link builders (ghapp://) + safe URL / prompt helpers
   theme.css                   Primer-token styling (ck-* classes)
@@ -199,6 +201,7 @@ test/
   generator.test.mjs          Stamps the list/data/ai templates, runs their smoke tests, checks the kit API
   tooling.test.mjs            Exercises the version stamp, sync-kit, and the freshness drift gate
   vendor-lucide.test.mjs      Checks the Lucide vendoring generator (sorting, key-strip, determinism)
+  kit-runtime.test.mjs        Checks input/state schema validation, the net.mjs SSRF guard, and concurrency-safe storage
 ```
 
 ## Run the tests
@@ -210,10 +213,11 @@ node test/deeplinks.test.mjs
 node test/generator.test.mjs
 node test/tooling.test.mjs
 node test/vendor-lucide.test.mjs
+node test/kit-runtime.test.mjs
 ```
 
 No dependencies to install — everything is vendored. Node 18+ (developed on 24).
-`npm test` runs all six in sequence.
+`npm test` runs all seven in sequence.
 
 ## License
 

--- a/skills/create-canvas-app/SKILL.md
+++ b/skills/create-canvas-app/SKILL.md
@@ -55,6 +55,12 @@ web/app.mjs     ── your Preact view
   open input (`resolveDomainId`), **not** by `instanceId` — open the same domain
   in two panels and they show the same data. Persistence goes through
   `userStore(extName, file)` → `$COPILOT_HOME/extensions/<name>/artifacts/<domain>.json`.
+  Two more tiers exist in `kit/storage.mjs` for non-durable/scoped state:
+  `sessionStore(sessionId, extName, file)` (per-session scratch, discarded with
+  the session) and `workspaceStore(workspacePath, file)` (rooted at the session
+  workspace). All three write atomically (temp + rename) and **serialize
+  concurrent saves to the same file**, so a racing agent + UI save can't corrupt
+  or `EPERM` the durable file.
 - **Agent and UI share handlers.** An action invoked by the agent and the same
   action invoked from a button run the identical handler and produce the identical
   state mutation. Write the logic once, in `canvas.mjs`.
@@ -87,6 +93,22 @@ invocation in the same envelope, so model failures deliberately:
 - For an **expected, transient** failure (a flaky upstream fetch on a background
   poll), don't throw — capture it into `state.error` and **return** so the error
   card shows while the poll stays quiet (see the data template's `refresh`).
+
+### Input & state are schema-validated at the boundary
+
+An action's `inputSchema` is **enforced by the runtime**, not just declared: a
+payload that violates it (wrong type, missing required field, out-of-enum value,
+or an unexpected property under `additionalProperties: false`) is rejected with
+an `invalid_input` error (**HTTP 400**) *before* your handler runs — from the
+agent side too. So `inputSchema` is your typed contract; write it precisely and
+your handler only sees well-shaped input. **Business rules still live in the
+handler** (a schema-valid but empty `"   "` title reaches the handler, which
+throws → 500). Open input is validated against `config.inputSchema` the same way.
+
+Optionally set `config.stateSchema` (same JSON-Schema subset, `kit/validate.mjs`)
+to guard the **durable shape**: if a handler produces state that violates it, the
+mutation is rolled back and the action fails loud (500) instead of persisting
+corrupt state. It's opt-in — omit it and any state shape is allowed.
 
 ## Icons — official GitHub Lucide, always
 
@@ -172,23 +194,29 @@ Most real canvases aren't user-entered CRUD lists; they pull from the network an
 refresh. The shape:
 
 1. **`fetch()` lives in the action handler (or a helper it calls), never in the
-   view.** Always bound it with a timeout so a slow upstream can't hang the panel:
+   view.** Use the kit's **`safeFetch`** — it SSRF-guards the URL and applies a
+   hard timeout, so a caller-influenced source can't reach the internal network
+   and a slow upstream can't hang the panel:
 
    ```js
+   import { safeFetch } from "./canvas-kit/net.mjs";
+
    async function fetchItems(url) {
-     const res = await fetch(url, { signal: AbortSignal.timeout(12000) });
+     const res = await safeFetch(url, { headers: { Accept: "application/json" } });
      if (!res.ok) throw new Error(`HTTP ${res.status}`);
      return mapItems(await res.json());
    }
    ```
 
-   The fetch runs server-side on the loopback runtime, so the generated `data`
-   template guards it with an **SSRF check**: it allows only `http`/`https` to a
-   **public** host and rejects loopback, link-local (incl. cloud metadata), and
-   private ranges — including every address the hostname resolves to. Anything
-   you feed back to the agent (e.g. via `list_items`) is still attacker-influenced
-   text, so keep the source one *you* choose and treat fetched content as
-   untrusted (render it as text, never `innerHTML`).
+   `safeFetch` runs server-side on the loopback runtime, so it enforces an **SSRF
+   guard** (`kit/net.mjs`): it allows only `http`/`https` to a **public** host and
+   rejects loopback, link-local (incl. cloud metadata), and private ranges —
+   including every address the hostname resolves to — then fetches with an
+   `AbortSignal.timeout`. `assertPublicUrl(url)` / `isBlockedAddress(ip)` are also
+   exported if you need the check without the fetch. Anything you feed back to the
+   agent (e.g. via `list_items`) is still attacker-influenced text, so keep the
+   source one *you* choose and treat fetched content as untrusted (render it as
+   text, never `innerHTML`).
 
 2. **Expose a `refresh` action** that fetches and writes the result into shared
    state. Capture failures into `state.error` and *return* (don't throw) so a

--- a/skills/create-canvas-app/kit/net.mjs
+++ b/skills/create-canvas-app/kit/net.mjs
@@ -1,0 +1,126 @@
+// canvas-kit/net.mjs
+//
+// Server-side network safety for canvases that fetch external data. A canvas
+// action runs on the loopback runtime with the app's network reach, so a
+// caller-influenced URL is an SSRF risk: it could target cloud metadata
+// (169.254.169.254), loopback, or the private network. This module is the kit's
+// sanctioned egress primitive — validate a URL, then fetch it with a hard
+// timeout — so every data canvas guards the same way instead of re-inlining the
+// check. SERVER-ONLY (uses node:dns / node:net): import it from the SDK-free
+// canvas.mjs, never from the browser view.
+//
+// Defense-in-depth, not a guarantee: a determined attacker could DNS-rebind
+// between the resolve check and the connect. For a canvas pointed at a source
+// you choose this is adequate; treat any fetched content as untrusted and render
+// it as TEXT (never innerHTML).
+
+import { lookup } from "node:dns/promises";
+import { isIP } from "node:net";
+
+/**
+ * True for addresses a server-side fetch should never reach: loopback,
+ * link-local (incl. cloud metadata 169.254.169.254), and private/CGNAT ranges.
+ * @param {string} ip
+ * @returns {boolean}
+ */
+export function isBlockedAddress(ip) {
+  const lower = ip.toLowerCase();
+  // Decode an IPv4-mapped/compatible IPv6 literal down to its embedded IPv4 so
+  // the IPv4 range checks apply. Covers BOTH the dotted tail (::ffff:127.0.0.1)
+  // and the HEX tail that `new URL()` normalizes literals to (::ffff:7f00:1) —
+  // without the decode, `[::ffff:127.0.0.1]` reaches loopback and
+  // `[::ffff:a9fe:a9fe]` reaches cloud metadata. Only matches when the high bits
+  // are all zero (leading "::"), so a normal public v6 (e.g. 2001:db8::7f00:1) is
+  // never misread as IPv4.
+  const addr = embeddedIPv4(lower) ?? ip;
+  if (isIP(addr) === 4) {
+    const [a, b] = addr.split(".").map(Number);
+    if (a === 0 || a === 127 || a === 10) return true;     // this-host / loopback / private
+    if (a === 169 && b === 254) return true;               // link-local (incl. cloud IMDS)
+    if (a === 172 && b >= 16 && b <= 31) return true;      // private
+    if (a === 192 && b === 168) return true;               // private
+    if (a === 100 && b >= 64 && b <= 127) return true;     // CGNAT
+    return false;
+  }
+  return lower === "::1" || lower === "::" || lower.startsWith("fe80") || lower.startsWith("fc") || lower.startsWith("fd");
+}
+
+// Decode an IPv4-mapped/compatible IPv6 literal (all-zero high groups, i.e. a
+// leading "::", optionally "::ffff:") to its dotted IPv4; else null. Accepts the
+// dotted tail (127.0.0.1) and the two-hex-group tail (7f00:1) that URL
+// normalization produces. Anchored on "::" so it can't misread a public v6.
+function embeddedIPv4(addr) {
+  const m = addr.match(/^::(?:ffff:)?((?:\d{1,3}\.){3}\d{1,3}|[0-9a-f]{1,4}:[0-9a-f]{1,4})$/);
+  if (!m) return null;
+  const tail = m[1];
+  if (tail.includes(".")) return isIP(tail) === 4 ? tail : null;
+  const [h1, h2] = tail.split(":");
+  const hi = parseInt(h1, 16), lo = parseInt(h2, 16);
+  return `${hi >> 8}.${hi & 255}.${lo >> 8}.${lo & 255}`;
+}
+
+/**
+ * Allow only http/https to a PUBLIC host. Rejects every address the hostname
+ * resolves to, so a public name can't be pointed at an internal IP. Throws on a
+ * blocked/invalid URL; resolves to void when the URL is safe to fetch.
+ * @param {string} url
+ */
+export async function assertPublicUrl(url) {
+  let u;
+  try { u = new URL(url); } catch { throw new Error("Invalid source URL"); }
+  if (u.protocol !== "http:" && u.protocol !== "https:") {
+    throw new Error("Blocked URL protocol: " + u.protocol);
+  }
+  let host = u.hostname;
+  if (host.startsWith("[") && host.endsWith("]")) host = host.slice(1, -1); // IPv6 brackets
+  if (host.toLowerCase() === "localhost") throw new Error("Blocked host: localhost");
+  const addrs = isIP(host) ? [host] : (await lookup(host, { all: true })).map((r) => r.address);
+  if (!addrs.length) throw new Error("Could not resolve host: " + host);
+  for (const ip of addrs) {
+    if (isBlockedAddress(ip)) throw new Error("Blocked private/loopback address: " + ip);
+  }
+}
+
+/**
+ * SSRF-guarded fetch with a mandatory timeout. Runs assertPublicUrl on the URL
+ * and on EVERY redirect hop, so a chosen public host can't 30x-redirect the
+ * request into loopback/metadata/private space. Returns the final Response as-is
+ * (does NOT throw on a non-2xx status — the caller checks res.ok), so it is a
+ * drop-in for a guarded fetch().
+ *
+ * Redirects are followed MANUALLY (redirect:"manual") rather than by fetch's
+ * default redirect:"follow": the default would chase a 3xx Location without
+ * re-running the guard, which silently undoes every check in this module. Here
+ * each hop's target is re-validated before we connect to it.
+ * @param {string} url
+ * @param {object} [opts]
+ * @param {number} [opts.timeoutMs=12000]     abort the WHOLE operation (all hops) after this many ms
+ * @param {number} [opts.maxRedirects=5]      how many 3xx hops to follow before giving up
+ * @param {object} [opts.headers]             request headers (merged as-is)
+ * @param {RequestInit} [opts.rest]           any other fetch init (method, body, …)
+ * @returns {Promise<Response>}
+ */
+export async function safeFetch(url, { timeoutMs = 12000, maxRedirects = 5, headers, ...rest } = {}) {
+  // One timeout signal bounds the entire operation, redirects included, so a
+  // chain of slow hops can't multiply the deadline.
+  const signal = AbortSignal.timeout(timeoutMs);
+  let current = url;
+  for (let hop = 0; ; hop++) {
+    await assertPublicUrl(current);
+    const res = await fetch(current, {
+      ...rest,
+      headers: headers ?? {},
+      redirect: "manual",
+      signal,
+    });
+    if (res.status >= 300 && res.status < 400 && res.headers.has("location")) {
+      if (hop >= maxRedirects) throw new Error("Too many redirects");
+      const next = new URL(res.headers.get("location"), current).href;
+      // Discard the redirect body so the connection can be freed before the next hop.
+      try { await res.body?.cancel(); } catch { /* no body / already consumed */ }
+      current = next;
+      continue;
+    }
+    return res;
+  }
+}

--- a/skills/create-canvas-app/kit/server.mjs
+++ b/skills/create-canvas-app/kit/server.mjs
@@ -20,6 +20,7 @@ import { createServer } from "node:http";
 import { readFile } from "node:fs/promises";
 import { join, normalize, extname, sep } from "node:path";
 import { fileURLToPath } from "node:url";
+import { validate } from "./validate.mjs";
 
 const KIT_DIR = fileURLToPath(new URL(".", import.meta.url));
 
@@ -53,6 +54,7 @@ export class CanvasKitError extends Error {
  * @param {(domainId:string)=>any|Promise<any>} [config.loadState]
  * @param {(domainId:string, state:any)=>void|Promise<void>} [config.saveState]
  * @param {Record<string,{description?:string,inputSchema?:object,handler:Function}>} config.actions
+ * @param {object} [config.stateSchema]  optional JSON-Schema-subset for the durable state; when set, a mutation that violates it is rolled back and fails (500)
  * @param {string} config.assetsDir  absolute path to the canvas web/ folder
  * @param {(ctx:object,state:any)=>string} [config.statusLine]
  */
@@ -118,8 +120,26 @@ export function createCanvasRuntime(config) {
     if (!action || typeof action.handler !== "function") {
       throw new CanvasKitError("unknown_action", `Unknown action: ${actionName}`);
     }
+    // Enforce the declared inputSchema at the boundary (agent OR ui). The schema
+    // is a contract authors already write; validating it here turns "declared but
+    // unchecked" into a typed boundary and stops a malformed/typo'd payload from
+    // reaching the handler. A shape violation is the CALLER's fault → invalid_input
+    // (HTTP 400). Business rules ("title can't be blank") still live in the handler
+    // and surface as a 500, so a schema-valid-but-empty string reaches the handler.
+    if (action.inputSchema) {
+      const errs = validate(action.inputSchema, input ?? {}, "input");
+      if (errs.length) {
+        throw new CanvasKitError("invalid_input", `Invalid input for '${actionName}': ${errs.join("; ")}`);
+      }
+    }
     const domainId = ctx?.domainId ?? "default";
     const d = await getDomain(domainId, ctx);
+    // Deep snapshot for stateSchema rollback: a handler may mutate state IN PLACE
+    // and return the same object, so a reference copy (prevState = d.state) would
+    // point at the same (now-corrupt) object and restore nothing. structuredClone
+    // gives a real pre-mutation copy. Durable state is JSON-shaped, so it clones
+    // cleanly. Only pay the clone when a stateSchema is actually configured.
+    const prevState = config.stateSchema ? structuredClone(d.state) : undefined;
     let mutated = false;
     const api = {
       get state() { return d.state; },
@@ -161,6 +181,17 @@ export function createCanvasRuntime(config) {
     };
     const result = await action.handler(api);
     if (mutated) {
+      // Optional stateSchema guards the durable shape: if a handler produced an
+      // invalid state, roll back the in-memory mutation and fail LOUD (a 500 —
+      // this is a handler bug, not caller input) instead of persisting/broadcasting
+      // corrupt state. Absent stateSchema, anything goes (opt-in).
+      if (config.stateSchema) {
+        const errs = validate(config.stateSchema, d.state, "state");
+        if (errs.length) {
+          d.state = prevState; // roll back so in-memory stays consistent
+          throw new Error(`Action '${actionName}' produced invalid state: ${errs.join("; ")}`);
+        }
+      }
       if (config.saveState) await config.saveState(domainId, d.state);
       broadcast(domainId);
     }
@@ -307,6 +338,15 @@ export function createCanvasRuntime(config) {
    * @returns {Promise<{url:string,title:string,status?:string}>}
    */
   async function openInstance({ instanceId, input, ctx }) {
+    // Validate the open input against the declared inputSchema (same contract the
+    // actions get). A bad open payload fails fast with invalid_input rather than
+    // silently resolving the wrong domain.
+    if (config.inputSchema) {
+      const errs = validate(config.inputSchema, input ?? {}, "open input");
+      if (errs.length) {
+        throw new CanvasKitError("invalid_input", `Invalid open input: ${errs.join("; ")}`);
+      }
+    }
     const domainId = config.resolveDomainId
       ? config.resolveDomainId(input ?? {}, ctx ?? {}) || "default"
       : "default";

--- a/skills/create-canvas-app/kit/storage.mjs
+++ b/skills/create-canvas-app/kit/storage.mjs
@@ -2,16 +2,59 @@
 //
 // Durable JSON state helpers. State is keyed by a *domain id* (a stable logical
 // identifier resolved from the open input), never by instanceId — per
-// create-canvas/SKILL.md. Two scopes:
+// create-canvas/SKILL.md. Three tiers, matching the Canvas SDK storage model:
 //   userStore      -> $COPILOT_HOME/extensions/<name>/artifacts/<file>   (per user, cross-session)
-//   workspaceStore -> <session.workspacePath>/<file>                     (per session)
+//   sessionStore   -> $COPILOT_HOME/session-state/<sessionId>/extensions/<name>/<file>  (per session, scratch)
+//   workspaceStore -> <session.workspacePath>/<file>                     (rooted at the session workspace)
+//
+// Sandboxing: callers derive the <file> from a domain id that MUST be sanitized
+// to a bare filename (the reference `fileFor` strips everything but
+// [A-Za-z0-9._-]); the store never joins caller input as a path, so a domain id
+// can't escape its extension's artifacts directory.
 
-import { readFile, writeFile, mkdir, rename } from "node:fs/promises";
+import { readFile, writeFile, mkdir, rename, unlink } from "node:fs/promises";
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
+import { randomBytes } from "node:crypto";
 
 function copilotHome() {
   return process.env.COPILOT_HOME || join(homedir(), ".copilot");
+}
+
+// Per-file write queue. Concurrent saves to the SAME durable file (an agent
+// action and a UI action racing) must not overlap: on Windows two renames to the
+// same destination collide with EPERM even with unique temp names. Chaining each
+// save onto the previous one for that path serializes them (last enqueued wins),
+// which is both correct (no interleaved writes) and portable.
+const writeQueues = new Map(); // absolute file path -> tail Promise
+
+async function atomicWrite(file, data) {
+  await mkdir(dirname(file), { recursive: true });
+  // Write to a temp sibling then atomically rename into place, so a crash or
+  // interruption mid-write can never truncate the existing durable file.
+  // rename(2) is atomic on the same filesystem. The temp name mixes pid + time +
+  // RANDOM bytes so two writers can never pick the same temp path.
+  const tmp = `${file}.${process.pid}.${Date.now()}.${randomBytes(6).toString("hex")}.tmp`;
+  await writeFile(tmp, JSON.stringify(data, null, 2), "utf8");
+  try {
+    await rename(tmp, file);
+  } catch (err) {
+    // Windows can transiently EPERM/EACCES a rename when the destination is
+    // briefly held (AV scanner, indexer). Retry once after a short beat; always
+    // clean up our temp so a failed save leaves no orphaned *.tmp behind.
+    if (err?.code === "EPERM" || err?.code === "EACCES") {
+      await new Promise((r) => setTimeout(r, 25));
+      try {
+        await rename(tmp, file);
+      } catch (err2) {
+        await unlink(tmp).catch(() => {});
+        throw err2;
+      }
+    } else {
+      await unlink(tmp).catch(() => {});
+      throw err;
+    }
+  }
 }
 
 function makeStore(file) {
@@ -32,13 +75,15 @@ function makeStore(file) {
       }
     },
     async save(data) {
-      await mkdir(dirname(file), { recursive: true });
-      // Write to a temp sibling then atomically rename into place, so a crash or
-      // interruption mid-write can never truncate the existing durable file.
-      // rename(2) is atomic on the same filesystem.
-      const tmp = `${file}.${process.pid}.${Date.now()}.tmp`;
-      await writeFile(tmp, JSON.stringify(data, null, 2), "utf8");
-      await rename(tmp, file);
+      // Serialize behind any in-flight save for this exact path (see writeQueues).
+      const prev = writeQueues.get(file) ?? Promise.resolve();
+      const run = prev.catch(() => {}).then(() => atomicWrite(file, data));
+      writeQueues.set(file, run);
+      try {
+        await run;
+      } finally {
+        if (writeQueues.get(file) === run) writeQueues.delete(file);
+      }
     },
   };
 }
@@ -46,6 +91,24 @@ function makeStore(file) {
 /** Per-user, cross-session artifact store for a named extension. */
 export function userStore(extensionName, fileName) {
   return makeStore(join(copilotHome(), "extensions", extensionName, "artifacts", fileName));
+}
+
+/**
+ * Per-session scratch store for a named extension, rooted under the session's
+ * state directory. Use for state that should NOT outlive the session (drafts,
+ * one-off working data). Pass the session id (e.g. from the SDK ctx).
+ */
+export function sessionStore(sessionId, extensionName, fileName) {
+  // Reduce the session id to a single safe path segment. The charset filter keeps
+  // "." (so dotted ids survive), so we must ALSO collapse any ".." run — otherwise
+  // a session id of ".." would join to one level ABOVE session-state and escape the
+  // per-session root. (sessionId is normally a trusted SDK value; this keeps the
+  // sanitizer honest regardless.)
+  const safeSession =
+    String(sessionId)
+      .replace(/[^A-Za-z0-9._-]/g, "_")
+      .replace(/\.\.+/g, "_") || "default";
+  return makeStore(join(copilotHome(), "session-state", safeSession, "extensions", extensionName, fileName));
 }
 
 /** Per-session store rooted at the session workspace path. */

--- a/skills/create-canvas-app/kit/validate.mjs
+++ b/skills/create-canvas-app/kit/validate.mjs
@@ -1,0 +1,146 @@
+// canvas-kit/validate.mjs
+//
+// A tiny, dependency-free JSON-Schema-*subset* validator. It exists so the
+// runtime can ENFORCE the action `inputSchema` (and an optional `stateSchema`)
+// that authors already declare — turning the iframe↔extension / agent↔extension
+// contract from "declared but unchecked" into "validated at the boundary". No
+// npm dependency (the kit ships vendored, no install step), and it only covers
+// the JSON Schema features the kit's schemas actually use:
+//
+//   type            "object" | "array" | "string" | "number" | "integer" |
+//                   "boolean" | "null"  (or an array of those)
+//   properties      per-key subschemas (objects)
+//   required        array of required property names (objects)
+//   additionalProperties   false | subschema (objects)
+//   items           subschema for every element (arrays)
+//   enum            allowed literal values (deep-equal)
+//   minLength/maxLength    string length bounds
+//   minimum/maximum        numeric bounds
+//   minItems/maxItems      array length bounds
+//
+// It is intentionally forgiving: an absent/empty schema validates anything, and
+// unknown keywords are ignored (so a richer schema never hard-fails here). The
+// goal is to catch the shape mistakes that actually break canvases — wrong type,
+// missing required field, unknown/typo'd property, out-of-enum value — not to be
+// a complete JSON Schema implementation.
+
+function typeOf(value) {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  if (Number.isInteger(value)) return "integer";
+  return typeof value; // "string" | "number" | "boolean" | "object" | "undefined"
+}
+
+// Does `value` satisfy a single JSON Schema `type` token? "number" accepts
+// integers; "integer" requires a whole number.
+function matchesType(value, t) {
+  const actual = typeOf(value);
+  if (t === "number") return actual === "number" || actual === "integer";
+  if (t === "integer") return actual === "integer";
+  return actual === t;
+}
+
+function deepEqual(a, b) {
+  if (a === b) return true;
+  if (typeof a !== typeof b || a === null || b === null) return false;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return a.length === b.length && a.every((x, i) => deepEqual(x, b[i]));
+  }
+  if (typeof a === "object" && typeof b === "object") {
+    const ak = Object.keys(a), bk = Object.keys(b);
+    return ak.length === bk.length && ak.every((k) => deepEqual(a[k], b[k]));
+  }
+  return false;
+}
+
+/**
+ * Validate `value` against a JSON-Schema-subset `schema`.
+ * @param {object|undefined} schema
+ * @param {any} value
+ * @param {string} [path]  dotted path used in error messages (default "input")
+ * @returns {string[]} human-readable error messages; empty array = valid.
+ */
+export function validate(schema, value, path = "input") {
+  const errors = [];
+  walk(schema, value, path, errors);
+  return errors;
+}
+
+function walk(schema, value, path, errors) {
+  if (!schema || typeof schema !== "object") return; // absent/degenerate schema = anything goes
+
+  // type (single token or array of tokens)
+  if (schema.type !== undefined) {
+    const types = Array.isArray(schema.type) ? schema.type : [schema.type];
+    if (!types.some((t) => matchesType(value, t))) {
+      errors.push(`${path}: expected ${types.join(" | ")}, got ${typeOf(value)}`);
+      return; // a wrong base type makes deeper checks meaningless
+    }
+  }
+
+  // enum
+  if (Array.isArray(schema.enum) && !schema.enum.some((allowed) => deepEqual(allowed, value))) {
+    errors.push(`${path}: must be one of ${schema.enum.map((v) => JSON.stringify(v)).join(", ")}`);
+  }
+
+  const kind = typeOf(value);
+
+  if (kind === "string") {
+    if (typeof schema.minLength === "number" && value.length < schema.minLength) {
+      errors.push(`${path}: must be at least ${schema.minLength} characters`);
+    }
+    if (typeof schema.maxLength === "number" && value.length > schema.maxLength) {
+      errors.push(`${path}: must be at most ${schema.maxLength} characters`);
+    }
+  }
+
+  if (kind === "number" || kind === "integer") {
+    if (typeof schema.minimum === "number" && value < schema.minimum) {
+      errors.push(`${path}: must be >= ${schema.minimum}`);
+    }
+    if (typeof schema.maximum === "number" && value > schema.maximum) {
+      errors.push(`${path}: must be <= ${schema.maximum}`);
+    }
+  }
+
+  if (kind === "array") {
+    if (typeof schema.minItems === "number" && value.length < schema.minItems) {
+      errors.push(`${path}: must have at least ${schema.minItems} item(s)`);
+    }
+    if (typeof schema.maxItems === "number" && value.length > schema.maxItems) {
+      errors.push(`${path}: must have at most ${schema.maxItems} item(s)`);
+    }
+    if (schema.items) {
+      value.forEach((item, i) => walk(schema.items, item, `${path}[${i}]`, errors));
+    }
+  }
+
+  if (kind === "object") {
+    const props = schema.properties ?? {};
+    if (Array.isArray(schema.required)) {
+      for (const key of schema.required) {
+        // Object.hasOwn (not `value[key] === undefined`): a required property
+        // named after a prototype member (e.g. "toString", "constructor") would
+        // otherwise read the inherited value and wrongly pass the check.
+        if (!Object.hasOwn(value, key)) errors.push(`${path}.${key}: required`);
+      }
+    }
+    for (const [key, sub] of Object.entries(props)) {
+      if (Object.hasOwn(value, key)) walk(sub, value[key], `${path}.${key}`, errors);
+    }
+    // Membership is tested with Object.hasOwn, NOT `key in props`: `in` walks the
+    // prototype chain, so an extra key named "toString"/"constructor"/"__proto__"
+    // etc. would satisfy `key in props` and escape additionalProperties. This
+    // validator is the enforcement boundary (input → 400, state → 500), so that
+    // would be a real contract hole.
+    if (schema.additionalProperties === false) {
+      for (const key of Object.keys(value)) {
+        if (!Object.hasOwn(props, key)) errors.push(`${path}.${key}: unexpected property`);
+      }
+    } else if (schema.additionalProperties && typeof schema.additionalProperties === "object") {
+      for (const key of Object.keys(value)) {
+        if (!Object.hasOwn(props, key)) walk(schema.additionalProperties, value[key], `${path}.${key}`, errors);
+      }
+    }
+  }
+}

--- a/skills/create-canvas-app/kit/validate.mjs
+++ b/skills/create-canvas-app/kit/validate.mjs
@@ -19,10 +19,13 @@
 //   minItems/maxItems      array length bounds
 //
 // It is intentionally forgiving: an absent/empty schema validates anything, and
-// unknown keywords are ignored (so a richer schema never hard-fails here). The
-// goal is to catch the shape mistakes that actually break canvases — wrong type,
-// missing required field, unknown/typo'd property, out-of-enum value — not to be
-// a complete JSON Schema implementation.
+// unknown keywords are ignored (so a richer schema never hard-fails here). A
+// property whose value is `undefined` is treated as ABSENT — `undefined` is not a
+// JSON value, so `{ x: undefined }` is equivalent to `{}` once it crosses the
+// agent↔extension / iframe↔extension boundary, and `{ optional }` shorthand with
+// an unset variable must not be rejected. The goal is to catch the shape mistakes
+// that actually break canvases — wrong type, missing required field, unknown/typo'd
+// property, out-of-enum value — not to be a complete JSON Schema implementation.
 
 function typeOf(value) {
   if (value === null) return "null";
@@ -121,24 +124,33 @@ function walk(schema, value, path, errors) {
       for (const key of schema.required) {
         // Object.hasOwn (not `value[key] === undefined`): a required property
         // named after a prototype member (e.g. "toString", "constructor") would
-        // otherwise read the inherited value and wrongly pass the check.
-        if (!Object.hasOwn(value, key)) errors.push(`${path}.${key}: required`);
+        // otherwise read the inherited value and wrongly pass the check. An
+        // explicit `undefined` counts as ABSENT (undefined is not a JSON value, so
+        // { x: undefined } is equivalent to {} once it crosses the wire).
+        if (!Object.hasOwn(value, key) || value[key] === undefined) errors.push(`${path}.${key}: required`);
       }
     }
     for (const [key, sub] of Object.entries(props)) {
-      if (Object.hasOwn(value, key)) walk(sub, value[key], `${path}.${key}`, errors);
+      // Skip absent OR explicitly-undefined optional properties: a caller passing
+      // { article } where `article` is an unset variable is idiomatic JS and, over
+      // a JSON boundary, indistinguishable from omitting the key. Only validate a
+      // property that is actually present with a defined value.
+      if (Object.hasOwn(value, key) && value[key] !== undefined) walk(sub, value[key], `${path}.${key}`, errors);
     }
     // Membership is tested with Object.hasOwn, NOT `key in props`: `in` walks the
     // prototype chain, so an extra key named "toString"/"constructor"/"__proto__"
     // etc. would satisfy `key in props` and escape additionalProperties. This
     // validator is the enforcement boundary (input → 400, state → 500), so that
-    // would be a real contract hole.
+    // would be a real contract hole. An explicit `undefined` value is treated as
+    // absent (see above), so it is never counted as an extra/unexpected property.
     if (schema.additionalProperties === false) {
       for (const key of Object.keys(value)) {
+        if (value[key] === undefined) continue;
         if (!Object.hasOwn(props, key)) errors.push(`${path}.${key}: unexpected property`);
       }
     } else if (schema.additionalProperties && typeof schema.additionalProperties === "object") {
       for (const key of Object.keys(value)) {
+        if (value[key] === undefined) continue;
         if (!Object.hasOwn(props, key)) walk(schema.additionalProperties, value[key], `${path}.${key}`, errors);
       }
     }

--- a/skills/create-canvas-app/kit/version.mjs
+++ b/skills/create-canvas-app/kit/version.mjs
@@ -10,4 +10,4 @@
 // convention (the skill ships as files, not an npm version); a commit short-sha
 // works too. Re-exported from client.mjs so a canvas can read it at runtime.
 
-export const KIT_VERSION = "2026-07-05.1";
+export const KIT_VERSION = "2026-07-07.1";

--- a/skills/create-canvas-app/package.json
+++ b/skills/create-canvas-app/package.json
@@ -5,7 +5,7 @@
   "description": "Dev tooling for the create-canvas-app skill (tests + Vally eval). Shipped canvases never get a package.json — this is for the skill repo only.",
   "license": "MIT",
   "scripts": {
-    "test": "node test/http.test.mjs && node test/kit-parity.test.mjs && node test/deeplinks.test.mjs && node test/generator.test.mjs && node test/tooling.test.mjs && node test/vendor-lucide.test.mjs",
+    "test": "node test/http.test.mjs && node test/kit-parity.test.mjs && node test/deeplinks.test.mjs && node test/generator.test.mjs && node test/tooling.test.mjs && node test/vendor-lucide.test.mjs && node test/kit-runtime.test.mjs",
     "eval:lint": "vally lint --eval-spec evals/create-canvas-app/eval.yaml",
     "eval": "vally eval --eval-spec evals/create-canvas-app/eval.yaml --skill-dir ."
   },

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/.kit-version.json
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/.kit-version.json
@@ -1,5 +1,5 @@
 {
-  "version": "2026-07-05.1",
-  "syncedAt": "2026-07-06T19:31:30.895Z",
+  "version": "2026-07-07.1",
+  "syncedAt": "2026-07-07T16:29:42.390Z",
   "source": "create-canvas-app/kit"
 }

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/.kit-version.json
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/.kit-version.json
@@ -1,5 +1,5 @@
 {
   "version": "2026-07-07.1",
-  "syncedAt": "2026-07-07T16:29:42.390Z",
+  "syncedAt": "2026-07-07T16:40:54.183Z",
   "source": "create-canvas-app/kit"
 }

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/net.mjs
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/net.mjs
@@ -1,0 +1,126 @@
+// canvas-kit/net.mjs
+//
+// Server-side network safety for canvases that fetch external data. A canvas
+// action runs on the loopback runtime with the app's network reach, so a
+// caller-influenced URL is an SSRF risk: it could target cloud metadata
+// (169.254.169.254), loopback, or the private network. This module is the kit's
+// sanctioned egress primitive — validate a URL, then fetch it with a hard
+// timeout — so every data canvas guards the same way instead of re-inlining the
+// check. SERVER-ONLY (uses node:dns / node:net): import it from the SDK-free
+// canvas.mjs, never from the browser view.
+//
+// Defense-in-depth, not a guarantee: a determined attacker could DNS-rebind
+// between the resolve check and the connect. For a canvas pointed at a source
+// you choose this is adequate; treat any fetched content as untrusted and render
+// it as TEXT (never innerHTML).
+
+import { lookup } from "node:dns/promises";
+import { isIP } from "node:net";
+
+/**
+ * True for addresses a server-side fetch should never reach: loopback,
+ * link-local (incl. cloud metadata 169.254.169.254), and private/CGNAT ranges.
+ * @param {string} ip
+ * @returns {boolean}
+ */
+export function isBlockedAddress(ip) {
+  const lower = ip.toLowerCase();
+  // Decode an IPv4-mapped/compatible IPv6 literal down to its embedded IPv4 so
+  // the IPv4 range checks apply. Covers BOTH the dotted tail (::ffff:127.0.0.1)
+  // and the HEX tail that `new URL()` normalizes literals to (::ffff:7f00:1) —
+  // without the decode, `[::ffff:127.0.0.1]` reaches loopback and
+  // `[::ffff:a9fe:a9fe]` reaches cloud metadata. Only matches when the high bits
+  // are all zero (leading "::"), so a normal public v6 (e.g. 2001:db8::7f00:1) is
+  // never misread as IPv4.
+  const addr = embeddedIPv4(lower) ?? ip;
+  if (isIP(addr) === 4) {
+    const [a, b] = addr.split(".").map(Number);
+    if (a === 0 || a === 127 || a === 10) return true;     // this-host / loopback / private
+    if (a === 169 && b === 254) return true;               // link-local (incl. cloud IMDS)
+    if (a === 172 && b >= 16 && b <= 31) return true;      // private
+    if (a === 192 && b === 168) return true;               // private
+    if (a === 100 && b >= 64 && b <= 127) return true;     // CGNAT
+    return false;
+  }
+  return lower === "::1" || lower === "::" || lower.startsWith("fe80") || lower.startsWith("fc") || lower.startsWith("fd");
+}
+
+// Decode an IPv4-mapped/compatible IPv6 literal (all-zero high groups, i.e. a
+// leading "::", optionally "::ffff:") to its dotted IPv4; else null. Accepts the
+// dotted tail (127.0.0.1) and the two-hex-group tail (7f00:1) that URL
+// normalization produces. Anchored on "::" so it can't misread a public v6.
+function embeddedIPv4(addr) {
+  const m = addr.match(/^::(?:ffff:)?((?:\d{1,3}\.){3}\d{1,3}|[0-9a-f]{1,4}:[0-9a-f]{1,4})$/);
+  if (!m) return null;
+  const tail = m[1];
+  if (tail.includes(".")) return isIP(tail) === 4 ? tail : null;
+  const [h1, h2] = tail.split(":");
+  const hi = parseInt(h1, 16), lo = parseInt(h2, 16);
+  return `${hi >> 8}.${hi & 255}.${lo >> 8}.${lo & 255}`;
+}
+
+/**
+ * Allow only http/https to a PUBLIC host. Rejects every address the hostname
+ * resolves to, so a public name can't be pointed at an internal IP. Throws on a
+ * blocked/invalid URL; resolves to void when the URL is safe to fetch.
+ * @param {string} url
+ */
+export async function assertPublicUrl(url) {
+  let u;
+  try { u = new URL(url); } catch { throw new Error("Invalid source URL"); }
+  if (u.protocol !== "http:" && u.protocol !== "https:") {
+    throw new Error("Blocked URL protocol: " + u.protocol);
+  }
+  let host = u.hostname;
+  if (host.startsWith("[") && host.endsWith("]")) host = host.slice(1, -1); // IPv6 brackets
+  if (host.toLowerCase() === "localhost") throw new Error("Blocked host: localhost");
+  const addrs = isIP(host) ? [host] : (await lookup(host, { all: true })).map((r) => r.address);
+  if (!addrs.length) throw new Error("Could not resolve host: " + host);
+  for (const ip of addrs) {
+    if (isBlockedAddress(ip)) throw new Error("Blocked private/loopback address: " + ip);
+  }
+}
+
+/**
+ * SSRF-guarded fetch with a mandatory timeout. Runs assertPublicUrl on the URL
+ * and on EVERY redirect hop, so a chosen public host can't 30x-redirect the
+ * request into loopback/metadata/private space. Returns the final Response as-is
+ * (does NOT throw on a non-2xx status — the caller checks res.ok), so it is a
+ * drop-in for a guarded fetch().
+ *
+ * Redirects are followed MANUALLY (redirect:"manual") rather than by fetch's
+ * default redirect:"follow": the default would chase a 3xx Location without
+ * re-running the guard, which silently undoes every check in this module. Here
+ * each hop's target is re-validated before we connect to it.
+ * @param {string} url
+ * @param {object} [opts]
+ * @param {number} [opts.timeoutMs=12000]     abort the WHOLE operation (all hops) after this many ms
+ * @param {number} [opts.maxRedirects=5]      how many 3xx hops to follow before giving up
+ * @param {object} [opts.headers]             request headers (merged as-is)
+ * @param {RequestInit} [opts.rest]           any other fetch init (method, body, …)
+ * @returns {Promise<Response>}
+ */
+export async function safeFetch(url, { timeoutMs = 12000, maxRedirects = 5, headers, ...rest } = {}) {
+  // One timeout signal bounds the entire operation, redirects included, so a
+  // chain of slow hops can't multiply the deadline.
+  const signal = AbortSignal.timeout(timeoutMs);
+  let current = url;
+  for (let hop = 0; ; hop++) {
+    await assertPublicUrl(current);
+    const res = await fetch(current, {
+      ...rest,
+      headers: headers ?? {},
+      redirect: "manual",
+      signal,
+    });
+    if (res.status >= 300 && res.status < 400 && res.headers.has("location")) {
+      if (hop >= maxRedirects) throw new Error("Too many redirects");
+      const next = new URL(res.headers.get("location"), current).href;
+      // Discard the redirect body so the connection can be freed before the next hop.
+      try { await res.body?.cancel(); } catch { /* no body / already consumed */ }
+      current = next;
+      continue;
+    }
+    return res;
+  }
+}

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/server.mjs
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/server.mjs
@@ -20,6 +20,7 @@ import { createServer } from "node:http";
 import { readFile } from "node:fs/promises";
 import { join, normalize, extname, sep } from "node:path";
 import { fileURLToPath } from "node:url";
+import { validate } from "./validate.mjs";
 
 const KIT_DIR = fileURLToPath(new URL(".", import.meta.url));
 
@@ -53,6 +54,7 @@ export class CanvasKitError extends Error {
  * @param {(domainId:string)=>any|Promise<any>} [config.loadState]
  * @param {(domainId:string, state:any)=>void|Promise<void>} [config.saveState]
  * @param {Record<string,{description?:string,inputSchema?:object,handler:Function}>} config.actions
+ * @param {object} [config.stateSchema]  optional JSON-Schema-subset for the durable state; when set, a mutation that violates it is rolled back and fails (500)
  * @param {string} config.assetsDir  absolute path to the canvas web/ folder
  * @param {(ctx:object,state:any)=>string} [config.statusLine]
  */
@@ -118,8 +120,26 @@ export function createCanvasRuntime(config) {
     if (!action || typeof action.handler !== "function") {
       throw new CanvasKitError("unknown_action", `Unknown action: ${actionName}`);
     }
+    // Enforce the declared inputSchema at the boundary (agent OR ui). The schema
+    // is a contract authors already write; validating it here turns "declared but
+    // unchecked" into a typed boundary and stops a malformed/typo'd payload from
+    // reaching the handler. A shape violation is the CALLER's fault → invalid_input
+    // (HTTP 400). Business rules ("title can't be blank") still live in the handler
+    // and surface as a 500, so a schema-valid-but-empty string reaches the handler.
+    if (action.inputSchema) {
+      const errs = validate(action.inputSchema, input ?? {}, "input");
+      if (errs.length) {
+        throw new CanvasKitError("invalid_input", `Invalid input for '${actionName}': ${errs.join("; ")}`);
+      }
+    }
     const domainId = ctx?.domainId ?? "default";
     const d = await getDomain(domainId, ctx);
+    // Deep snapshot for stateSchema rollback: a handler may mutate state IN PLACE
+    // and return the same object, so a reference copy (prevState = d.state) would
+    // point at the same (now-corrupt) object and restore nothing. structuredClone
+    // gives a real pre-mutation copy. Durable state is JSON-shaped, so it clones
+    // cleanly. Only pay the clone when a stateSchema is actually configured.
+    const prevState = config.stateSchema ? structuredClone(d.state) : undefined;
     let mutated = false;
     const api = {
       get state() { return d.state; },
@@ -161,6 +181,17 @@ export function createCanvasRuntime(config) {
     };
     const result = await action.handler(api);
     if (mutated) {
+      // Optional stateSchema guards the durable shape: if a handler produced an
+      // invalid state, roll back the in-memory mutation and fail LOUD (a 500 —
+      // this is a handler bug, not caller input) instead of persisting/broadcasting
+      // corrupt state. Absent stateSchema, anything goes (opt-in).
+      if (config.stateSchema) {
+        const errs = validate(config.stateSchema, d.state, "state");
+        if (errs.length) {
+          d.state = prevState; // roll back so in-memory stays consistent
+          throw new Error(`Action '${actionName}' produced invalid state: ${errs.join("; ")}`);
+        }
+      }
       if (config.saveState) await config.saveState(domainId, d.state);
       broadcast(domainId);
     }
@@ -307,6 +338,15 @@ export function createCanvasRuntime(config) {
    * @returns {Promise<{url:string,title:string,status?:string}>}
    */
   async function openInstance({ instanceId, input, ctx }) {
+    // Validate the open input against the declared inputSchema (same contract the
+    // actions get). A bad open payload fails fast with invalid_input rather than
+    // silently resolving the wrong domain.
+    if (config.inputSchema) {
+      const errs = validate(config.inputSchema, input ?? {}, "open input");
+      if (errs.length) {
+        throw new CanvasKitError("invalid_input", `Invalid open input: ${errs.join("; ")}`);
+      }
+    }
     const domainId = config.resolveDomainId
       ? config.resolveDomainId(input ?? {}, ctx ?? {}) || "default"
       : "default";

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/storage.mjs
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/storage.mjs
@@ -2,16 +2,59 @@
 //
 // Durable JSON state helpers. State is keyed by a *domain id* (a stable logical
 // identifier resolved from the open input), never by instanceId — per
-// create-canvas/SKILL.md. Two scopes:
+// create-canvas/SKILL.md. Three tiers, matching the Canvas SDK storage model:
 //   userStore      -> $COPILOT_HOME/extensions/<name>/artifacts/<file>   (per user, cross-session)
-//   workspaceStore -> <session.workspacePath>/<file>                     (per session)
+//   sessionStore   -> $COPILOT_HOME/session-state/<sessionId>/extensions/<name>/<file>  (per session, scratch)
+//   workspaceStore -> <session.workspacePath>/<file>                     (rooted at the session workspace)
+//
+// Sandboxing: callers derive the <file> from a domain id that MUST be sanitized
+// to a bare filename (the reference `fileFor` strips everything but
+// [A-Za-z0-9._-]); the store never joins caller input as a path, so a domain id
+// can't escape its extension's artifacts directory.
 
-import { readFile, writeFile, mkdir, rename } from "node:fs/promises";
+import { readFile, writeFile, mkdir, rename, unlink } from "node:fs/promises";
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
+import { randomBytes } from "node:crypto";
 
 function copilotHome() {
   return process.env.COPILOT_HOME || join(homedir(), ".copilot");
+}
+
+// Per-file write queue. Concurrent saves to the SAME durable file (an agent
+// action and a UI action racing) must not overlap: on Windows two renames to the
+// same destination collide with EPERM even with unique temp names. Chaining each
+// save onto the previous one for that path serializes them (last enqueued wins),
+// which is both correct (no interleaved writes) and portable.
+const writeQueues = new Map(); // absolute file path -> tail Promise
+
+async function atomicWrite(file, data) {
+  await mkdir(dirname(file), { recursive: true });
+  // Write to a temp sibling then atomically rename into place, so a crash or
+  // interruption mid-write can never truncate the existing durable file.
+  // rename(2) is atomic on the same filesystem. The temp name mixes pid + time +
+  // RANDOM bytes so two writers can never pick the same temp path.
+  const tmp = `${file}.${process.pid}.${Date.now()}.${randomBytes(6).toString("hex")}.tmp`;
+  await writeFile(tmp, JSON.stringify(data, null, 2), "utf8");
+  try {
+    await rename(tmp, file);
+  } catch (err) {
+    // Windows can transiently EPERM/EACCES a rename when the destination is
+    // briefly held (AV scanner, indexer). Retry once after a short beat; always
+    // clean up our temp so a failed save leaves no orphaned *.tmp behind.
+    if (err?.code === "EPERM" || err?.code === "EACCES") {
+      await new Promise((r) => setTimeout(r, 25));
+      try {
+        await rename(tmp, file);
+      } catch (err2) {
+        await unlink(tmp).catch(() => {});
+        throw err2;
+      }
+    } else {
+      await unlink(tmp).catch(() => {});
+      throw err;
+    }
+  }
 }
 
 function makeStore(file) {
@@ -32,13 +75,15 @@ function makeStore(file) {
       }
     },
     async save(data) {
-      await mkdir(dirname(file), { recursive: true });
-      // Write to a temp sibling then atomically rename into place, so a crash or
-      // interruption mid-write can never truncate the existing durable file.
-      // rename(2) is atomic on the same filesystem.
-      const tmp = `${file}.${process.pid}.${Date.now()}.tmp`;
-      await writeFile(tmp, JSON.stringify(data, null, 2), "utf8");
-      await rename(tmp, file);
+      // Serialize behind any in-flight save for this exact path (see writeQueues).
+      const prev = writeQueues.get(file) ?? Promise.resolve();
+      const run = prev.catch(() => {}).then(() => atomicWrite(file, data));
+      writeQueues.set(file, run);
+      try {
+        await run;
+      } finally {
+        if (writeQueues.get(file) === run) writeQueues.delete(file);
+      }
     },
   };
 }
@@ -46,6 +91,24 @@ function makeStore(file) {
 /** Per-user, cross-session artifact store for a named extension. */
 export function userStore(extensionName, fileName) {
   return makeStore(join(copilotHome(), "extensions", extensionName, "artifacts", fileName));
+}
+
+/**
+ * Per-session scratch store for a named extension, rooted under the session's
+ * state directory. Use for state that should NOT outlive the session (drafts,
+ * one-off working data). Pass the session id (e.g. from the SDK ctx).
+ */
+export function sessionStore(sessionId, extensionName, fileName) {
+  // Reduce the session id to a single safe path segment. The charset filter keeps
+  // "." (so dotted ids survive), so we must ALSO collapse any ".." run — otherwise
+  // a session id of ".." would join to one level ABOVE session-state and escape the
+  // per-session root. (sessionId is normally a trusted SDK value; this keeps the
+  // sanitizer honest regardless.)
+  const safeSession =
+    String(sessionId)
+      .replace(/[^A-Za-z0-9._-]/g, "_")
+      .replace(/\.\.+/g, "_") || "default";
+  return makeStore(join(copilotHome(), "session-state", safeSession, "extensions", extensionName, fileName));
 }
 
 /** Per-session store rooted at the session workspace path. */

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/validate.mjs
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/validate.mjs
@@ -1,0 +1,146 @@
+// canvas-kit/validate.mjs
+//
+// A tiny, dependency-free JSON-Schema-*subset* validator. It exists so the
+// runtime can ENFORCE the action `inputSchema` (and an optional `stateSchema`)
+// that authors already declare — turning the iframe↔extension / agent↔extension
+// contract from "declared but unchecked" into "validated at the boundary". No
+// npm dependency (the kit ships vendored, no install step), and it only covers
+// the JSON Schema features the kit's schemas actually use:
+//
+//   type            "object" | "array" | "string" | "number" | "integer" |
+//                   "boolean" | "null"  (or an array of those)
+//   properties      per-key subschemas (objects)
+//   required        array of required property names (objects)
+//   additionalProperties   false | subschema (objects)
+//   items           subschema for every element (arrays)
+//   enum            allowed literal values (deep-equal)
+//   minLength/maxLength    string length bounds
+//   minimum/maximum        numeric bounds
+//   minItems/maxItems      array length bounds
+//
+// It is intentionally forgiving: an absent/empty schema validates anything, and
+// unknown keywords are ignored (so a richer schema never hard-fails here). The
+// goal is to catch the shape mistakes that actually break canvases — wrong type,
+// missing required field, unknown/typo'd property, out-of-enum value — not to be
+// a complete JSON Schema implementation.
+
+function typeOf(value) {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  if (Number.isInteger(value)) return "integer";
+  return typeof value; // "string" | "number" | "boolean" | "object" | "undefined"
+}
+
+// Does `value` satisfy a single JSON Schema `type` token? "number" accepts
+// integers; "integer" requires a whole number.
+function matchesType(value, t) {
+  const actual = typeOf(value);
+  if (t === "number") return actual === "number" || actual === "integer";
+  if (t === "integer") return actual === "integer";
+  return actual === t;
+}
+
+function deepEqual(a, b) {
+  if (a === b) return true;
+  if (typeof a !== typeof b || a === null || b === null) return false;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return a.length === b.length && a.every((x, i) => deepEqual(x, b[i]));
+  }
+  if (typeof a === "object" && typeof b === "object") {
+    const ak = Object.keys(a), bk = Object.keys(b);
+    return ak.length === bk.length && ak.every((k) => deepEqual(a[k], b[k]));
+  }
+  return false;
+}
+
+/**
+ * Validate `value` against a JSON-Schema-subset `schema`.
+ * @param {object|undefined} schema
+ * @param {any} value
+ * @param {string} [path]  dotted path used in error messages (default "input")
+ * @returns {string[]} human-readable error messages; empty array = valid.
+ */
+export function validate(schema, value, path = "input") {
+  const errors = [];
+  walk(schema, value, path, errors);
+  return errors;
+}
+
+function walk(schema, value, path, errors) {
+  if (!schema || typeof schema !== "object") return; // absent/degenerate schema = anything goes
+
+  // type (single token or array of tokens)
+  if (schema.type !== undefined) {
+    const types = Array.isArray(schema.type) ? schema.type : [schema.type];
+    if (!types.some((t) => matchesType(value, t))) {
+      errors.push(`${path}: expected ${types.join(" | ")}, got ${typeOf(value)}`);
+      return; // a wrong base type makes deeper checks meaningless
+    }
+  }
+
+  // enum
+  if (Array.isArray(schema.enum) && !schema.enum.some((allowed) => deepEqual(allowed, value))) {
+    errors.push(`${path}: must be one of ${schema.enum.map((v) => JSON.stringify(v)).join(", ")}`);
+  }
+
+  const kind = typeOf(value);
+
+  if (kind === "string") {
+    if (typeof schema.minLength === "number" && value.length < schema.minLength) {
+      errors.push(`${path}: must be at least ${schema.minLength} characters`);
+    }
+    if (typeof schema.maxLength === "number" && value.length > schema.maxLength) {
+      errors.push(`${path}: must be at most ${schema.maxLength} characters`);
+    }
+  }
+
+  if (kind === "number" || kind === "integer") {
+    if (typeof schema.minimum === "number" && value < schema.minimum) {
+      errors.push(`${path}: must be >= ${schema.minimum}`);
+    }
+    if (typeof schema.maximum === "number" && value > schema.maximum) {
+      errors.push(`${path}: must be <= ${schema.maximum}`);
+    }
+  }
+
+  if (kind === "array") {
+    if (typeof schema.minItems === "number" && value.length < schema.minItems) {
+      errors.push(`${path}: must have at least ${schema.minItems} item(s)`);
+    }
+    if (typeof schema.maxItems === "number" && value.length > schema.maxItems) {
+      errors.push(`${path}: must have at most ${schema.maxItems} item(s)`);
+    }
+    if (schema.items) {
+      value.forEach((item, i) => walk(schema.items, item, `${path}[${i}]`, errors));
+    }
+  }
+
+  if (kind === "object") {
+    const props = schema.properties ?? {};
+    if (Array.isArray(schema.required)) {
+      for (const key of schema.required) {
+        // Object.hasOwn (not `value[key] === undefined`): a required property
+        // named after a prototype member (e.g. "toString", "constructor") would
+        // otherwise read the inherited value and wrongly pass the check.
+        if (!Object.hasOwn(value, key)) errors.push(`${path}.${key}: required`);
+      }
+    }
+    for (const [key, sub] of Object.entries(props)) {
+      if (Object.hasOwn(value, key)) walk(sub, value[key], `${path}.${key}`, errors);
+    }
+    // Membership is tested with Object.hasOwn, NOT `key in props`: `in` walks the
+    // prototype chain, so an extra key named "toString"/"constructor"/"__proto__"
+    // etc. would satisfy `key in props` and escape additionalProperties. This
+    // validator is the enforcement boundary (input → 400, state → 500), so that
+    // would be a real contract hole.
+    if (schema.additionalProperties === false) {
+      for (const key of Object.keys(value)) {
+        if (!Object.hasOwn(props, key)) errors.push(`${path}.${key}: unexpected property`);
+      }
+    } else if (schema.additionalProperties && typeof schema.additionalProperties === "object") {
+      for (const key of Object.keys(value)) {
+        if (!Object.hasOwn(props, key)) walk(schema.additionalProperties, value[key], `${path}.${key}`, errors);
+      }
+    }
+  }
+}

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/validate.mjs
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/validate.mjs
@@ -19,10 +19,13 @@
 //   minItems/maxItems      array length bounds
 //
 // It is intentionally forgiving: an absent/empty schema validates anything, and
-// unknown keywords are ignored (so a richer schema never hard-fails here). The
-// goal is to catch the shape mistakes that actually break canvases — wrong type,
-// missing required field, unknown/typo'd property, out-of-enum value — not to be
-// a complete JSON Schema implementation.
+// unknown keywords are ignored (so a richer schema never hard-fails here). A
+// property whose value is `undefined` is treated as ABSENT — `undefined` is not a
+// JSON value, so `{ x: undefined }` is equivalent to `{}` once it crosses the
+// agent↔extension / iframe↔extension boundary, and `{ optional }` shorthand with
+// an unset variable must not be rejected. The goal is to catch the shape mistakes
+// that actually break canvases — wrong type, missing required field, unknown/typo'd
+// property, out-of-enum value — not to be a complete JSON Schema implementation.
 
 function typeOf(value) {
   if (value === null) return "null";
@@ -121,24 +124,33 @@ function walk(schema, value, path, errors) {
       for (const key of schema.required) {
         // Object.hasOwn (not `value[key] === undefined`): a required property
         // named after a prototype member (e.g. "toString", "constructor") would
-        // otherwise read the inherited value and wrongly pass the check.
-        if (!Object.hasOwn(value, key)) errors.push(`${path}.${key}: required`);
+        // otherwise read the inherited value and wrongly pass the check. An
+        // explicit `undefined` counts as ABSENT (undefined is not a JSON value, so
+        // { x: undefined } is equivalent to {} once it crosses the wire).
+        if (!Object.hasOwn(value, key) || value[key] === undefined) errors.push(`${path}.${key}: required`);
       }
     }
     for (const [key, sub] of Object.entries(props)) {
-      if (Object.hasOwn(value, key)) walk(sub, value[key], `${path}.${key}`, errors);
+      // Skip absent OR explicitly-undefined optional properties: a caller passing
+      // { article } where `article` is an unset variable is idiomatic JS and, over
+      // a JSON boundary, indistinguishable from omitting the key. Only validate a
+      // property that is actually present with a defined value.
+      if (Object.hasOwn(value, key) && value[key] !== undefined) walk(sub, value[key], `${path}.${key}`, errors);
     }
     // Membership is tested with Object.hasOwn, NOT `key in props`: `in` walks the
     // prototype chain, so an extra key named "toString"/"constructor"/"__proto__"
     // etc. would satisfy `key in props` and escape additionalProperties. This
     // validator is the enforcement boundary (input → 400, state → 500), so that
-    // would be a real contract hole.
+    // would be a real contract hole. An explicit `undefined` value is treated as
+    // absent (see above), so it is never counted as an extra/unexpected property.
     if (schema.additionalProperties === false) {
       for (const key of Object.keys(value)) {
+        if (value[key] === undefined) continue;
         if (!Object.hasOwn(props, key)) errors.push(`${path}.${key}: unexpected property`);
       }
     } else if (schema.additionalProperties && typeof schema.additionalProperties === "object") {
       for (const key of Object.keys(value)) {
+        if (value[key] === undefined) continue;
         if (!Object.hasOwn(props, key)) walk(schema.additionalProperties, value[key], `${path}.${key}`, errors);
       }
     }

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/version.mjs
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/version.mjs
@@ -10,4 +10,4 @@
 // convention (the skill ships as files, not an npm version); a commit short-sha
 // works too. Re-exported from client.mjs so a canvas can read it at runtime.
 
-export const KIT_VERSION = "2026-07-05.1";
+export const KIT_VERSION = "2026-07-07.1";

--- a/skills/create-canvas-app/scripts/new-canvas.mjs
+++ b/skills/create-canvas-app/scripts/new-canvas.mjs
@@ -409,10 +409,9 @@ const DATA_CANVAS_MJS = `// canvas.mjs — {{titleText}} canvas definition (data
 //   * the view polls a "refresh" action on a visibility-gated timer (app.mjs).
 
 import { fileURLToPath } from "node:url";
-import { lookup } from "node:dns/promises";
-import { isIP } from "node:net";
 import { userStore } from "./canvas-kit/storage.mjs";
 import { nid } from "./canvas-kit/format.mjs";
+import { safeFetch } from "./canvas-kit/net.mjs";
 
 const EXT_NAME = "{{name}}";
 
@@ -425,52 +424,17 @@ function fileFor(domainId) {
   return userStore(EXT_NAME, \`\${safe}.json\`);
 }
 
-// SSRF guard: true for loopback, link-local (incl. cloud metadata 169.254.169.254),
-// and private/CGNAT ranges — the targets a server-side fetch should never reach.
-function isBlockedAddress(ip) {
-  const addr = ip.startsWith("::ffff:") ? ip.slice(7) : ip; // unwrap IPv4-mapped IPv6
-  if (isIP(addr) === 4) {
-    const [a, b] = addr.split(".").map(Number);
-    if (a === 0 || a === 127 || a === 10) return true;     // this-host / loopback / private
-    if (a === 169 && b === 254) return true;               // link-local (incl. cloud IMDS)
-    if (a === 172 && b >= 16 && b <= 31) return true;      // private
-    if (a === 192 && b === 168) return true;               // private
-    if (a === 100 && b >= 64 && b <= 127) return true;     // CGNAT
-    return false;
-  }
-  const v6 = addr.toLowerCase();
-  return v6 === "::1" || v6 === "::" || v6.startsWith("fe80") || v6.startsWith("fc") || v6.startsWith("fd");
-}
-
-// Allow only http/https to a PUBLIC host. Rejects every address the hostname
-// resolves to, so a public name can't be pointed at an internal IP.
-async function assertPublicUrl(url) {
-  let u;
-  try { u = new URL(url); } catch { throw new Error("Invalid source URL"); }
-  if (u.protocol !== "http:" && u.protocol !== "https:") {
-    throw new Error("Blocked URL protocol: " + u.protocol);
-  }
-  let host = u.hostname;
-  if (host.startsWith("[") && host.endsWith("]")) host = host.slice(1, -1); // IPv6 brackets
-  if (host.toLowerCase() === "localhost") throw new Error("Blocked host: localhost");
-  const addrs = isIP(host) ? [host] : (await lookup(host, { all: true })).map((r) => r.address);
-  if (!addrs.length) throw new Error("Could not resolve host: " + host);
-  for (const ip of addrs) {
-    if (isBlockedAddress(ip)) throw new Error("Blocked private/loopback address: " + ip);
-  }
-}
-
 async function fetchItems(url) {
   // This runs server-side on the loopback runtime, so a caller-set \`url\` would
-  // otherwise be an unrestricted fetch. Block private/loopback/link-local
-  // targets BEFORE connecting (SSRF guard). A determined attacker could still
-  // DNS-rebind between this check and the fetch; for a local dev tool pointed at
-  // a source you trust this is adequate defense-in-depth. The response still
-  // flows back to the agent, so render fetched fields as TEXT, never innerHTML.
-  await assertPublicUrl(url);
-  const res = await fetch(url, {
+  // otherwise be an unrestricted fetch. The kit's safeFetch() blocks
+  // private/loopback/link-local targets BEFORE connecting (SSRF guard) and
+  // applies a hard timeout so a slow upstream can't hang the panel. A determined
+  // attacker could still DNS-rebind between the check and the fetch; for a local
+  // dev tool pointed at a source you trust this is adequate defense-in-depth. The
+  // response still flows back to the agent, so render fetched fields as TEXT,
+  // never innerHTML.
+  const res = await safeFetch(url, {
     headers: { Accept: "application/json", "User-Agent": "copilot-canvas" },
-    signal: AbortSignal.timeout(12000),
   });
   if (!res.ok) throw new Error(\`HTTP \${res.status}\`);
   return mapItems(await res.json());

--- a/skills/create-canvas-app/test/generator.test.mjs
+++ b/skills/create-canvas-app/test/generator.test.mjs
@@ -288,19 +288,20 @@ async function main() {
       });
     }
 
-    // data-template-specific contract: fetch-in-handler + refresh + poll helper
-    await test("data canvas.mjs fetches in a handler with a timeout + refresh action", async () => {
+    // data-template-specific contract: fetch-in-handler via the kit's guarded
+    // safeFetch + refresh + poll helper
+    await test("data canvas.mjs fetches via the kit's safeFetch (guarded + timeout) + refresh action", async () => {
       const canvas = await read(join(work, "gen-feed", "canvas.mjs"));
-      assert.match(canvas, /await fetch\(/);
-      assert.match(canvas, /AbortSignal\.timeout\(/);
+      assert.match(canvas, /from "\.\/canvas-kit\/net\.mjs"/);
+      assert.match(canvas, /await safeFetch\(/);
       assert.match(canvas, /refresh:\s*\{/);
     });
 
-    await test("data canvas.mjs guards the server-side fetch against SSRF", async () => {
-      const canvas = await read(join(work, "gen-feed", "canvas.mjs"));
-      assert.match(canvas, /await assertPublicUrl\(url\)/);
-      assert.match(canvas, /a === 169 && b === 254/); // link-local / cloud metadata blocked
-      assert.match(canvas, /Blocked private\/loopback address/);
+    await test("kit net.mjs guards the server-side fetch against SSRF (vendored into the canvas)", async () => {
+      const net = await read(join(work, "gen-feed", "canvas-kit", "net.mjs"));
+      assert.match(net, /a === 169 && b === 254/); // link-local / cloud metadata blocked
+      assert.match(net, /Blocked private\/loopback address/);
+      assert.match(net, /AbortSignal\.timeout\(/); // safeFetch applies a hard timeout
     });
 
     await test("data app.mjs uses the visibility-gated poll helper", async () => {

--- a/skills/create-canvas-app/test/http.test.mjs
+++ b/skills/create-canvas-app/test/http.test.mjs
@@ -186,6 +186,15 @@ async function main() {
     assert.equal(body.code, "unknown_action");
   });
 
+  await test("schema-invalid input returns a 400 invalid_input before the handler", async () => {
+    // status is an enum(open|decided|parked); "bogus" violates the inputSchema, so
+    // the runtime rejects it at the boundary (400) instead of running the handler.
+    const { status, body } = await action(open.url, "set_status", { id: "x", status: "bogus" });
+    assert.equal(status, 400);
+    assert.equal(body.ok, false);
+    assert.equal(body.code, "invalid_input");
+  });
+
   await test("handler validation error surfaces as a 500 failure", async () => {
     const { status, body } = await action(open.url, "add_decision", { title: "   " });
     assert.equal(status, 500); // handler throw -> 500 (a kit error like unknown_action is 400)

--- a/skills/create-canvas-app/test/kit-runtime.test.mjs
+++ b/skills/create-canvas-app/test/kit-runtime.test.mjs
@@ -68,6 +68,22 @@ async function main() {
     assert.deepEqual(validate(undefined, { anything: true }), []); // no schema = anything
   });
 
+  await test("validate: an optional property explicitly set to undefined is treated as absent", () => {
+    // { value, article } where `article` is an unset variable is idiomatic JS; over
+    // a JSON boundary `undefined` is dropped, so the validator must NOT type-check it.
+    const schema = {
+      type: "object",
+      properties: { value: { type: "string" }, article: { type: "object" } },
+      required: ["value"],
+      additionalProperties: false,
+    };
+    assert.deepEqual(validate(schema, { value: "up", article: undefined }), [], "undefined optional prop must pass");
+    // A REQUIRED property explicitly set to undefined is still missing.
+    assert.ok(validate(schema, { value: undefined }).some((e) => /value: required/.test(e)));
+    // An UNKNOWN key set to undefined is not an unexpected property (it's absent).
+    assert.deepEqual(validate(schema, { value: "up", bogus: undefined }), [], "undefined unknown key = absent");
+  });
+
   await test("validate: prototype-named keys can't escape additionalProperties (in-operator hole)", () => {
     const schema = { type: "object", properties: { title: { type: "string" } }, additionalProperties: false };
     // These keys all exist on Object.prototype; `key in props` would treat them as

--- a/skills/create-canvas-app/test/kit-runtime.test.mjs
+++ b/skills/create-canvas-app/test/kit-runtime.test.mjs
@@ -1,0 +1,256 @@
+// test/kit-runtime.test.mjs — unit tests for the kit runtime primitives added to
+// enforce the Canvas SDK contract: JSON-schema input/state validation
+// (validate.mjs + server.mjs wiring), the SSRF/egress guard (net.mjs), and the
+// concurrency-safe durable store (storage.mjs). No deps; Node 18+.
+// Run: node test/kit-runtime.test.mjs
+
+import assert from "node:assert/strict";
+import { mkdtemp, rm, readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve, sep } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const KIT = join(ROOT, "kit");
+// Dynamic import() needs a file:// URL on Windows (a bare C:\ path is rejected).
+const imp = (file) => import(pathToFileURL(join(KIT, file)).href);
+
+let passed = 0;
+async function test(name, fn) {
+  try {
+    await fn();
+    passed++;
+    console.log(`  ok  ${name}`);
+  } catch (e) {
+    console.error(`FAIL  ${name}\n      ${e.stack || e.message}`);
+    process.exitCode = 1;
+    throw e;
+  }
+}
+async function throwsAsync(fn, re) {
+  let threw = null;
+  try { await fn(); } catch (e) { threw = e; }
+  assert.ok(threw, "expected the call to throw");
+  if (re) assert.match(String(threw.message), re);
+  return threw;
+}
+
+async function main() {
+  console.log("create-canvas-app kit runtime tests (validate / net / storage)");
+
+  // ---- validate.mjs --------------------------------------------------------
+  const { validate } = await imp("validate.mjs");
+
+  await test("validate: a valid object passes", () => {
+    const schema = { type: "object", properties: { a: { type: "string" } }, required: ["a"], additionalProperties: false };
+    assert.deepEqual(validate(schema, { a: "hi" }), []);
+  });
+
+  await test("validate: missing required + wrong type + unknown prop are all reported", () => {
+    const schema = { type: "object", properties: { a: { type: "string" }, n: { type: "number" } }, required: ["a"], additionalProperties: false };
+    const errs = validate(schema, { n: "not-a-number", extra: 1 });
+    assert.ok(errs.some((e) => /a: required/.test(e)));
+    assert.ok(errs.some((e) => /n: expected number/.test(e)));
+    assert.ok(errs.some((e) => /extra: unexpected property/.test(e)));
+  });
+
+  await test("validate: enum, integer, and array items", () => {
+    assert.ok(validate({ enum: ["open", "done"] }, "nope").length === 1);
+    assert.deepEqual(validate({ type: "integer" }, 3), []);
+    assert.ok(validate({ type: "integer" }, 3.5).length === 1);
+    assert.deepEqual(validate({ type: "array", items: { type: "string" } }, ["a", "b"]), []);
+    assert.ok(validate({ type: "array", items: { type: "string" } }, ["a", 2]).length === 1);
+  });
+
+  await test("validate: bounds (minLength / minimum) and a permissive empty schema", () => {
+    assert.ok(validate({ type: "string", minLength: 2 }, "x").length === 1);
+    assert.ok(validate({ type: "number", minimum: 0 }, -1).length === 1);
+    assert.deepEqual(validate(undefined, { anything: true }), []); // no schema = anything
+  });
+
+  await test("validate: prototype-named keys can't escape additionalProperties (in-operator hole)", () => {
+    const schema = { type: "object", properties: { title: { type: "string" } }, additionalProperties: false };
+    // These keys all exist on Object.prototype; `key in props` would treat them as
+    // declared. Object.hasOwn must reject them as unexpected properties.
+    for (const bad of ["toString", "constructor", "valueOf", "hasOwnProperty", "__proto__"]) {
+      const errs = validate(schema, JSON.parse(`{"title":"ok","${bad}":1}`));
+      assert.ok(errs.some((e) => e.includes(`${bad}: unexpected property`)), `${bad} must be rejected`);
+    }
+    // A prototype-named REQUIRED key that is absent must still be reported missing.
+    assert.ok(validate({ type: "object", required: ["toString"] }, {}).some((e) => /toString: required/.test(e)));
+    // An additionalProperties SUBSCHEMA must apply to a prototype-named extra key.
+    assert.ok(validate({ type: "object", properties: {}, additionalProperties: { type: "number" } }, JSON.parse('{"toString":"x"}')).length === 1);
+  });
+
+  // ---- server.mjs: input + state validation --------------------------------
+  const { createCanvasRuntime, CanvasKitError } = await imp("server.mjs");
+
+  function makeRuntime() {
+    return createCanvasRuntime({
+      id: "t", displayName: "T", description: "", assetsDir: KIT,
+      createInitialState: () => ({ count: 0 }),
+      stateSchema: { type: "object", properties: { count: { type: "integer", minimum: 0 } }, required: ["count"], additionalProperties: false },
+      actions: {
+        set_count: {
+          inputSchema: { type: "object", properties: { count: { type: "integer" } }, required: ["count"], additionalProperties: false },
+          handler: ({ set, input }) => { set((s) => ({ ...s, count: input.count })); return { count: input.count }; },
+        },
+        // Same effect as set_count but MUTATES state in place (returns the same
+        // object) — exercises the stateSchema rollback deep-snapshot path.
+        set_count_inplace: {
+          inputSchema: { type: "object", properties: { count: { type: "integer" } }, required: ["count"], additionalProperties: false },
+          handler: ({ set, input }) => { set((s) => { s.count = input.count; return s; }); return { count: input.count }; },
+        },
+      },
+    });
+  }
+
+  await test("runtime: valid action input passes and mutates state", async () => {
+    const rt = makeRuntime();
+    const res = await rt.invoke("set_count", { count: 5 }, { domainId: "d" });
+    assert.equal(res.count, 5);
+    assert.equal((await rt.getState("d")).count, 5);
+  });
+
+  await test("runtime: bad input type is rejected as invalid_input before the handler", async () => {
+    const rt = makeRuntime();
+    const err = await throwsAsync(() => rt.invoke("set_count", { count: "x" }, { domainId: "d" }), /Invalid input/);
+    assert.ok(err instanceof CanvasKitError);
+    assert.equal(err.code, "invalid_input");
+    assert.equal((await rt.getState("d")).count, 0, "state must be untouched when input is rejected");
+  });
+
+  await test("runtime: unknown property is rejected (additionalProperties:false)", async () => {
+    const rt = makeRuntime();
+    const err = await throwsAsync(() => rt.invoke("set_count", { count: 1, bogus: 2 }, { domainId: "d" }));
+    assert.equal(err.code, "invalid_input");
+  });
+
+  await test("runtime: a handler that produces invalid state is rolled back and fails", async () => {
+    const rt = makeRuntime();
+    await rt.invoke("set_count", { count: 3 }, { domainId: "d" }); // valid baseline
+    // count = -1 violates stateSchema (minimum 0) -> rejected + rolled back.
+    await throwsAsync(() => rt.invoke("set_count", { count: -1 }, { domainId: "d" }), /invalid state/);
+    assert.equal((await rt.getState("d")).count, 3, "state must roll back to the last valid value");
+  });
+
+  await test("runtime: an IN-PLACE mutation that produces invalid state also rolls back", async () => {
+    const rt = makeRuntime();
+    await rt.invoke("set_count_inplace", { count: 3 }, { domainId: "d" }); // valid baseline
+    // In-place mutation to -1 violates stateSchema. A reference-only snapshot would
+    // point at the mutated object and "restore" the corrupt value; a deep snapshot
+    // must bring count back to 3.
+    await throwsAsync(() => rt.invoke("set_count_inplace", { count: -1 }, { domainId: "d" }), /invalid state/);
+    assert.equal((await rt.getState("d")).count, 3, "in-place mutation must roll back to the last valid value");
+  });
+
+  // ---- net.mjs: SSRF / egress guard (offline; IP literals, no DNS) ---------
+  const { isBlockedAddress, assertPublicUrl, safeFetch } = await imp("net.mjs");
+
+  await test("net: isBlockedAddress flags loopback/link-local/private, allows public", () => {
+    for (const ip of ["127.0.0.1", "169.254.169.254", "10.0.0.1", "192.168.1.1", "::1"]) {
+      assert.equal(isBlockedAddress(ip), true, `${ip} should be blocked`);
+    }
+    assert.equal(isBlockedAddress("8.8.8.8"), false);
+  });
+
+  await test("net: assertPublicUrl blocks loopback/metadata/localhost/bad-scheme, allows a public IP", async () => {
+    await throwsAsync(() => assertPublicUrl("http://127.0.0.1/"), /Blocked/);
+    await throwsAsync(() => assertPublicUrl("http://169.254.169.254/"), /Blocked/);
+    await throwsAsync(() => assertPublicUrl("http://localhost/"), /Blocked host/);
+    await throwsAsync(() => assertPublicUrl("ftp://8.8.8.8/"), /protocol/);
+    await assertPublicUrl("http://8.8.8.8/"); // public IP literal — resolves, no DNS, no fetch
+  });
+
+  await test("net: IPv4-mapped IPv6 (hex form new URL normalizes to) is still blocked", async () => {
+    // new URL("http://[::ffff:127.0.0.1]/").hostname -> "[::ffff:7f00:1]"
+    assert.equal(isBlockedAddress("::ffff:7f00:1"), true, "::ffff:7f00:1 = 127.0.0.1");
+    assert.equal(isBlockedAddress("::ffff:a9fe:a9fe"), true, "::ffff:a9fe:a9fe = 169.254.169.254 (IMDS)");
+    assert.equal(isBlockedAddress("::ffff:0808:0808"), false, "::ffff:8.8.8.8 is public");
+    assert.equal(isBlockedAddress("2001:db8::7f00:1"), false, "a public v6 must NOT be misread as 127.0.0.1");
+    // the full path through URL normalization must reject loopback + metadata:
+    await throwsAsync(() => assertPublicUrl("http://[::ffff:127.0.0.1]/"), /Blocked/);
+    await throwsAsync(() => assertPublicUrl("http://[::ffff:169.254.169.254]/latest/meta-data/"), /Blocked/);
+  });
+
+  await test("net: safeFetch refuses a blocked target before connecting", async () => {
+    await throwsAsync(() => safeFetch("http://127.0.0.1:1/"), /Blocked/);
+  });
+
+  await test("net: safeFetch re-checks the guard on every redirect hop (no SSRF via 30x)", async () => {
+    // A public host that 302-redirects to the metadata endpoint must NOT be chased.
+    // Stub fetch to (a) assert we asked for manual redirects and (b) hand back a
+    // 302 -> Location: link-local. safeFetch must re-run assertPublicUrl on the hop
+    // and throw, and must have called fetch exactly once (never reached the target).
+    const realFetch = globalThis.fetch;
+    let calls = 0;
+    let sawManual = false;
+    globalThis.fetch = async (_url, opts) => {
+      calls++;
+      if (opts && opts.redirect === "manual") sawManual = true;
+      return new Response(null, { status: 302, headers: { location: "http://169.254.169.254/latest/meta-data/" } });
+    };
+    try {
+      await throwsAsync(() => safeFetch("http://8.8.8.8/"), /Blocked/);
+      assert.equal(sawManual, true, "safeFetch must request redirect:'manual'");
+      assert.equal(calls, 1, "must not follow the redirect into blocked space");
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  await test("net: safeFetch follows a redirect to another PUBLIC host and returns its response", async () => {
+    const realFetch = globalThis.fetch;
+    let calls = 0;
+    globalThis.fetch = async (url) => {
+      calls++;
+      if (calls === 1) return new Response(null, { status: 302, headers: { location: "http://9.9.9.9/final" } });
+      return new Response("ok", { status: 200 });
+    };
+    try {
+      const res = await safeFetch("http://8.8.8.8/");
+      assert.equal(res.status, 200);
+      assert.equal(calls, 2, "should have followed exactly one hop");
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  // ---- storage.mjs: concurrency-safe save + tiers --------------------------
+  const home = await mkdtemp(join(tmpdir(), "ck-storage-"));
+  process.env.COPILOT_HOME = home;
+  const { userStore, sessionStore } = await imp("storage.mjs");
+
+  await test("storage: concurrent saves to one domain all resolve without EPERM and leave valid JSON", async () => {
+    const store = userStore("concurrency-ext", "d.json");
+    // Fire many saves at once — the old temp name (pid+ms) collided under this,
+    // failing a rename with EPERM on Windows. Unique temp names must fix it.
+    await Promise.all(Array.from({ length: 12 }, (_, i) => store.save({ n: i })));
+    const loaded = await store.load();
+    assert.ok(loaded && typeof loaded.n === "number", "final file is valid JSON");
+    const dir = join(home, "extensions", "concurrency-ext", "artifacts");
+    const leftover = (await readdir(dir)).filter((f) => f.endsWith(".tmp"));
+    assert.deepEqual(leftover, [], "no orphaned .tmp files remain");
+  });
+
+  await test("storage: sessionStore is rooted under session-state/<id>/extensions/<name>", () => {
+    const store = sessionStore("sess-123", "my-ext", "d.json");
+    assert.match(store.file.replace(/\\/g, "/"), /session-state\/sess-123\/extensions\/my-ext\/d\.json$/);
+  });
+
+  await test("storage: sessionStore('..') can't escape the session-state root", () => {
+    // ".." would otherwise join one level above session-state. The sanitizer must
+    // collapse the dot-run so the resolved path stays inside session-state/.
+    const store = sessionStore("..", "my-ext", "d.json");
+    const root = resolve(join(home, "session-state"));
+    assert.ok(
+      resolve(store.file).startsWith(root + sep),
+      `resolved path must stay under session-state (got ${store.file})`,
+    );
+  });
+
+  await rm(home, { recursive: true, force: true });
+  console.log(`\n${passed} checks passed`);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## What

Hardens the `create-canvas-app` canvas-kit so generated canvases enforce the Canvas SDK contract out of the box, and makes the durable store concurrency- and traversal-safe. Bumps `KIT_VERSION` to `2026-07-07.1` and re-syncs the byte-mirror.

## Why

Sync review of the Copilot host app canvas surface found the SDK/theme/authoring contract itself unchanged since our last sync (a verified no-op there), but surfaced gaps in the kit's own server-side safety: unguarded outbound fetch, declared-but-unenforced input/state schemas, and a durable store that could collide under concurrent writes on Windows.

## Changes

- **`kit/net.mjs` (new)** — SSRF/egress guard: `assertPublicUrl` + `isBlockedAddress` + `safeFetch`. Blocks loopback/link-local/metadata/private targets including IPv4-mapped IPv6. `safeFetch` follows redirects **manually** and re-runs the guard on **every hop** under a single shared timeout, so a public host can't `30x`-redirect the request into internal space.
- **`kit/validate.mjs` (new)** — JSON-Schema-subset validator. Uses `Object.hasOwn` (not `key in`) so prototype-named keys can't bypass `additionalProperties`.
- **`kit/server.mjs`** — enforces the declared `inputSchema` at the action **and** open boundary (`invalid_input` → 400); optional `stateSchema` rolls back and fails loud on invalid state. Rollback snapshots via `structuredClone` so **in-place** handler mutations restore correctly.
- **`kit/storage.mjs`** — per-file write queue + unique temp names + one retry to fix concurrent-save `EPERM` on Windows; adds a `sessionStore` tier with a hardened id sanitizer that collapses `..` so a session id can't escape the `session-state` root.
- **Byte-mirror + tests** — mirrored into `reference/decision-log/canvas-kit/` via `sync-kit`; adds `test/kit-runtime.test.mjs` covering validate/net/storage plus regression tests for redirect-SSRF, in-place rollback, and `..` traversal.

## Verification

`npm test` — all groups green locally: 46 (http/generator) + 12 (tooling) + 8 (vendor-lucide) + 19 (kit runtime) checks, byte-mirror parity enforced by `kit-parity`.

## Notes

- `KIT_VERSION` bumped only because kit bytes changed.
- Downstream consumers that vendor the kit should re-run `sync-kit` to pick up `2026-07-07.1`.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>