### PR TITLE
Harden canvas-kit runtime: schema validation, SSRF-safe fetch, storage tiers, security fixes

### DIFF
--- a/skills/create-canvas-app/README.md
+++ b/skills/create-canvas-app/README.md
@@ -174,8 +174,10 @@ from jongio/copilot-extensions/extensions/stock-ticker."* No clone, no build.
 SKILL.md                      The Copilot skill (authoring contract + workflow)
 kit/                          The canonical kit — copy into your extension as canvas-kit/
   client.mjs                  Browser runtime: html, mountCanvas, pollWhileVisible, hooks, Icon, formatters, deep-link builders
-  server.mjs                  SDK-free runtime: /state, /events (SSE), /action, static
-  storage.mjs                 Durable per-user JSON store
+  server.mjs                  SDK-free runtime: /state, /events (SSE), /action, static, inputSchema/stateSchema validation
+  storage.mjs                 Durable JSON store — userStore / sessionStore / workspaceStore (atomic, concurrency-safe writes)
+  validate.mjs                Dependency-free JSON-Schema-subset validator (enforces action inputSchema + stateSchema)
+  net.mjs                     Server-side egress guard: assertPublicUrl / isBlockedAddress / safeFetch (SSRF-safe fetch + timeout)
   format.mjs                  nid + relativeTime / compactNumber / percent helpers
   deeplinks.mjs               github-app deep-link builders (ghapp://) + safe URL / prompt helpers
   theme.css                   Primer-token styling (ck-* classes)
@@ -194,26 +196,30 @@ scripts/
   install-local.ps1           Install this skill into $COPILOT_HOME/skills
 test/
   http.test.mjs               Boots the runtime over real HTTP and checks the contract
+  client.test.mjs             Unit-tests the DOM-free client transport (connectCanvas): /state, SSE, invoke
   kit-parity.test.mjs         Asserts kit/ == reference canvas-kit/ (no drift)
   deeplinks.test.mjs          Checks the ghapp:// builders: validation, encoding, injection resistance
   generator.test.mjs          Stamps the list/data/ai templates, runs their smoke tests, checks the kit API
   tooling.test.mjs            Exercises the version stamp, sync-kit, and the freshness drift gate
   vendor-lucide.test.mjs      Checks the Lucide vendoring generator (sorting, key-strip, determinism)
+  kit-runtime.test.mjs        Checks input/state schema validation, the net.mjs SSRF guard, and concurrency-safe storage
 ```
 
 ## Run the tests
 
 ```sh
 node test/http.test.mjs
+node test/client.test.mjs
 node test/kit-parity.test.mjs
 node test/deeplinks.test.mjs
 node test/generator.test.mjs
 node test/tooling.test.mjs
 node test/vendor-lucide.test.mjs
+node test/kit-runtime.test.mjs
 ```
 
 No dependencies to install — everything is vendored. Node 18+ (developed on 24).
-`npm test` runs all six in sequence.
+`npm test` runs all eight in sequence.
 
 ## License
 

--- a/skills/create-canvas-app/SKILL.md
+++ b/skills/create-canvas-app/SKILL.md
@@ -55,6 +55,12 @@ web/app.mjs     ── your Preact view
   open input (`resolveDomainId`), **not** by `instanceId` — open the same domain
   in two panels and they show the same data. Persistence goes through
   `userStore(extName, file)` → `$COPILOT_HOME/extensions/<name>/artifacts/<domain>.json`.
+  Two more tiers exist in `kit/storage.mjs` for non-durable/scoped state:
+  `sessionStore(sessionId, extName, file)` (per-session scratch, discarded with
+  the session) and `workspaceStore(workspacePath, file)` (rooted at the session
+  workspace). All three write atomically (temp + rename) and **serialize
+  concurrent saves to the same file**, so a racing agent + UI save can't corrupt
+  or `EPERM` the durable file.
 - **Agent and UI share handlers.** An action invoked by the agent and the same
   action invoked from a button run the identical handler and produce the identical
   state mutation. Write the logic once, in `canvas.mjs`.
@@ -87,6 +93,22 @@ invocation in the same envelope, so model failures deliberately:
 - For an **expected, transient** failure (a flaky upstream fetch on a background
   poll), don't throw — capture it into `state.error` and **return** so the error
   card shows while the poll stays quiet (see the data template's `refresh`).
+
+### Input & state are schema-validated at the boundary
+
+An action's `inputSchema` is **enforced by the runtime**, not just declared: a
+payload that violates it (wrong type, missing required field, out-of-enum value,
+or an unexpected property under `additionalProperties: false`) is rejected with
+an `invalid_input` error (**HTTP 400**) *before* your handler runs — from the
+agent side too. So `inputSchema` is your typed contract; write it precisely and
+your handler only sees well-shaped input. **Business rules still live in the
+handler** (a schema-valid but empty `"   "` title reaches the handler, which
+throws → 500). Open input is validated against `config.inputSchema` the same way.
+
+Optionally set `config.stateSchema` (same JSON-Schema subset, `kit/validate.mjs`)
+to guard the **durable shape**: if a handler produces state that violates it, the
+mutation is rolled back and the action fails loud (500) instead of persisting
+corrupt state. It's opt-in — omit it and any state shape is allowed.
 
 ## Icons — official GitHub Lucide, always
 
@@ -172,23 +194,29 @@ Most real canvases aren't user-entered CRUD lists; they pull from the network an
 refresh. The shape:
 
 1. **`fetch()` lives in the action handler (or a helper it calls), never in the
-   view.** Always bound it with a timeout so a slow upstream can't hang the panel:
+   view.** Use the kit's **`safeFetch`** — it SSRF-guards the URL and applies a
+   hard timeout, so a caller-influenced source can't reach the internal network
+   and a slow upstream can't hang the panel:
 
    ```js
+   import { safeFetch } from "./canvas-kit/net.mjs";
+
    async function fetchItems(url) {
-     const res = await fetch(url, { signal: AbortSignal.timeout(12000) });
+     const res = await safeFetch(url, { headers: { Accept: "application/json" } });
      if (!res.ok) throw new Error(`HTTP ${res.status}`);
      return mapItems(await res.json());
    }
    ```
 
-   The fetch runs server-side on the loopback runtime, so the generated `data`
-   template guards it with an **SSRF check**: it allows only `http`/`https` to a
-   **public** host and rejects loopback, link-local (incl. cloud metadata), and
-   private ranges — including every address the hostname resolves to. Anything
-   you feed back to the agent (e.g. via `list_items`) is still attacker-influenced
-   text, so keep the source one *you* choose and treat fetched content as
-   untrusted (render it as text, never `innerHTML`).
+   `safeFetch` runs server-side on the loopback runtime, so it enforces an **SSRF
+   guard** (`kit/net.mjs`): it allows only `http`/`https` to a **public** host and
+   rejects loopback, link-local (incl. cloud metadata), and private ranges —
+   including every address the hostname resolves to — then fetches with an
+   `AbortSignal.timeout`. `assertPublicUrl(url)` / `isBlockedAddress(ip)` are also
+   exported if you need the check without the fetch. Anything you feed back to the
+   agent (e.g. via `list_items`) is still attacker-influenced text, so keep the
+   source one *you* choose and treat fetched content as untrusted (render it as
+   text, never `innerHTML`).
 
 2. **Expose a `refresh` action** that fetches and writes the result into shared
    state. Capture failures into `state.error` and *return* (don't throw) so a
@@ -487,9 +515,10 @@ out-of-band, so it never counts against `kit/` ↔ `canvas-kit/` parity.
 A canvas isn't done because the server boots. Verify the UI:
 
 1. Run the standalone HTTP test to prove the runtime contract:
-   `node test/http.test.mjs` (and `node test/kit-parity.test.mjs`,
+   `node test/http.test.mjs` (and `node test/client.test.mjs`,
+   `node test/kit-parity.test.mjs`,
    `node test/generator.test.mjs`, `node test/tooling.test.mjs`,
-   `node test/vendor-lucide.test.mjs`). A stamped canvas
+   `node test/vendor-lucide.test.mjs`, `node test/kit-runtime.test.mjs`). A stamped canvas
    ships its own `test/smoke.test.mjs` — run it from the canvas folder
    (`node test/smoke.test.mjs`) to prove its actions over real HTTP.
 2. Open the canvas and **look at it** (Playwright or the browser canvas):
@@ -513,6 +542,10 @@ A canvas isn't done because the server boots. Verify the UI:
 - `test/http.test.mjs` — boots the SDK-free runtime over real HTTP and checks
   `/state`, `/events`, `/action`, static serving, path-traversal safety, and the
   host-model actions (offline-error capture + a wired-host stub).
+- `test/client.test.mjs` — unit-tests the DOM-free client transport
+  (`connectCanvas`): the initial `/state` fetch, SSE state pushes + connected flag,
+  and `invoke` → `POST /action` (result + `CanvasActionError` on failure), with
+  stubbed `fetch`/`EventSource` (no browser needed).
 - `test/kit-parity.test.mjs` — guarantees `kit/` and the reference's bundled
   `canvas-kit/` stay byte-identical.
 - `test/deeplinks.test.mjs` — checks the `ghapp://` builders: input validation
@@ -524,6 +557,11 @@ A canvas isn't done because the server boots. Verify the UI:
   `scripts/sync-kit.mjs`, and the offline `scripts/check-kit-freshness.mjs` drift gate.
 - `test/vendor-lucide.test.mjs` — checks the Lucide vendoring generator
   (`scripts/vendor-lucide.mjs`): sorting, `key`-strip, alias mapping, determinism.
+- `test/kit-runtime.test.mjs` — exercises the runtime hardening: `kit/validate.mjs`
+  input/`stateSchema` validation (incl. prototype-key safety), the `kit/net.mjs`
+  SSRF guard (`assertPublicUrl`/`safeFetch`, IPv4-mapped-IPv6 forms), concurrency-safe
+  `kit/storage.mjs` saves + `sessionStore`, prototype-safe `kit/icons.mjs` name
+  resolution, and the server's bounded SSE subscriber cap.
 
 ## Footguns
 

--- a/skills/create-canvas-app/kit/client.mjs
+++ b/skills/create-canvas-app/kit/client.mjs
@@ -85,6 +85,74 @@ export function pollWhileVisible(tick, seconds, { whenVisible = true, immediate 
 }
 
 /**
+ * DOM-FREE transport for a canvas: owns the loopback wiring (GET /state, GET
+ * /events SSE, POST /action) and the derived `state`/`connected`, with no Preact
+ * and no DOM. `mountCanvas` composes this with a render loop; keeping it separate
+ * makes the reconnect/invoke glue unit-testable without a browser (see
+ * test/client.test.mjs). Both callbacks receive the latest `(state, connected)`.
+ * @param {object} [opts]
+ * @param {(state:any, connected:boolean)=>void} [opts.onState]      fired on the initial /state and every SSE push
+ * @param {(connected:boolean)=>void} [opts.onConnected]             fired when the SSE stream opens/errors
+ * @param {typeof EventSource} [opts.EventSourceImpl]                override the SSE impl (tests); defaults to the global
+ * @returns {{invoke:Function, refresh:Function, get state():any, get connected():boolean}}
+ */
+export function connectCanvas({ onState, onConnected, EventSourceImpl } = {}) {
+  let state = null;
+  let connected = false;
+  const ES = EventSourceImpl || (typeof EventSource !== "undefined" ? EventSource : null);
+
+  async function invoke(actionName, input) {
+    const res = await fetch("./action", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ actionName, input: input ?? {} }),
+    });
+    const data = await res.json().catch(() => ({ ok: false }));
+    if (!data.ok) {
+      throw new CanvasActionError(data.code || "error", data.message || "action failed");
+    }
+    return data.result;
+  }
+
+  async function refresh() {
+    try {
+      state = await (await fetch("./state")).json();
+      onState?.(state, connected);
+    } catch { /* offline; SSE will recover */ }
+  }
+
+  function connect() {
+    if (!ES) return; // no EventSource (e.g. a non-browser host); refresh() still works
+    const es = new ES("./events");
+    es.onmessage = (e) => {
+      let next;
+      try {
+        next = JSON.parse(e.data);
+      } catch {
+        return; // ignore a malformed SSE frame; the next push recovers
+      }
+      // Update OUTSIDE the try so a bug in onState surfaces as a real error
+      // instead of being silently mislabeled a "malformed frame".
+      state = next;
+      connected = true;
+      onState?.(state, connected);
+    };
+    es.onopen = () => { connected = true; onConnected?.(connected); };
+    es.onerror = () => { connected = false; onConnected?.(connected); /* EventSource auto-reconnects */ };
+  }
+
+  refresh();
+  connect();
+
+  return {
+    invoke,
+    refresh,
+    get state() { return state; },
+    get connected() { return connected; },
+  };
+}
+
+/**
  * Mount a canvas view and keep it live.
  * @param {object} opts
  * @param {(model:{state:any, invoke:Function, connected:boolean})=>any} opts.view
@@ -102,56 +170,29 @@ export function mountCanvas({ view, mount, onState, poll } = {}) {
   // HTML shell) would linger as a sibling. Clear it once so Preact owns an empty
   // root; the view's own loading branch covers the gap until first state.
   root.replaceChildren();
-  let state = null;
-  let connected = false;
 
-  async function invoke(actionName, input) {
-    const res = await fetch("./action", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ actionName, input: input ?? {} }),
-    });
-    const data = await res.json().catch(() => ({ ok: false }));
-    if (!data.ok) {
-      throw new CanvasActionError(data.code || "error", data.message || "action failed");
-    }
-    return data.result;
-  }
+  let latestState = null;
+  let latestConnected = false;
+  let client;
 
   function rerender() {
-    render(view({ state, invoke, connected }), root);
+    render(view({ state: latestState, invoke: client.invoke, connected: latestConnected }), root);
   }
 
-  async function refresh() {
-    try {
-      state = await (await fetch("./state")).json();
+  // The transport is DOM-free (connectCanvas); this wrapper only adds the Preact
+  // render on each state/connection change.
+  client = connectCanvas({
+    onState: (state, connected) => {
+      latestState = state;
+      latestConnected = connected;
       onState?.(state);
       rerender();
-    } catch { /* offline; SSE will recover */ }
-  }
-
-  function connect() {
-    const es = new EventSource("./events");
-    es.onmessage = (e) => {
-      let next;
-      try {
-        next = JSON.parse(e.data);
-      } catch {
-        return; // ignore a malformed SSE frame; the next push recovers
-      }
-      // Update + render OUTSIDE the try so a bug in onState/the view surfaces as
-      // a real error instead of being silently mislabeled a "malformed frame".
-      state = next;
-      connected = true;
-      onState?.(state);
+    },
+    onConnected: (connected) => {
+      latestConnected = connected;
       rerender();
-    };
-    es.onopen = () => { connected = true; rerender(); };
-    es.onerror = () => { connected = false; rerender(); /* EventSource auto-reconnects */ };
-  }
-
-  refresh();
-  connect();
+    },
+  });
 
   // Built-in fixed-interval auto-refresh, delegating to the shared
   // visibility-gated primitive. Pass `poll: { action, seconds, immediate }`.
@@ -164,7 +205,7 @@ export function mountCanvas({ view, mount, onState, poll } = {}) {
   // @property {boolean} [immediate=false]   fire one tick right after mount
   function startPoll({ action, seconds, input, whenVisible = true, immediate = false } = {}) {
     return pollWhileVisible(
-      () => (action ? invoke(action, input) : refresh()),
+      () => (action ? client.invoke(action, input) : client.refresh()),
       seconds,
       { whenVisible, immediate }
     );
@@ -174,10 +215,10 @@ export function mountCanvas({ view, mount, onState, poll } = {}) {
   if (poll) stopPoll = startPoll(poll);
 
   return {
-    invoke,
-    refresh,
+    invoke: client.invoke,
+    refresh: client.refresh,
     stopPoll: () => stopPoll(),
-    get state() { return state; },
+    get state() { return latestState; },
   };
 }
 

--- a/skills/create-canvas-app/kit/icons.mjs
+++ b/skills/create-canvas-app/kit/icons.mjs
@@ -23,7 +23,18 @@ const VIEWBOX = "0 0 24 24";
 const STROKE_WIDTH = 2;
 
 function resolve(name) {
-  return LUCIDE[name] || LUCIDE[aliases[name]] || null;
+  // Own-property lookups only. Bracket access on a plain object reaches inherited
+  // Object.prototype members, so a name like "toString"/"constructor"/
+  // "hasOwnProperty" would otherwise resolve to a function (making hasIcon() lie
+  // and Icon()/lucideSVG() throw in nodeToString). Object.hasOwn keeps resolution
+  // to the real, vendored icon set.
+  if (typeof name !== "string") return null;
+  if (Object.hasOwn(LUCIDE, name)) return LUCIDE[name];
+  if (Object.hasOwn(aliases, name)) {
+    const target = aliases[name];
+    if (Object.hasOwn(LUCIDE, target)) return LUCIDE[target];
+  }
+  return null;
 }
 
 function kebab(k) {

--- a/skills/create-canvas-app/kit/net.mjs
+++ b/skills/create-canvas-app/kit/net.mjs
@@ -1,0 +1,103 @@
+// canvas-kit/net.mjs
+//
+// Server-side network safety for canvases that fetch external data. A canvas
+// action runs on the loopback runtime with the app's network reach, so a
+// caller-influenced URL is an SSRF risk: it could target cloud metadata
+// (169.254.169.254), loopback, or the private network. This module is the kit's
+// sanctioned egress primitive — validate a URL, then fetch it with a hard
+// timeout — so every data canvas guards the same way instead of re-inlining the
+// check. SERVER-ONLY (uses node:dns / node:net): import it from the SDK-free
+// canvas.mjs, never from the browser view.
+//
+// Defense-in-depth, not a guarantee: a determined attacker could DNS-rebind
+// between the resolve check and the connect. For a canvas pointed at a source
+// you choose this is adequate; treat any fetched content as untrusted and render
+// it as TEXT (never innerHTML).
+
+import { lookup } from "node:dns/promises";
+import { isIP } from "node:net";
+
+/**
+ * True for addresses a server-side fetch should never reach: loopback,
+ * link-local (incl. cloud metadata 169.254.169.254), and private/CGNAT ranges.
+ * @param {string} ip
+ * @returns {boolean}
+ */
+export function isBlockedAddress(ip) {
+  const lower = ip.toLowerCase();
+  // Decode an IPv4-mapped/compatible IPv6 literal down to its embedded IPv4 so
+  // the IPv4 range checks apply. Covers BOTH the dotted tail (::ffff:127.0.0.1)
+  // and the HEX tail that `new URL()` normalizes literals to (::ffff:7f00:1) —
+  // without the decode, `[::ffff:127.0.0.1]` reaches loopback and
+  // `[::ffff:a9fe:a9fe]` reaches cloud metadata. Only matches when the high bits
+  // are all zero (leading "::"), so a normal public v6 (e.g. 2001:db8::7f00:1) is
+  // never misread as IPv4.
+  const addr = embeddedIPv4(lower) ?? ip;
+  if (isIP(addr) === 4) {
+    const [a, b] = addr.split(".").map(Number);
+    if (a === 0 || a === 127 || a === 10) return true;     // this-host / loopback / private
+    if (a === 169 && b === 254) return true;               // link-local (incl. cloud IMDS)
+    if (a === 172 && b >= 16 && b <= 31) return true;      // private
+    if (a === 192 && b === 168) return true;               // private
+    if (a === 100 && b >= 64 && b <= 127) return true;     // CGNAT
+    return false;
+  }
+  return lower === "::1" || lower === "::" || lower.startsWith("fe80") || lower.startsWith("fc") || lower.startsWith("fd");
+}
+
+// Decode an IPv4-mapped/compatible IPv6 literal (all-zero high groups, i.e. a
+// leading "::", optionally "::ffff:") to its dotted IPv4; else null. Accepts the
+// dotted tail (127.0.0.1) and the two-hex-group tail (7f00:1) that URL
+// normalization produces. Anchored on "::" so it can't misread a public v6.
+function embeddedIPv4(addr) {
+  const m = addr.match(/^::(?:ffff:)?((?:\d{1,3}\.){3}\d{1,3}|[0-9a-f]{1,4}:[0-9a-f]{1,4})$/);
+  if (!m) return null;
+  const tail = m[1];
+  if (tail.includes(".")) return isIP(tail) === 4 ? tail : null;
+  const [h1, h2] = tail.split(":");
+  const hi = parseInt(h1, 16), lo = parseInt(h2, 16);
+  return `${hi >> 8}.${hi & 255}.${lo >> 8}.${lo & 255}`;
+}
+
+/**
+ * Allow only http/https to a PUBLIC host. Rejects every address the hostname
+ * resolves to, so a public name can't be pointed at an internal IP. Throws on a
+ * blocked/invalid URL; resolves to void when the URL is safe to fetch.
+ * @param {string} url
+ */
+export async function assertPublicUrl(url) {
+  let u;
+  try { u = new URL(url); } catch { throw new Error("Invalid source URL"); }
+  if (u.protocol !== "http:" && u.protocol !== "https:") {
+    throw new Error("Blocked URL protocol: " + u.protocol);
+  }
+  let host = u.hostname;
+  if (host.startsWith("[") && host.endsWith("]")) host = host.slice(1, -1); // IPv6 brackets
+  if (host.toLowerCase() === "localhost") throw new Error("Blocked host: localhost");
+  const addrs = isIP(host) ? [host] : (await lookup(host, { all: true })).map((r) => r.address);
+  if (!addrs.length) throw new Error("Could not resolve host: " + host);
+  for (const ip of addrs) {
+    if (isBlockedAddress(ip)) throw new Error("Blocked private/loopback address: " + ip);
+  }
+}
+
+/**
+ * SSRF-guarded fetch with a mandatory timeout. Runs assertPublicUrl(url) first,
+ * then fetch() with an AbortSignal.timeout so a slow upstream can't hang the
+ * panel. Returns the Response as-is (does NOT throw on a non-2xx status — the
+ * caller checks res.ok), so it is a drop-in for a guarded fetch().
+ * @param {string} url
+ * @param {object} [opts]
+ * @param {number} [opts.timeoutMs=12000]  abort the request after this many ms
+ * @param {object} [opts.headers]          request headers (merged as-is)
+ * @param {RequestInit} [opts.rest]        any other fetch init (method, body, …)
+ * @returns {Promise<Response>}
+ */
+export async function safeFetch(url, { timeoutMs = 12000, headers, ...rest } = {}) {
+  await assertPublicUrl(url);
+  return fetch(url, {
+    ...rest,
+    headers: headers ?? {},
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+}

--- a/skills/create-canvas-app/kit/server.mjs
+++ b/skills/create-canvas-app/kit/server.mjs
@@ -20,6 +20,7 @@ import { createServer } from "node:http";
 import { readFile } from "node:fs/promises";
 import { join, normalize, extname, sep } from "node:path";
 import { fileURLToPath } from "node:url";
+import { validate } from "./validate.mjs";
 
 const KIT_DIR = fileURLToPath(new URL(".", import.meta.url));
 
@@ -53,6 +54,7 @@ export class CanvasKitError extends Error {
  * @param {(domainId:string)=>any|Promise<any>} [config.loadState]
  * @param {(domainId:string, state:any)=>void|Promise<void>} [config.saveState]
  * @param {Record<string,{description?:string,inputSchema?:object,handler:Function}>} config.actions
+ * @param {object} [config.stateSchema]  optional JSON-Schema-subset for the durable state; when set, a mutation that violates it is rolled back and fails (500)
  * @param {string} config.assetsDir  absolute path to the canvas web/ folder
  * @param {(ctx:object,state:any)=>string} [config.statusLine]
  */
@@ -114,12 +116,32 @@ export function createCanvasRuntime(config) {
 
   // Core action invoker — the single code path behind both agent and UI actions.
   async function invoke(actionName, input, ctx) {
-    const action = config.actions[actionName];
+    // Own-property lookup: `config.actions[actionName]` via bracket access would
+    // otherwise reach inherited members (e.g. "constructor", "toString"). The
+    // handler-typeof check below already rejects those, but resolving by
+    // Object.hasOwn keeps the boundary explicit and consistent with validate.mjs.
+    const action =
+      typeof actionName === "string" && Object.hasOwn(config.actions, actionName)
+        ? config.actions[actionName]
+        : null;
     if (!action || typeof action.handler !== "function") {
       throw new CanvasKitError("unknown_action", `Unknown action: ${actionName}`);
     }
+    // Enforce the declared inputSchema at the boundary (agent OR ui). The schema
+    // is a contract authors already write; validating it here turns "declared but
+    // unchecked" into a typed boundary and stops a malformed/typo'd payload from
+    // reaching the handler. A shape violation is the CALLER's fault → invalid_input
+    // (HTTP 400). Business rules ("title can't be blank") still live in the handler
+    // and surface as a 500, so a schema-valid-but-empty string reaches the handler.
+    if (action.inputSchema) {
+      const errs = validate(action.inputSchema, input ?? {}, "input");
+      if (errs.length) {
+        throw new CanvasKitError("invalid_input", `Invalid input for '${actionName}': ${errs.join("; ")}`);
+      }
+    }
     const domainId = ctx?.domainId ?? "default";
     const d = await getDomain(domainId, ctx);
+    const prevState = d.state; // snapshot for stateSchema rollback (below)
     let mutated = false;
     const api = {
       get state() { return d.state; },
@@ -161,6 +183,17 @@ export function createCanvasRuntime(config) {
     };
     const result = await action.handler(api);
     if (mutated) {
+      // Optional stateSchema guards the durable shape: if a handler produced an
+      // invalid state, roll back the in-memory mutation and fail LOUD (a 500 —
+      // this is a handler bug, not caller input) instead of persisting/broadcasting
+      // corrupt state. Absent stateSchema, anything goes (opt-in).
+      if (config.stateSchema) {
+        const errs = validate(config.stateSchema, d.state, "state");
+        if (errs.length) {
+          d.state = prevState; // roll back so in-memory stays consistent
+          throw new Error(`Action '${actionName}' produced invalid state: ${errs.join("; ")}`);
+        }
+      }
       if (config.saveState) await config.saveState(domainId, d.state);
       broadcast(domainId);
     }
@@ -202,6 +235,12 @@ export function createCanvasRuntime(config) {
   // local client can't force unbounded memory growth on the loopback runtime.
   const MAX_BODY_BYTES = 1 << 20; // 1 MiB
 
+  // Cap concurrent SSE subscribers PER INSTANCE. A canvas panel needs only one
+  // /events stream (a couple across reopens); a runaway reconnect loop or a
+  // hostile local process hitting the loopback port could otherwise accumulate
+  // unbounded response handles + keep-alive timers. 64 is far above any real use.
+  const MAX_SSE_CLIENTS = 64;
+
   function readBody(req) {
     return new Promise((resolve, reject) => {
       const chunks = [];
@@ -240,6 +279,13 @@ export function createCanvasRuntime(config) {
 
       // GET /events — Server-Sent Events stream of state
       if (req.method === "GET" && path === "/events") {
+        // Refuse once an instance is saturated, so subscribers can't grow without
+        // bound (each holds a response handle + a keep-alive interval).
+        if (inst && inst.clients.size >= MAX_SSE_CLIENTS) {
+          res.writeHead(503, { "Content-Type": "text/plain", "Retry-After": "5" });
+          res.end("too many event subscribers");
+          return;
+        }
         res.writeHead(200, {
           "Content-Type": "text/event-stream",
           "Cache-Control": "no-cache",
@@ -307,6 +353,15 @@ export function createCanvasRuntime(config) {
    * @returns {Promise<{url:string,title:string,status?:string}>}
    */
   async function openInstance({ instanceId, input, ctx }) {
+    // Validate the open input against the declared inputSchema (same contract the
+    // actions get). A bad open payload fails fast with invalid_input rather than
+    // silently resolving the wrong domain.
+    if (config.inputSchema) {
+      const errs = validate(config.inputSchema, input ?? {}, "open input");
+      if (errs.length) {
+        throw new CanvasKitError("invalid_input", `Invalid open input: ${errs.join("; ")}`);
+      }
+    }
     const domainId = config.resolveDomainId
       ? config.resolveDomainId(input ?? {}, ctx ?? {}) || "default"
       : "default";

--- a/skills/create-canvas-app/kit/storage.mjs
+++ b/skills/create-canvas-app/kit/storage.mjs
@@ -2,16 +2,59 @@
 //
 // Durable JSON state helpers. State is keyed by a *domain id* (a stable logical
 // identifier resolved from the open input), never by instanceId — per
-// create-canvas/SKILL.md. Two scopes:
+// create-canvas/SKILL.md. Three tiers, matching the Canvas SDK storage model:
 //   userStore      -> $COPILOT_HOME/extensions/<name>/artifacts/<file>   (per user, cross-session)
-//   workspaceStore -> <session.workspacePath>/<file>                     (per session)
+//   sessionStore   -> $COPILOT_HOME/session-state/<sessionId>/extensions/<name>/<file>  (per session, scratch)
+//   workspaceStore -> <session.workspacePath>/<file>                     (rooted at the session workspace)
+//
+// Sandboxing: callers derive the <file> from a domain id that MUST be sanitized
+// to a bare filename (the reference `fileFor` strips everything but
+// [A-Za-z0-9._-]); the store never joins caller input as a path, so a domain id
+// can't escape its extension's artifacts directory.
 
-import { readFile, writeFile, mkdir, rename } from "node:fs/promises";
+import { readFile, writeFile, mkdir, rename, unlink } from "node:fs/promises";
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
+import { randomBytes } from "node:crypto";
 
 function copilotHome() {
   return process.env.COPILOT_HOME || join(homedir(), ".copilot");
+}
+
+// Per-file write queue. Concurrent saves to the SAME durable file (an agent
+// action and a UI action racing) must not overlap: on Windows two renames to the
+// same destination collide with EPERM even with unique temp names. Chaining each
+// save onto the previous one for that path serializes them (last enqueued wins),
+// which is both correct (no interleaved writes) and portable.
+const writeQueues = new Map(); // absolute file path -> tail Promise
+
+async function atomicWrite(file, data) {
+  await mkdir(dirname(file), { recursive: true });
+  // Write to a temp sibling then atomically rename into place, so a crash or
+  // interruption mid-write can never truncate the existing durable file.
+  // rename(2) is atomic on the same filesystem. The temp name mixes pid + time +
+  // RANDOM bytes so two writers can never pick the same temp path.
+  const tmp = `${file}.${process.pid}.${Date.now()}.${randomBytes(6).toString("hex")}.tmp`;
+  await writeFile(tmp, JSON.stringify(data, null, 2), "utf8");
+  try {
+    await rename(tmp, file);
+  } catch (err) {
+    // Windows can transiently EPERM/EACCES a rename when the destination is
+    // briefly held (AV scanner, indexer). Retry once after a short beat; always
+    // clean up our temp so a failed save leaves no orphaned *.tmp behind.
+    if (err?.code === "EPERM" || err?.code === "EACCES") {
+      await new Promise((r) => setTimeout(r, 25));
+      try {
+        await rename(tmp, file);
+      } catch (err2) {
+        await unlink(tmp).catch(() => {});
+        throw err2;
+      }
+    } else {
+      await unlink(tmp).catch(() => {});
+      throw err;
+    }
+  }
 }
 
 function makeStore(file) {
@@ -32,13 +75,15 @@ function makeStore(file) {
       }
     },
     async save(data) {
-      await mkdir(dirname(file), { recursive: true });
-      // Write to a temp sibling then atomically rename into place, so a crash or
-      // interruption mid-write can never truncate the existing durable file.
-      // rename(2) is atomic on the same filesystem.
-      const tmp = `${file}.${process.pid}.${Date.now()}.tmp`;
-      await writeFile(tmp, JSON.stringify(data, null, 2), "utf8");
-      await rename(tmp, file);
+      // Serialize behind any in-flight save for this exact path (see writeQueues).
+      const prev = writeQueues.get(file) ?? Promise.resolve();
+      const run = prev.catch(() => {}).then(() => atomicWrite(file, data));
+      writeQueues.set(file, run);
+      try {
+        await run;
+      } finally {
+        if (writeQueues.get(file) === run) writeQueues.delete(file);
+      }
     },
   };
 }
@@ -46,6 +91,16 @@ function makeStore(file) {
 /** Per-user, cross-session artifact store for a named extension. */
 export function userStore(extensionName, fileName) {
   return makeStore(join(copilotHome(), "extensions", extensionName, "artifacts", fileName));
+}
+
+/**
+ * Per-session scratch store for a named extension, rooted under the session's
+ * state directory. Use for state that should NOT outlive the session (drafts,
+ * one-off working data). Pass the session id (e.g. from the SDK ctx).
+ */
+export function sessionStore(sessionId, extensionName, fileName) {
+  const safeSession = String(sessionId).replace(/[^A-Za-z0-9._-]/g, "_") || "default";
+  return makeStore(join(copilotHome(), "session-state", safeSession, "extensions", extensionName, fileName));
 }
 
 /** Per-session store rooted at the session workspace path. */

--- a/skills/create-canvas-app/kit/validate.mjs
+++ b/skills/create-canvas-app/kit/validate.mjs
@@ -1,0 +1,146 @@
+// canvas-kit/validate.mjs
+//
+// A tiny, dependency-free JSON-Schema-*subset* validator. It exists so the
+// runtime can ENFORCE the action `inputSchema` (and an optional `stateSchema`)
+// that authors already declare — turning the iframe↔extension / agent↔extension
+// contract from "declared but unchecked" into "validated at the boundary". No
+// npm dependency (the kit ships vendored, no install step), and it only covers
+// the JSON Schema features the kit's schemas actually use:
+//
+//   type            "object" | "array" | "string" | "number" | "integer" |
+//                   "boolean" | "null"  (or an array of those)
+//   properties      per-key subschemas (objects)
+//   required        array of required property names (objects)
+//   additionalProperties   false | subschema (objects)
+//   items           subschema for every element (arrays)
+//   enum            allowed literal values (deep-equal)
+//   minLength/maxLength    string length bounds
+//   minimum/maximum        numeric bounds
+//   minItems/maxItems      array length bounds
+//
+// It is intentionally forgiving: an absent/empty schema validates anything, and
+// unknown keywords are ignored (so a richer schema never hard-fails here). The
+// goal is to catch the shape mistakes that actually break canvases — wrong type,
+// missing required field, unknown/typo'd property, out-of-enum value — not to be
+// a complete JSON Schema implementation.
+
+function typeOf(value) {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  if (Number.isInteger(value)) return "integer";
+  return typeof value; // "string" | "number" | "boolean" | "object" | "undefined"
+}
+
+// Does `value` satisfy a single JSON Schema `type` token? "number" accepts
+// integers; "integer" requires a whole number.
+function matchesType(value, t) {
+  const actual = typeOf(value);
+  if (t === "number") return actual === "number" || actual === "integer";
+  if (t === "integer") return actual === "integer";
+  return actual === t;
+}
+
+function deepEqual(a, b) {
+  if (a === b) return true;
+  if (typeof a !== typeof b || a === null || b === null) return false;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return a.length === b.length && a.every((x, i) => deepEqual(x, b[i]));
+  }
+  if (typeof a === "object" && typeof b === "object") {
+    const ak = Object.keys(a), bk = Object.keys(b);
+    return ak.length === bk.length && ak.every((k) => deepEqual(a[k], b[k]));
+  }
+  return false;
+}
+
+/**
+ * Validate `value` against a JSON-Schema-subset `schema`.
+ * @param {object|undefined} schema
+ * @param {any} value
+ * @param {string} [path]  dotted path used in error messages (default "input")
+ * @returns {string[]} human-readable error messages; empty array = valid.
+ */
+export function validate(schema, value, path = "input") {
+  const errors = [];
+  walk(schema, value, path, errors);
+  return errors;
+}
+
+function walk(schema, value, path, errors) {
+  if (!schema || typeof schema !== "object") return; // absent/degenerate schema = anything goes
+
+  // type (single token or array of tokens)
+  if (schema.type !== undefined) {
+    const types = Array.isArray(schema.type) ? schema.type : [schema.type];
+    if (!types.some((t) => matchesType(value, t))) {
+      errors.push(`${path}: expected ${types.join(" | ")}, got ${typeOf(value)}`);
+      return; // a wrong base type makes deeper checks meaningless
+    }
+  }
+
+  // enum
+  if (Array.isArray(schema.enum) && !schema.enum.some((allowed) => deepEqual(allowed, value))) {
+    errors.push(`${path}: must be one of ${schema.enum.map((v) => JSON.stringify(v)).join(", ")}`);
+  }
+
+  const kind = typeOf(value);
+
+  if (kind === "string") {
+    if (typeof schema.minLength === "number" && value.length < schema.minLength) {
+      errors.push(`${path}: must be at least ${schema.minLength} characters`);
+    }
+    if (typeof schema.maxLength === "number" && value.length > schema.maxLength) {
+      errors.push(`${path}: must be at most ${schema.maxLength} characters`);
+    }
+  }
+
+  if (kind === "number" || kind === "integer") {
+    if (typeof schema.minimum === "number" && value < schema.minimum) {
+      errors.push(`${path}: must be >= ${schema.minimum}`);
+    }
+    if (typeof schema.maximum === "number" && value > schema.maximum) {
+      errors.push(`${path}: must be <= ${schema.maximum}`);
+    }
+  }
+
+  if (kind === "array") {
+    if (typeof schema.minItems === "number" && value.length < schema.minItems) {
+      errors.push(`${path}: must have at least ${schema.minItems} item(s)`);
+    }
+    if (typeof schema.maxItems === "number" && value.length > schema.maxItems) {
+      errors.push(`${path}: must have at most ${schema.maxItems} item(s)`);
+    }
+    if (schema.items) {
+      value.forEach((item, i) => walk(schema.items, item, `${path}[${i}]`, errors));
+    }
+  }
+
+  if (kind === "object") {
+    const props = schema.properties ?? {};
+    if (Array.isArray(schema.required)) {
+      for (const key of schema.required) {
+        // Object.hasOwn (not `value[key] === undefined`): a required property
+        // named after a prototype member (e.g. "toString", "constructor") would
+        // otherwise read the inherited value and wrongly pass the check.
+        if (!Object.hasOwn(value, key)) errors.push(`${path}.${key}: required`);
+      }
+    }
+    for (const [key, sub] of Object.entries(props)) {
+      if (Object.hasOwn(value, key)) walk(sub, value[key], `${path}.${key}`, errors);
+    }
+    // Membership is tested with Object.hasOwn, NOT `key in props`: `in` walks the
+    // prototype chain, so an extra key named "toString"/"constructor"/"__proto__"
+    // etc. would satisfy `key in props` and escape additionalProperties. This
+    // validator is the enforcement boundary (input → 400, state → 500), so that
+    // would be a real contract hole.
+    if (schema.additionalProperties === false) {
+      for (const key of Object.keys(value)) {
+        if (!Object.hasOwn(props, key)) errors.push(`${path}.${key}: unexpected property`);
+      }
+    } else if (schema.additionalProperties && typeof schema.additionalProperties === "object") {
+      for (const key of Object.keys(value)) {
+        if (!Object.hasOwn(props, key)) walk(schema.additionalProperties, value[key], `${path}.${key}`, errors);
+      }
+    }
+  }
+}

--- a/skills/create-canvas-app/kit/version.mjs
+++ b/skills/create-canvas-app/kit/version.mjs
@@ -10,4 +10,4 @@
 // convention (the skill ships as files, not an npm version); a commit short-sha
 // works too. Re-exported from client.mjs so a canvas can read it at runtime.
 
-export const KIT_VERSION = "2026-07-05.1";
+export const KIT_VERSION = "2026-07-07.3";

--- a/skills/create-canvas-app/package.json
+++ b/skills/create-canvas-app/package.json
@@ -5,7 +5,7 @@
   "description": "Dev tooling for the create-canvas-app skill (tests + Vally eval). Shipped canvases never get a package.json — this is for the skill repo only.",
   "license": "MIT",
   "scripts": {
-    "test": "node test/http.test.mjs && node test/kit-parity.test.mjs && node test/deeplinks.test.mjs && node test/generator.test.mjs && node test/tooling.test.mjs && node test/vendor-lucide.test.mjs",
+    "test": "node test/http.test.mjs && node test/client.test.mjs && node test/kit-parity.test.mjs && node test/deeplinks.test.mjs && node test/generator.test.mjs && node test/tooling.test.mjs && node test/vendor-lucide.test.mjs && node test/kit-runtime.test.mjs",
     "eval:lint": "vally lint --eval-spec evals/create-canvas-app/eval.yaml",
     "eval": "vally eval --eval-spec evals/create-canvas-app/eval.yaml --skill-dir ."
   },

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/.kit-version.json
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/.kit-version.json
@@ -1,5 +1,5 @@
 {
-  "version": "2026-07-05.1",
-  "syncedAt": "2026-07-06T19:31:30.895Z",
+  "version": "2026-07-07.3",
+  "syncedAt": "2026-07-07T16:42:18.366Z",
   "source": "create-canvas-app/kit"
 }

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/client.mjs
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/client.mjs
@@ -85,6 +85,74 @@ export function pollWhileVisible(tick, seconds, { whenVisible = true, immediate 
 }
 
 /**
+ * DOM-FREE transport for a canvas: owns the loopback wiring (GET /state, GET
+ * /events SSE, POST /action) and the derived `state`/`connected`, with no Preact
+ * and no DOM. `mountCanvas` composes this with a render loop; keeping it separate
+ * makes the reconnect/invoke glue unit-testable without a browser (see
+ * test/client.test.mjs). Both callbacks receive the latest `(state, connected)`.
+ * @param {object} [opts]
+ * @param {(state:any, connected:boolean)=>void} [opts.onState]      fired on the initial /state and every SSE push
+ * @param {(connected:boolean)=>void} [opts.onConnected]             fired when the SSE stream opens/errors
+ * @param {typeof EventSource} [opts.EventSourceImpl]                override the SSE impl (tests); defaults to the global
+ * @returns {{invoke:Function, refresh:Function, get state():any, get connected():boolean}}
+ */
+export function connectCanvas({ onState, onConnected, EventSourceImpl } = {}) {
+  let state = null;
+  let connected = false;
+  const ES = EventSourceImpl || (typeof EventSource !== "undefined" ? EventSource : null);
+
+  async function invoke(actionName, input) {
+    const res = await fetch("./action", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ actionName, input: input ?? {} }),
+    });
+    const data = await res.json().catch(() => ({ ok: false }));
+    if (!data.ok) {
+      throw new CanvasActionError(data.code || "error", data.message || "action failed");
+    }
+    return data.result;
+  }
+
+  async function refresh() {
+    try {
+      state = await (await fetch("./state")).json();
+      onState?.(state, connected);
+    } catch { /* offline; SSE will recover */ }
+  }
+
+  function connect() {
+    if (!ES) return; // no EventSource (e.g. a non-browser host); refresh() still works
+    const es = new ES("./events");
+    es.onmessage = (e) => {
+      let next;
+      try {
+        next = JSON.parse(e.data);
+      } catch {
+        return; // ignore a malformed SSE frame; the next push recovers
+      }
+      // Update OUTSIDE the try so a bug in onState surfaces as a real error
+      // instead of being silently mislabeled a "malformed frame".
+      state = next;
+      connected = true;
+      onState?.(state, connected);
+    };
+    es.onopen = () => { connected = true; onConnected?.(connected); };
+    es.onerror = () => { connected = false; onConnected?.(connected); /* EventSource auto-reconnects */ };
+  }
+
+  refresh();
+  connect();
+
+  return {
+    invoke,
+    refresh,
+    get state() { return state; },
+    get connected() { return connected; },
+  };
+}
+
+/**
  * Mount a canvas view and keep it live.
  * @param {object} opts
  * @param {(model:{state:any, invoke:Function, connected:boolean})=>any} opts.view
@@ -102,56 +170,29 @@ export function mountCanvas({ view, mount, onState, poll } = {}) {
   // HTML shell) would linger as a sibling. Clear it once so Preact owns an empty
   // root; the view's own loading branch covers the gap until first state.
   root.replaceChildren();
-  let state = null;
-  let connected = false;
 
-  async function invoke(actionName, input) {
-    const res = await fetch("./action", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ actionName, input: input ?? {} }),
-    });
-    const data = await res.json().catch(() => ({ ok: false }));
-    if (!data.ok) {
-      throw new CanvasActionError(data.code || "error", data.message || "action failed");
-    }
-    return data.result;
-  }
+  let latestState = null;
+  let latestConnected = false;
+  let client;
 
   function rerender() {
-    render(view({ state, invoke, connected }), root);
+    render(view({ state: latestState, invoke: client.invoke, connected: latestConnected }), root);
   }
 
-  async function refresh() {
-    try {
-      state = await (await fetch("./state")).json();
+  // The transport is DOM-free (connectCanvas); this wrapper only adds the Preact
+  // render on each state/connection change.
+  client = connectCanvas({
+    onState: (state, connected) => {
+      latestState = state;
+      latestConnected = connected;
       onState?.(state);
       rerender();
-    } catch { /* offline; SSE will recover */ }
-  }
-
-  function connect() {
-    const es = new EventSource("./events");
-    es.onmessage = (e) => {
-      let next;
-      try {
-        next = JSON.parse(e.data);
-      } catch {
-        return; // ignore a malformed SSE frame; the next push recovers
-      }
-      // Update + render OUTSIDE the try so a bug in onState/the view surfaces as
-      // a real error instead of being silently mislabeled a "malformed frame".
-      state = next;
-      connected = true;
-      onState?.(state);
+    },
+    onConnected: (connected) => {
+      latestConnected = connected;
       rerender();
-    };
-    es.onopen = () => { connected = true; rerender(); };
-    es.onerror = () => { connected = false; rerender(); /* EventSource auto-reconnects */ };
-  }
-
-  refresh();
-  connect();
+    },
+  });
 
   // Built-in fixed-interval auto-refresh, delegating to the shared
   // visibility-gated primitive. Pass `poll: { action, seconds, immediate }`.
@@ -164,7 +205,7 @@ export function mountCanvas({ view, mount, onState, poll } = {}) {
   // @property {boolean} [immediate=false]   fire one tick right after mount
   function startPoll({ action, seconds, input, whenVisible = true, immediate = false } = {}) {
     return pollWhileVisible(
-      () => (action ? invoke(action, input) : refresh()),
+      () => (action ? client.invoke(action, input) : client.refresh()),
       seconds,
       { whenVisible, immediate }
     );
@@ -174,10 +215,10 @@ export function mountCanvas({ view, mount, onState, poll } = {}) {
   if (poll) stopPoll = startPoll(poll);
 
   return {
-    invoke,
-    refresh,
+    invoke: client.invoke,
+    refresh: client.refresh,
     stopPoll: () => stopPoll(),
-    get state() { return state; },
+    get state() { return latestState; },
   };
 }
 

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/icons.mjs
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/icons.mjs
@@ -23,7 +23,18 @@ const VIEWBOX = "0 0 24 24";
 const STROKE_WIDTH = 2;
 
 function resolve(name) {
-  return LUCIDE[name] || LUCIDE[aliases[name]] || null;
+  // Own-property lookups only. Bracket access on a plain object reaches inherited
+  // Object.prototype members, so a name like "toString"/"constructor"/
+  // "hasOwnProperty" would otherwise resolve to a function (making hasIcon() lie
+  // and Icon()/lucideSVG() throw in nodeToString). Object.hasOwn keeps resolution
+  // to the real, vendored icon set.
+  if (typeof name !== "string") return null;
+  if (Object.hasOwn(LUCIDE, name)) return LUCIDE[name];
+  if (Object.hasOwn(aliases, name)) {
+    const target = aliases[name];
+    if (Object.hasOwn(LUCIDE, target)) return LUCIDE[target];
+  }
+  return null;
 }
 
 function kebab(k) {

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/net.mjs
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/net.mjs
@@ -1,0 +1,103 @@
+// canvas-kit/net.mjs
+//
+// Server-side network safety for canvases that fetch external data. A canvas
+// action runs on the loopback runtime with the app's network reach, so a
+// caller-influenced URL is an SSRF risk: it could target cloud metadata
+// (169.254.169.254), loopback, or the private network. This module is the kit's
+// sanctioned egress primitive — validate a URL, then fetch it with a hard
+// timeout — so every data canvas guards the same way instead of re-inlining the
+// check. SERVER-ONLY (uses node:dns / node:net): import it from the SDK-free
+// canvas.mjs, never from the browser view.
+//
+// Defense-in-depth, not a guarantee: a determined attacker could DNS-rebind
+// between the resolve check and the connect. For a canvas pointed at a source
+// you choose this is adequate; treat any fetched content as untrusted and render
+// it as TEXT (never innerHTML).
+
+import { lookup } from "node:dns/promises";
+import { isIP } from "node:net";
+
+/**
+ * True for addresses a server-side fetch should never reach: loopback,
+ * link-local (incl. cloud metadata 169.254.169.254), and private/CGNAT ranges.
+ * @param {string} ip
+ * @returns {boolean}
+ */
+export function isBlockedAddress(ip) {
+  const lower = ip.toLowerCase();
+  // Decode an IPv4-mapped/compatible IPv6 literal down to its embedded IPv4 so
+  // the IPv4 range checks apply. Covers BOTH the dotted tail (::ffff:127.0.0.1)
+  // and the HEX tail that `new URL()` normalizes literals to (::ffff:7f00:1) —
+  // without the decode, `[::ffff:127.0.0.1]` reaches loopback and
+  // `[::ffff:a9fe:a9fe]` reaches cloud metadata. Only matches when the high bits
+  // are all zero (leading "::"), so a normal public v6 (e.g. 2001:db8::7f00:1) is
+  // never misread as IPv4.
+  const addr = embeddedIPv4(lower) ?? ip;
+  if (isIP(addr) === 4) {
+    const [a, b] = addr.split(".").map(Number);
+    if (a === 0 || a === 127 || a === 10) return true;     // this-host / loopback / private
+    if (a === 169 && b === 254) return true;               // link-local (incl. cloud IMDS)
+    if (a === 172 && b >= 16 && b <= 31) return true;      // private
+    if (a === 192 && b === 168) return true;               // private
+    if (a === 100 && b >= 64 && b <= 127) return true;     // CGNAT
+    return false;
+  }
+  return lower === "::1" || lower === "::" || lower.startsWith("fe80") || lower.startsWith("fc") || lower.startsWith("fd");
+}
+
+// Decode an IPv4-mapped/compatible IPv6 literal (all-zero high groups, i.e. a
+// leading "::", optionally "::ffff:") to its dotted IPv4; else null. Accepts the
+// dotted tail (127.0.0.1) and the two-hex-group tail (7f00:1) that URL
+// normalization produces. Anchored on "::" so it can't misread a public v6.
+function embeddedIPv4(addr) {
+  const m = addr.match(/^::(?:ffff:)?((?:\d{1,3}\.){3}\d{1,3}|[0-9a-f]{1,4}:[0-9a-f]{1,4})$/);
+  if (!m) return null;
+  const tail = m[1];
+  if (tail.includes(".")) return isIP(tail) === 4 ? tail : null;
+  const [h1, h2] = tail.split(":");
+  const hi = parseInt(h1, 16), lo = parseInt(h2, 16);
+  return `${hi >> 8}.${hi & 255}.${lo >> 8}.${lo & 255}`;
+}
+
+/**
+ * Allow only http/https to a PUBLIC host. Rejects every address the hostname
+ * resolves to, so a public name can't be pointed at an internal IP. Throws on a
+ * blocked/invalid URL; resolves to void when the URL is safe to fetch.
+ * @param {string} url
+ */
+export async function assertPublicUrl(url) {
+  let u;
+  try { u = new URL(url); } catch { throw new Error("Invalid source URL"); }
+  if (u.protocol !== "http:" && u.protocol !== "https:") {
+    throw new Error("Blocked URL protocol: " + u.protocol);
+  }
+  let host = u.hostname;
+  if (host.startsWith("[") && host.endsWith("]")) host = host.slice(1, -1); // IPv6 brackets
+  if (host.toLowerCase() === "localhost") throw new Error("Blocked host: localhost");
+  const addrs = isIP(host) ? [host] : (await lookup(host, { all: true })).map((r) => r.address);
+  if (!addrs.length) throw new Error("Could not resolve host: " + host);
+  for (const ip of addrs) {
+    if (isBlockedAddress(ip)) throw new Error("Blocked private/loopback address: " + ip);
+  }
+}
+
+/**
+ * SSRF-guarded fetch with a mandatory timeout. Runs assertPublicUrl(url) first,
+ * then fetch() with an AbortSignal.timeout so a slow upstream can't hang the
+ * panel. Returns the Response as-is (does NOT throw on a non-2xx status — the
+ * caller checks res.ok), so it is a drop-in for a guarded fetch().
+ * @param {string} url
+ * @param {object} [opts]
+ * @param {number} [opts.timeoutMs=12000]  abort the request after this many ms
+ * @param {object} [opts.headers]          request headers (merged as-is)
+ * @param {RequestInit} [opts.rest]        any other fetch init (method, body, …)
+ * @returns {Promise<Response>}
+ */
+export async function safeFetch(url, { timeoutMs = 12000, headers, ...rest } = {}) {
+  await assertPublicUrl(url);
+  return fetch(url, {
+    ...rest,
+    headers: headers ?? {},
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+}

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/server.mjs
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/server.mjs
@@ -20,6 +20,7 @@ import { createServer } from "node:http";
 import { readFile } from "node:fs/promises";
 import { join, normalize, extname, sep } from "node:path";
 import { fileURLToPath } from "node:url";
+import { validate } from "./validate.mjs";
 
 const KIT_DIR = fileURLToPath(new URL(".", import.meta.url));
 
@@ -53,6 +54,7 @@ export class CanvasKitError extends Error {
  * @param {(domainId:string)=>any|Promise<any>} [config.loadState]
  * @param {(domainId:string, state:any)=>void|Promise<void>} [config.saveState]
  * @param {Record<string,{description?:string,inputSchema?:object,handler:Function}>} config.actions
+ * @param {object} [config.stateSchema]  optional JSON-Schema-subset for the durable state; when set, a mutation that violates it is rolled back and fails (500)
  * @param {string} config.assetsDir  absolute path to the canvas web/ folder
  * @param {(ctx:object,state:any)=>string} [config.statusLine]
  */
@@ -114,12 +116,32 @@ export function createCanvasRuntime(config) {
 
   // Core action invoker — the single code path behind both agent and UI actions.
   async function invoke(actionName, input, ctx) {
-    const action = config.actions[actionName];
+    // Own-property lookup: `config.actions[actionName]` via bracket access would
+    // otherwise reach inherited members (e.g. "constructor", "toString"). The
+    // handler-typeof check below already rejects those, but resolving by
+    // Object.hasOwn keeps the boundary explicit and consistent with validate.mjs.
+    const action =
+      typeof actionName === "string" && Object.hasOwn(config.actions, actionName)
+        ? config.actions[actionName]
+        : null;
     if (!action || typeof action.handler !== "function") {
       throw new CanvasKitError("unknown_action", `Unknown action: ${actionName}`);
     }
+    // Enforce the declared inputSchema at the boundary (agent OR ui). The schema
+    // is a contract authors already write; validating it here turns "declared but
+    // unchecked" into a typed boundary and stops a malformed/typo'd payload from
+    // reaching the handler. A shape violation is the CALLER's fault → invalid_input
+    // (HTTP 400). Business rules ("title can't be blank") still live in the handler
+    // and surface as a 500, so a schema-valid-but-empty string reaches the handler.
+    if (action.inputSchema) {
+      const errs = validate(action.inputSchema, input ?? {}, "input");
+      if (errs.length) {
+        throw new CanvasKitError("invalid_input", `Invalid input for '${actionName}': ${errs.join("; ")}`);
+      }
+    }
     const domainId = ctx?.domainId ?? "default";
     const d = await getDomain(domainId, ctx);
+    const prevState = d.state; // snapshot for stateSchema rollback (below)
     let mutated = false;
     const api = {
       get state() { return d.state; },
@@ -161,6 +183,17 @@ export function createCanvasRuntime(config) {
     };
     const result = await action.handler(api);
     if (mutated) {
+      // Optional stateSchema guards the durable shape: if a handler produced an
+      // invalid state, roll back the in-memory mutation and fail LOUD (a 500 —
+      // this is a handler bug, not caller input) instead of persisting/broadcasting
+      // corrupt state. Absent stateSchema, anything goes (opt-in).
+      if (config.stateSchema) {
+        const errs = validate(config.stateSchema, d.state, "state");
+        if (errs.length) {
+          d.state = prevState; // roll back so in-memory stays consistent
+          throw new Error(`Action '${actionName}' produced invalid state: ${errs.join("; ")}`);
+        }
+      }
       if (config.saveState) await config.saveState(domainId, d.state);
       broadcast(domainId);
     }
@@ -202,6 +235,12 @@ export function createCanvasRuntime(config) {
   // local client can't force unbounded memory growth on the loopback runtime.
   const MAX_BODY_BYTES = 1 << 20; // 1 MiB
 
+  // Cap concurrent SSE subscribers PER INSTANCE. A canvas panel needs only one
+  // /events stream (a couple across reopens); a runaway reconnect loop or a
+  // hostile local process hitting the loopback port could otherwise accumulate
+  // unbounded response handles + keep-alive timers. 64 is far above any real use.
+  const MAX_SSE_CLIENTS = 64;
+
   function readBody(req) {
     return new Promise((resolve, reject) => {
       const chunks = [];
@@ -240,6 +279,13 @@ export function createCanvasRuntime(config) {
 
       // GET /events — Server-Sent Events stream of state
       if (req.method === "GET" && path === "/events") {
+        // Refuse once an instance is saturated, so subscribers can't grow without
+        // bound (each holds a response handle + a keep-alive interval).
+        if (inst && inst.clients.size >= MAX_SSE_CLIENTS) {
+          res.writeHead(503, { "Content-Type": "text/plain", "Retry-After": "5" });
+          res.end("too many event subscribers");
+          return;
+        }
         res.writeHead(200, {
           "Content-Type": "text/event-stream",
           "Cache-Control": "no-cache",
@@ -307,6 +353,15 @@ export function createCanvasRuntime(config) {
    * @returns {Promise<{url:string,title:string,status?:string}>}
    */
   async function openInstance({ instanceId, input, ctx }) {
+    // Validate the open input against the declared inputSchema (same contract the
+    // actions get). A bad open payload fails fast with invalid_input rather than
+    // silently resolving the wrong domain.
+    if (config.inputSchema) {
+      const errs = validate(config.inputSchema, input ?? {}, "open input");
+      if (errs.length) {
+        throw new CanvasKitError("invalid_input", `Invalid open input: ${errs.join("; ")}`);
+      }
+    }
     const domainId = config.resolveDomainId
       ? config.resolveDomainId(input ?? {}, ctx ?? {}) || "default"
       : "default";

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/storage.mjs
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/storage.mjs
@@ -2,16 +2,59 @@
 //
 // Durable JSON state helpers. State is keyed by a *domain id* (a stable logical
 // identifier resolved from the open input), never by instanceId — per
-// create-canvas/SKILL.md. Two scopes:
+// create-canvas/SKILL.md. Three tiers, matching the Canvas SDK storage model:
 //   userStore      -> $COPILOT_HOME/extensions/<name>/artifacts/<file>   (per user, cross-session)
-//   workspaceStore -> <session.workspacePath>/<file>                     (per session)
+//   sessionStore   -> $COPILOT_HOME/session-state/<sessionId>/extensions/<name>/<file>  (per session, scratch)
+//   workspaceStore -> <session.workspacePath>/<file>                     (rooted at the session workspace)
+//
+// Sandboxing: callers derive the <file> from a domain id that MUST be sanitized
+// to a bare filename (the reference `fileFor` strips everything but
+// [A-Za-z0-9._-]); the store never joins caller input as a path, so a domain id
+// can't escape its extension's artifacts directory.
 
-import { readFile, writeFile, mkdir, rename } from "node:fs/promises";
+import { readFile, writeFile, mkdir, rename, unlink } from "node:fs/promises";
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
+import { randomBytes } from "node:crypto";
 
 function copilotHome() {
   return process.env.COPILOT_HOME || join(homedir(), ".copilot");
+}
+
+// Per-file write queue. Concurrent saves to the SAME durable file (an agent
+// action and a UI action racing) must not overlap: on Windows two renames to the
+// same destination collide with EPERM even with unique temp names. Chaining each
+// save onto the previous one for that path serializes them (last enqueued wins),
+// which is both correct (no interleaved writes) and portable.
+const writeQueues = new Map(); // absolute file path -> tail Promise
+
+async function atomicWrite(file, data) {
+  await mkdir(dirname(file), { recursive: true });
+  // Write to a temp sibling then atomically rename into place, so a crash or
+  // interruption mid-write can never truncate the existing durable file.
+  // rename(2) is atomic on the same filesystem. The temp name mixes pid + time +
+  // RANDOM bytes so two writers can never pick the same temp path.
+  const tmp = `${file}.${process.pid}.${Date.now()}.${randomBytes(6).toString("hex")}.tmp`;
+  await writeFile(tmp, JSON.stringify(data, null, 2), "utf8");
+  try {
+    await rename(tmp, file);
+  } catch (err) {
+    // Windows can transiently EPERM/EACCES a rename when the destination is
+    // briefly held (AV scanner, indexer). Retry once after a short beat; always
+    // clean up our temp so a failed save leaves no orphaned *.tmp behind.
+    if (err?.code === "EPERM" || err?.code === "EACCES") {
+      await new Promise((r) => setTimeout(r, 25));
+      try {
+        await rename(tmp, file);
+      } catch (err2) {
+        await unlink(tmp).catch(() => {});
+        throw err2;
+      }
+    } else {
+      await unlink(tmp).catch(() => {});
+      throw err;
+    }
+  }
 }
 
 function makeStore(file) {
@@ -32,13 +75,15 @@ function makeStore(file) {
       }
     },
     async save(data) {
-      await mkdir(dirname(file), { recursive: true });
-      // Write to a temp sibling then atomically rename into place, so a crash or
-      // interruption mid-write can never truncate the existing durable file.
-      // rename(2) is atomic on the same filesystem.
-      const tmp = `${file}.${process.pid}.${Date.now()}.tmp`;
-      await writeFile(tmp, JSON.stringify(data, null, 2), "utf8");
-      await rename(tmp, file);
+      // Serialize behind any in-flight save for this exact path (see writeQueues).
+      const prev = writeQueues.get(file) ?? Promise.resolve();
+      const run = prev.catch(() => {}).then(() => atomicWrite(file, data));
+      writeQueues.set(file, run);
+      try {
+        await run;
+      } finally {
+        if (writeQueues.get(file) === run) writeQueues.delete(file);
+      }
     },
   };
 }
@@ -46,6 +91,16 @@ function makeStore(file) {
 /** Per-user, cross-session artifact store for a named extension. */
 export function userStore(extensionName, fileName) {
   return makeStore(join(copilotHome(), "extensions", extensionName, "artifacts", fileName));
+}
+
+/**
+ * Per-session scratch store for a named extension, rooted under the session's
+ * state directory. Use for state that should NOT outlive the session (drafts,
+ * one-off working data). Pass the session id (e.g. from the SDK ctx).
+ */
+export function sessionStore(sessionId, extensionName, fileName) {
+  const safeSession = String(sessionId).replace(/[^A-Za-z0-9._-]/g, "_") || "default";
+  return makeStore(join(copilotHome(), "session-state", safeSession, "extensions", extensionName, fileName));
 }
 
 /** Per-session store rooted at the session workspace path. */

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/validate.mjs
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/validate.mjs
@@ -1,0 +1,146 @@
+// canvas-kit/validate.mjs
+//
+// A tiny, dependency-free JSON-Schema-*subset* validator. It exists so the
+// runtime can ENFORCE the action `inputSchema` (and an optional `stateSchema`)
+// that authors already declare — turning the iframe↔extension / agent↔extension
+// contract from "declared but unchecked" into "validated at the boundary". No
+// npm dependency (the kit ships vendored, no install step), and it only covers
+// the JSON Schema features the kit's schemas actually use:
+//
+//   type            "object" | "array" | "string" | "number" | "integer" |
+//                   "boolean" | "null"  (or an array of those)
+//   properties      per-key subschemas (objects)
+//   required        array of required property names (objects)
+//   additionalProperties   false | subschema (objects)
+//   items           subschema for every element (arrays)
+//   enum            allowed literal values (deep-equal)
+//   minLength/maxLength    string length bounds
+//   minimum/maximum        numeric bounds
+//   minItems/maxItems      array length bounds
+//
+// It is intentionally forgiving: an absent/empty schema validates anything, and
+// unknown keywords are ignored (so a richer schema never hard-fails here). The
+// goal is to catch the shape mistakes that actually break canvases — wrong type,
+// missing required field, unknown/typo'd property, out-of-enum value — not to be
+// a complete JSON Schema implementation.
+
+function typeOf(value) {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  if (Number.isInteger(value)) return "integer";
+  return typeof value; // "string" | "number" | "boolean" | "object" | "undefined"
+}
+
+// Does `value` satisfy a single JSON Schema `type` token? "number" accepts
+// integers; "integer" requires a whole number.
+function matchesType(value, t) {
+  const actual = typeOf(value);
+  if (t === "number") return actual === "number" || actual === "integer";
+  if (t === "integer") return actual === "integer";
+  return actual === t;
+}
+
+function deepEqual(a, b) {
+  if (a === b) return true;
+  if (typeof a !== typeof b || a === null || b === null) return false;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return a.length === b.length && a.every((x, i) => deepEqual(x, b[i]));
+  }
+  if (typeof a === "object" && typeof b === "object") {
+    const ak = Object.keys(a), bk = Object.keys(b);
+    return ak.length === bk.length && ak.every((k) => deepEqual(a[k], b[k]));
+  }
+  return false;
+}
+
+/**
+ * Validate `value` against a JSON-Schema-subset `schema`.
+ * @param {object|undefined} schema
+ * @param {any} value
+ * @param {string} [path]  dotted path used in error messages (default "input")
+ * @returns {string[]} human-readable error messages; empty array = valid.
+ */
+export function validate(schema, value, path = "input") {
+  const errors = [];
+  walk(schema, value, path, errors);
+  return errors;
+}
+
+function walk(schema, value, path, errors) {
+  if (!schema || typeof schema !== "object") return; // absent/degenerate schema = anything goes
+
+  // type (single token or array of tokens)
+  if (schema.type !== undefined) {
+    const types = Array.isArray(schema.type) ? schema.type : [schema.type];
+    if (!types.some((t) => matchesType(value, t))) {
+      errors.push(`${path}: expected ${types.join(" | ")}, got ${typeOf(value)}`);
+      return; // a wrong base type makes deeper checks meaningless
+    }
+  }
+
+  // enum
+  if (Array.isArray(schema.enum) && !schema.enum.some((allowed) => deepEqual(allowed, value))) {
+    errors.push(`${path}: must be one of ${schema.enum.map((v) => JSON.stringify(v)).join(", ")}`);
+  }
+
+  const kind = typeOf(value);
+
+  if (kind === "string") {
+    if (typeof schema.minLength === "number" && value.length < schema.minLength) {
+      errors.push(`${path}: must be at least ${schema.minLength} characters`);
+    }
+    if (typeof schema.maxLength === "number" && value.length > schema.maxLength) {
+      errors.push(`${path}: must be at most ${schema.maxLength} characters`);
+    }
+  }
+
+  if (kind === "number" || kind === "integer") {
+    if (typeof schema.minimum === "number" && value < schema.minimum) {
+      errors.push(`${path}: must be >= ${schema.minimum}`);
+    }
+    if (typeof schema.maximum === "number" && value > schema.maximum) {
+      errors.push(`${path}: must be <= ${schema.maximum}`);
+    }
+  }
+
+  if (kind === "array") {
+    if (typeof schema.minItems === "number" && value.length < schema.minItems) {
+      errors.push(`${path}: must have at least ${schema.minItems} item(s)`);
+    }
+    if (typeof schema.maxItems === "number" && value.length > schema.maxItems) {
+      errors.push(`${path}: must have at most ${schema.maxItems} item(s)`);
+    }
+    if (schema.items) {
+      value.forEach((item, i) => walk(schema.items, item, `${path}[${i}]`, errors));
+    }
+  }
+
+  if (kind === "object") {
+    const props = schema.properties ?? {};
+    if (Array.isArray(schema.required)) {
+      for (const key of schema.required) {
+        // Object.hasOwn (not `value[key] === undefined`): a required property
+        // named after a prototype member (e.g. "toString", "constructor") would
+        // otherwise read the inherited value and wrongly pass the check.
+        if (!Object.hasOwn(value, key)) errors.push(`${path}.${key}: required`);
+      }
+    }
+    for (const [key, sub] of Object.entries(props)) {
+      if (Object.hasOwn(value, key)) walk(sub, value[key], `${path}.${key}`, errors);
+    }
+    // Membership is tested with Object.hasOwn, NOT `key in props`: `in` walks the
+    // prototype chain, so an extra key named "toString"/"constructor"/"__proto__"
+    // etc. would satisfy `key in props` and escape additionalProperties. This
+    // validator is the enforcement boundary (input → 400, state → 500), so that
+    // would be a real contract hole.
+    if (schema.additionalProperties === false) {
+      for (const key of Object.keys(value)) {
+        if (!Object.hasOwn(props, key)) errors.push(`${path}.${key}: unexpected property`);
+      }
+    } else if (schema.additionalProperties && typeof schema.additionalProperties === "object") {
+      for (const key of Object.keys(value)) {
+        if (!Object.hasOwn(props, key)) walk(schema.additionalProperties, value[key], `${path}.${key}`, errors);
+      }
+    }
+  }
+}

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/version.mjs
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/version.mjs
@@ -10,4 +10,4 @@
 // convention (the skill ships as files, not an npm version); a commit short-sha
 // works too. Re-exported from client.mjs so a canvas can read it at runtime.
 
-export const KIT_VERSION = "2026-07-05.1";
+export const KIT_VERSION = "2026-07-07.3";

--- a/skills/create-canvas-app/scripts/new-canvas.mjs
+++ b/skills/create-canvas-app/scripts/new-canvas.mjs
@@ -409,10 +409,9 @@ const DATA_CANVAS_MJS = `// canvas.mjs — {{titleText}} canvas definition (data
 //   * the view polls a "refresh" action on a visibility-gated timer (app.mjs).
 
 import { fileURLToPath } from "node:url";
-import { lookup } from "node:dns/promises";
-import { isIP } from "node:net";
 import { userStore } from "./canvas-kit/storage.mjs";
 import { nid } from "./canvas-kit/format.mjs";
+import { safeFetch } from "./canvas-kit/net.mjs";
 
 const EXT_NAME = "{{name}}";
 
@@ -425,52 +424,17 @@ function fileFor(domainId) {
   return userStore(EXT_NAME, \`\${safe}.json\`);
 }
 
-// SSRF guard: true for loopback, link-local (incl. cloud metadata 169.254.169.254),
-// and private/CGNAT ranges — the targets a server-side fetch should never reach.
-function isBlockedAddress(ip) {
-  const addr = ip.startsWith("::ffff:") ? ip.slice(7) : ip; // unwrap IPv4-mapped IPv6
-  if (isIP(addr) === 4) {
-    const [a, b] = addr.split(".").map(Number);
-    if (a === 0 || a === 127 || a === 10) return true;     // this-host / loopback / private
-    if (a === 169 && b === 254) return true;               // link-local (incl. cloud IMDS)
-    if (a === 172 && b >= 16 && b <= 31) return true;      // private
-    if (a === 192 && b === 168) return true;               // private
-    if (a === 100 && b >= 64 && b <= 127) return true;     // CGNAT
-    return false;
-  }
-  const v6 = addr.toLowerCase();
-  return v6 === "::1" || v6 === "::" || v6.startsWith("fe80") || v6.startsWith("fc") || v6.startsWith("fd");
-}
-
-// Allow only http/https to a PUBLIC host. Rejects every address the hostname
-// resolves to, so a public name can't be pointed at an internal IP.
-async function assertPublicUrl(url) {
-  let u;
-  try { u = new URL(url); } catch { throw new Error("Invalid source URL"); }
-  if (u.protocol !== "http:" && u.protocol !== "https:") {
-    throw new Error("Blocked URL protocol: " + u.protocol);
-  }
-  let host = u.hostname;
-  if (host.startsWith("[") && host.endsWith("]")) host = host.slice(1, -1); // IPv6 brackets
-  if (host.toLowerCase() === "localhost") throw new Error("Blocked host: localhost");
-  const addrs = isIP(host) ? [host] : (await lookup(host, { all: true })).map((r) => r.address);
-  if (!addrs.length) throw new Error("Could not resolve host: " + host);
-  for (const ip of addrs) {
-    if (isBlockedAddress(ip)) throw new Error("Blocked private/loopback address: " + ip);
-  }
-}
-
 async function fetchItems(url) {
   // This runs server-side on the loopback runtime, so a caller-set \`url\` would
-  // otherwise be an unrestricted fetch. Block private/loopback/link-local
-  // targets BEFORE connecting (SSRF guard). A determined attacker could still
-  // DNS-rebind between this check and the fetch; for a local dev tool pointed at
-  // a source you trust this is adequate defense-in-depth. The response still
-  // flows back to the agent, so render fetched fields as TEXT, never innerHTML.
-  await assertPublicUrl(url);
-  const res = await fetch(url, {
+  // otherwise be an unrestricted fetch. The kit's safeFetch() blocks
+  // private/loopback/link-local targets BEFORE connecting (SSRF guard) and
+  // applies a hard timeout so a slow upstream can't hang the panel. A determined
+  // attacker could still DNS-rebind between the check and the fetch; for a local
+  // dev tool pointed at a source you trust this is adequate defense-in-depth. The
+  // response still flows back to the agent, so render fetched fields as TEXT,
+  // never innerHTML.
+  const res = await safeFetch(url, {
     headers: { Accept: "application/json", "User-Agent": "copilot-canvas" },
-    signal: AbortSignal.timeout(12000),
   });
   if (!res.ok) throw new Error(\`HTTP \${res.status}\`);
   return mapItems(await res.json());

--- a/skills/create-canvas-app/test/client.test.mjs
+++ b/skills/create-canvas-app/test/client.test.mjs
@@ -1,0 +1,143 @@
+// test/client.test.mjs — unit tests for the DOM-free canvas transport
+// (connectCanvas in kit/client.mjs): the loopback wiring — initial /state fetch,
+// SSE state pushes, connected flag, and POST /action invoke/errors — that used to
+// be locked inside mountCanvas and only reachable through a real browser. Stubs
+// global fetch and injects a fake EventSource, so no DOM/network is needed.
+// No deps; Node 18+.  Run: node test/client.test.mjs
+
+import assert from "node:assert/strict";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { join } from "node:path";
+
+const KIT = join(fileURLToPath(new URL("..", import.meta.url)), "kit");
+const { connectCanvas, CanvasActionError } = await import(pathToFileURL(join(KIT, "client.mjs")).href);
+
+let passed = 0;
+async function test(name, fn) {
+  try {
+    await fn();
+    passed++;
+    console.log(`  ok  ${name}`);
+  } catch (e) {
+    console.error(`FAIL  ${name}\n      ${e.stack || e.message}`);
+    process.exitCode = 1;
+    throw e;
+  }
+}
+const flush = () => new Promise((r) => setImmediate(r));
+
+// ---- test doubles ----------------------------------------------------------
+// A fake EventSource: records the last instance so a test can drive its events.
+class FakeES {
+  constructor(url) {
+    this.url = url;
+    this.onmessage = null;
+    this.onopen = null;
+    this.onerror = null;
+    FakeES.last = this;
+  }
+  message(data) { this.onmessage?.({ data: JSON.stringify(data) }); }
+  raw(data) { this.onmessage?.({ data }); }
+  open() { this.onopen?.(); }
+  error() { this.onerror?.(); }
+}
+
+// A fetch stub for the two loopback endpoints the transport uses.
+let stateBody;
+let actionResponse;
+let lastAction;
+function installFetch() {
+  lastAction = null;
+  globalThis.fetch = async (url, opts) => {
+    const u = String(url);
+    if (u.endsWith("./state") || u.endsWith("/state")) {
+      return { json: async () => stateBody };
+    }
+    if (u.endsWith("./action") || u.endsWith("/action")) {
+      lastAction = JSON.parse(opts.body);
+      return { json: async () => actionResponse };
+    }
+    throw new Error("unexpected fetch: " + u);
+  };
+}
+
+const realFetch = globalThis.fetch;
+try {
+  console.log("create-canvas-app client transport tests (connectCanvas)");
+  installFetch();
+
+  // A single client drives the state/SSE tests; invoke error cases use fresh ones.
+  stateBody = { items: ["a"], v: 1 };
+  actionResponse = { ok: true, result: { done: true } };
+  const states = [];
+  const conns = [];
+  const client = connectCanvas({
+    EventSourceImpl: FakeES,
+    onState: (s, c) => states.push({ s, c }),
+    onConnected: (c) => conns.push(c),
+  });
+
+  await test("initial refresh fetches /state and fires onState", async () => {
+    await flush();
+    assert.deepEqual(client.state, { items: ["a"], v: 1 });
+    assert.deepEqual(states.at(-1).s, { items: ["a"], v: 1 });
+    assert.equal(client.connected, false, "no SSE open yet");
+  });
+
+  await test("an SSE message updates state and marks connected", () => {
+    FakeES.last.message({ items: ["a", "b"], v: 2 });
+    assert.deepEqual(client.state, { items: ["a", "b"], v: 2 });
+    assert.equal(client.connected, true);
+    assert.deepEqual(states.at(-1).s, { items: ["a", "b"], v: 2 });
+    assert.equal(states.at(-1).c, true, "onState carries the connected flag");
+  });
+
+  await test("onopen/onerror flip connected and fire onConnected", () => {
+    FakeES.last.error();
+    assert.equal(client.connected, false);
+    assert.equal(conns.at(-1), false);
+    FakeES.last.open();
+    assert.equal(client.connected, true);
+    assert.equal(conns.at(-1), true);
+  });
+
+  await test("a malformed SSE frame is ignored (state unchanged, no throw)", () => {
+    const before = client.state;
+    FakeES.last.raw("{ not json");
+    assert.equal(client.state, before, "state is untouched by a bad frame");
+  });
+
+  await test("invoke POSTs /action with the actionName + input and returns result", async () => {
+    const r = await client.invoke("do_thing", { a: 1 });
+    assert.deepEqual(r, { done: true });
+    assert.deepEqual(lastAction, { actionName: "do_thing", input: { a: 1 } });
+  });
+
+  await test("invoke defaults missing input to {}", async () => {
+    actionResponse = { ok: true, result: 5 };
+    await client.invoke("no_input");
+    assert.deepEqual(lastAction.input, {});
+  });
+
+  await test("invoke rejects with CanvasActionError on { ok:false }", async () => {
+    actionResponse = { ok: false, code: "invalid_input", message: "nope" };
+    await assert.rejects(
+      () => client.invoke("bad"),
+      (e) => e instanceof CanvasActionError && e.code === "invalid_input" && /nope/.test(e.message),
+    );
+  });
+
+  await test("connectCanvas without an EventSource still refreshes (no throw)", async () => {
+    stateBody = { ok: true };
+    const only = [];
+    const c2 = connectCanvas({ EventSourceImpl: null, onState: (s) => only.push(s) });
+    await flush();
+    assert.deepEqual(c2.state, { ok: true }, "refresh works without SSE");
+    assert.equal(c2.connected, false);
+    assert.equal(only.length, 1);
+  });
+} finally {
+  globalThis.fetch = realFetch;
+}
+
+console.log(`\n${passed} checks passed`);

--- a/skills/create-canvas-app/test/generator.test.mjs
+++ b/skills/create-canvas-app/test/generator.test.mjs
@@ -122,7 +122,11 @@ async function main() {
   });
 
   // ---- kit API surface -----------------------------------------------------
-  await test("client.mjs exports pollWhileVisible + re-exports format helpers", async () => {
+  await test("client.mjs exports pollWhileVisible + connectCanvas + re-exports format helpers", async () => {
+    const client = await import("../kit/client.mjs");
+    assert.equal(typeof client.pollWhileVisible, "function");
+    assert.equal(typeof client.mountCanvas, "function");
+    assert.equal(typeof client.connectCanvas, "function", "the DOM-free transport is exported");
     const src = await read(join(ROOT, "kit", "client.mjs"));
     assert.match(src, /export function pollWhileVisible/);
     assert.match(src, /document\.visibilityState/);
@@ -288,19 +292,20 @@ async function main() {
       });
     }
 
-    // data-template-specific contract: fetch-in-handler + refresh + poll helper
-    await test("data canvas.mjs fetches in a handler with a timeout + refresh action", async () => {
+    // data-template-specific contract: fetch-in-handler via the kit's guarded
+    // safeFetch + refresh + poll helper
+    await test("data canvas.mjs fetches via the kit's safeFetch (guarded + timeout) + refresh action", async () => {
       const canvas = await read(join(work, "gen-feed", "canvas.mjs"));
-      assert.match(canvas, /await fetch\(/);
-      assert.match(canvas, /AbortSignal\.timeout\(/);
+      assert.match(canvas, /from "\.\/canvas-kit\/net\.mjs"/);
+      assert.match(canvas, /await safeFetch\(/);
       assert.match(canvas, /refresh:\s*\{/);
     });
 
-    await test("data canvas.mjs guards the server-side fetch against SSRF", async () => {
-      const canvas = await read(join(work, "gen-feed", "canvas.mjs"));
-      assert.match(canvas, /await assertPublicUrl\(url\)/);
-      assert.match(canvas, /a === 169 && b === 254/); // link-local / cloud metadata blocked
-      assert.match(canvas, /Blocked private\/loopback address/);
+    await test("kit net.mjs guards the server-side fetch against SSRF (vendored into the canvas)", async () => {
+      const net = await read(join(work, "gen-feed", "canvas-kit", "net.mjs"));
+      assert.match(net, /a === 169 && b === 254/); // link-local / cloud metadata blocked
+      assert.match(net, /Blocked private\/loopback address/);
+      assert.match(net, /AbortSignal\.timeout\(/); // safeFetch applies a hard timeout
     });
 
     await test("data app.mjs uses the visibility-gated poll helper", async () => {

--- a/skills/create-canvas-app/test/http.test.mjs
+++ b/skills/create-canvas-app/test/http.test.mjs
@@ -186,6 +186,15 @@ async function main() {
     assert.equal(body.code, "unknown_action");
   });
 
+  await test("schema-invalid input returns a 400 invalid_input before the handler", async () => {
+    // status is an enum(open|decided|parked); "bogus" violates the inputSchema, so
+    // the runtime rejects it at the boundary (400) instead of running the handler.
+    const { status, body } = await action(open.url, "set_status", { id: "x", status: "bogus" });
+    assert.equal(status, 400);
+    assert.equal(body.ok, false);
+    assert.equal(body.code, "invalid_input");
+  });
+
   await test("handler validation error surfaces as a 500 failure", async () => {
     const { status, body } = await action(open.url, "add_decision", { title: "   " });
     assert.equal(status, 500); // handler throw -> 500 (a kit error like unknown_action is 400)

--- a/skills/create-canvas-app/test/kit-runtime.test.mjs
+++ b/skills/create-canvas-app/test/kit-runtime.test.mjs
@@ -1,0 +1,246 @@
+// test/kit-runtime.test.mjs — unit tests for the kit runtime primitives added to
+// enforce the Canvas SDK contract: JSON-schema input/state validation
+// (validate.mjs + server.mjs wiring), the SSRF/egress guard (net.mjs), and the
+// concurrency-safe durable store (storage.mjs). No deps; Node 18+.
+// Run: node test/kit-runtime.test.mjs
+
+import assert from "node:assert/strict";
+import http from "node:http";
+import { mkdtemp, rm, readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const KIT = join(ROOT, "kit");
+// Dynamic import() needs a file:// URL on Windows (a bare C:\ path is rejected).
+const imp = (file) => import(pathToFileURL(join(KIT, file)).href);
+
+let passed = 0;
+async function test(name, fn) {
+  try {
+    await fn();
+    passed++;
+    console.log(`  ok  ${name}`);
+  } catch (e) {
+    console.error(`FAIL  ${name}\n      ${e.stack || e.message}`);
+    process.exitCode = 1;
+    throw e;
+  }
+}
+async function throwsAsync(fn, re) {
+  let threw = null;
+  try { await fn(); } catch (e) { threw = e; }
+  assert.ok(threw, "expected the call to throw");
+  if (re) assert.match(String(threw.message), re);
+  return threw;
+}
+
+async function main() {
+  console.log("create-canvas-app kit runtime tests (validate / net / storage)");
+
+  // ---- validate.mjs --------------------------------------------------------
+  const { validate } = await imp("validate.mjs");
+
+  await test("validate: a valid object passes", () => {
+    const schema = { type: "object", properties: { a: { type: "string" } }, required: ["a"], additionalProperties: false };
+    assert.deepEqual(validate(schema, { a: "hi" }), []);
+  });
+
+  await test("validate: missing required + wrong type + unknown prop are all reported", () => {
+    const schema = { type: "object", properties: { a: { type: "string" }, n: { type: "number" } }, required: ["a"], additionalProperties: false };
+    const errs = validate(schema, { n: "not-a-number", extra: 1 });
+    assert.ok(errs.some((e) => /a: required/.test(e)));
+    assert.ok(errs.some((e) => /n: expected number/.test(e)));
+    assert.ok(errs.some((e) => /extra: unexpected property/.test(e)));
+  });
+
+  await test("validate: enum, integer, and array items", () => {
+    assert.ok(validate({ enum: ["open", "done"] }, "nope").length === 1);
+    assert.deepEqual(validate({ type: "integer" }, 3), []);
+    assert.ok(validate({ type: "integer" }, 3.5).length === 1);
+    assert.deepEqual(validate({ type: "array", items: { type: "string" } }, ["a", "b"]), []);
+    assert.ok(validate({ type: "array", items: { type: "string" } }, ["a", 2]).length === 1);
+  });
+
+  await test("validate: bounds (minLength / minimum) and a permissive empty schema", () => {
+    assert.ok(validate({ type: "string", minLength: 2 }, "x").length === 1);
+    assert.ok(validate({ type: "number", minimum: 0 }, -1).length === 1);
+    assert.deepEqual(validate(undefined, { anything: true }), []); // no schema = anything
+  });
+
+  await test("validate: prototype-named keys can't escape additionalProperties (in-operator hole)", () => {
+    const schema = { type: "object", properties: { title: { type: "string" } }, additionalProperties: false };
+    // These keys all exist on Object.prototype; `key in props` would treat them as
+    // declared. Object.hasOwn must reject them as unexpected properties.
+    for (const bad of ["toString", "constructor", "valueOf", "hasOwnProperty", "__proto__"]) {
+      const errs = validate(schema, JSON.parse(`{"title":"ok","${bad}":1}`));
+      assert.ok(errs.some((e) => e.includes(`${bad}: unexpected property`)), `${bad} must be rejected`);
+    }
+    // A prototype-named REQUIRED key that is absent must still be reported missing.
+    assert.ok(validate({ type: "object", required: ["toString"] }, {}).some((e) => /toString: required/.test(e)));
+    // An additionalProperties SUBSCHEMA must apply to a prototype-named extra key.
+    assert.ok(validate({ type: "object", properties: {}, additionalProperties: { type: "number" } }, JSON.parse('{"toString":"x"}')).length === 1);
+  });
+
+  // ---- server.mjs: input + state validation --------------------------------
+  const { createCanvasRuntime, CanvasKitError } = await imp("server.mjs");
+
+  function makeRuntime() {
+    return createCanvasRuntime({
+      id: "t", displayName: "T", description: "", assetsDir: KIT,
+      createInitialState: () => ({ count: 0 }),
+      stateSchema: { type: "object", properties: { count: { type: "integer", minimum: 0 } }, required: ["count"], additionalProperties: false },
+      actions: {
+        set_count: {
+          inputSchema: { type: "object", properties: { count: { type: "integer" } }, required: ["count"], additionalProperties: false },
+          handler: ({ set, input }) => { set((s) => ({ ...s, count: input.count })); return { count: input.count }; },
+        },
+      },
+    });
+  }
+
+  await test("runtime: valid action input passes and mutates state", async () => {
+    const rt = makeRuntime();
+    const res = await rt.invoke("set_count", { count: 5 }, { domainId: "d" });
+    assert.equal(res.count, 5);
+    assert.equal((await rt.getState("d")).count, 5);
+  });
+
+  await test("runtime: bad input type is rejected as invalid_input before the handler", async () => {
+    const rt = makeRuntime();
+    const err = await throwsAsync(() => rt.invoke("set_count", { count: "x" }, { domainId: "d" }), /Invalid input/);
+    assert.ok(err instanceof CanvasKitError);
+    assert.equal(err.code, "invalid_input");
+    assert.equal((await rt.getState("d")).count, 0, "state must be untouched when input is rejected");
+  });
+
+  await test("runtime: unknown property is rejected (additionalProperties:false)", async () => {
+    const rt = makeRuntime();
+    const err = await throwsAsync(() => rt.invoke("set_count", { count: 1, bogus: 2 }, { domainId: "d" }));
+    assert.equal(err.code, "invalid_input");
+  });
+
+  await test("runtime: a prototype-named action name is rejected as unknown (own-property lookup)", async () => {
+    const rt = makeRuntime();
+    for (const name of ["constructor", "toString", "hasOwnProperty", "__proto__"]) {
+      const err = await throwsAsync(() => rt.invoke(name, {}, { domainId: "d" }));
+      assert.equal(err.code, "unknown_action", `${name} must be unknown_action`);
+    }
+  });
+
+  await test("runtime: a handler that produces invalid state is rolled back and fails", async () => {
+    const rt = makeRuntime();
+    await rt.invoke("set_count", { count: 3 }, { domainId: "d" }); // valid baseline
+    // count = -1 violates stateSchema (minimum 0) -> rejected + rolled back.
+    await throwsAsync(() => rt.invoke("set_count", { count: -1 }, { domainId: "d" }), /invalid state/);
+    assert.equal((await rt.getState("d")).count, 3, "state must roll back to the last valid value");
+  });
+
+  // ---- net.mjs: SSRF / egress guard (offline; IP literals, no DNS) ---------
+  const { isBlockedAddress, assertPublicUrl, safeFetch } = await imp("net.mjs");
+
+  await test("net: isBlockedAddress flags loopback/link-local/private, allows public", () => {
+    for (const ip of ["127.0.0.1", "169.254.169.254", "10.0.0.1", "192.168.1.1", "::1"]) {
+      assert.equal(isBlockedAddress(ip), true, `${ip} should be blocked`);
+    }
+    assert.equal(isBlockedAddress("8.8.8.8"), false);
+  });
+
+  await test("net: assertPublicUrl blocks loopback/metadata/localhost/bad-scheme, allows a public IP", async () => {
+    await throwsAsync(() => assertPublicUrl("http://127.0.0.1/"), /Blocked/);
+    await throwsAsync(() => assertPublicUrl("http://169.254.169.254/"), /Blocked/);
+    await throwsAsync(() => assertPublicUrl("http://localhost/"), /Blocked host/);
+    await throwsAsync(() => assertPublicUrl("ftp://8.8.8.8/"), /protocol/);
+    await assertPublicUrl("http://8.8.8.8/"); // public IP literal — resolves, no DNS, no fetch
+  });
+
+  await test("net: IPv4-mapped IPv6 (hex form new URL normalizes to) is still blocked", async () => {
+    // new URL("http://[::ffff:127.0.0.1]/").hostname -> "[::ffff:7f00:1]"
+    assert.equal(isBlockedAddress("::ffff:7f00:1"), true, "::ffff:7f00:1 = 127.0.0.1");
+    assert.equal(isBlockedAddress("::ffff:a9fe:a9fe"), true, "::ffff:a9fe:a9fe = 169.254.169.254 (IMDS)");
+    assert.equal(isBlockedAddress("::ffff:0808:0808"), false, "::ffff:8.8.8.8 is public");
+    assert.equal(isBlockedAddress("2001:db8::7f00:1"), false, "a public v6 must NOT be misread as 127.0.0.1");
+    // the full path through URL normalization must reject loopback + metadata:
+    await throwsAsync(() => assertPublicUrl("http://[::ffff:127.0.0.1]/"), /Blocked/);
+    await throwsAsync(() => assertPublicUrl("http://[::ffff:169.254.169.254]/latest/meta-data/"), /Blocked/);
+  });
+
+  await test("net: safeFetch refuses a blocked target before connecting", async () => {
+    await throwsAsync(() => safeFetch("http://127.0.0.1:1/"), /Blocked/);
+  });
+
+  // ---- storage.mjs: concurrency-safe save + tiers --------------------------
+  const home = await mkdtemp(join(tmpdir(), "ck-storage-"));
+  process.env.COPILOT_HOME = home;
+  const { userStore, sessionStore } = await imp("storage.mjs");
+
+  await test("storage: concurrent saves to one domain all resolve without EPERM and leave valid JSON", async () => {
+    const store = userStore("concurrency-ext", "d.json");
+    // Fire many saves at once — the old temp name (pid+ms) collided under this,
+    // failing a rename with EPERM on Windows. Unique temp names must fix it.
+    await Promise.all(Array.from({ length: 12 }, (_, i) => store.save({ n: i })));
+    const loaded = await store.load();
+    assert.ok(loaded && typeof loaded.n === "number", "final file is valid JSON");
+    const dir = join(home, "extensions", "concurrency-ext", "artifacts");
+    const leftover = (await readdir(dir)).filter((f) => f.endsWith(".tmp"));
+    assert.deepEqual(leftover, [], "no orphaned .tmp files remain");
+  });
+
+  await test("storage: sessionStore is rooted under session-state/<id>/extensions/<name>", () => {
+    const store = sessionStore("sess-123", "my-ext", "d.json");
+    assert.match(store.file.replace(/\\/g, "/"), /session-state\/sess-123\/extensions\/my-ext\/d\.json$/);
+  });
+
+  // ---- icons.mjs: prototype-safe name resolution ---------------------------
+  const { hasIcon, lucideSVG, Icon } = await imp("icons.mjs");
+
+  await test("icons: a real icon resolves; prototype-named lookups do not", () => {
+    assert.equal(hasIcon("circle-check"), true);
+    // Inherited Object.prototype members must NOT resolve as icons.
+    for (const bad of ["toString", "constructor", "hasOwnProperty", "valueOf", "__proto__"]) {
+      assert.equal(hasIcon(bad), false, `hasIcon(${bad}) must be false`);
+    }
+    assert.equal(hasIcon(123), false, "non-string name is not an icon");
+  });
+
+  await test("icons: lucideSVG/Icon return empty/null for a prototype name instead of throwing", () => {
+    assert.equal(lucideSVG("toString"), "", "lucideSVG must degrade to empty, not throw");
+    assert.equal(Icon({ name: "constructor" }), null, "Icon must degrade to null, not throw");
+    assert.match(lucideSVG("circle-check"), /^<svg /, "a real icon still renders");
+  });
+
+  // ---- server.mjs: SSE subscriber cap (bounded /events) --------------------
+  await test("server: caps concurrent SSE subscribers per instance (503 past the cap)", async () => {
+    const rt = createCanvasRuntime({
+      id: "sse", displayName: "SSE", description: "", assetsDir: KIT,
+      createInitialState: () => ({ ok: true }),
+      actions: {},
+    });
+    const open = await rt.openInstance({ instanceId: "s", input: {}, ctx: { instanceId: "s", input: {} } });
+    const u = new URL(open.url);
+    // Open one /events stream and read its HTTP status, keeping the socket alive.
+    const openStream = () => new Promise((resolve, reject) => {
+      const req = http.get({ hostname: u.hostname, port: u.port, path: "/events", agent: false,
+        headers: { Accept: "text/event-stream" } }, (res) => { res.resume(); resolve({ status: res.statusCode, req }); });
+      req.on("error", reject);
+    });
+    const conns = [];
+    try {
+      // Cap is 64: the first 64 succeed (200), the 65th is refused (503).
+      for (let i = 0; i < 64; i++) conns.push(await openStream());
+      assert.ok(conns.every((c) => c.status === 200), "first 64 subscribers accepted");
+      const over = await openStream();
+      conns.push(over);
+      assert.equal(over.status, 503, "the 65th subscriber is refused");
+    } finally {
+      for (const c of conns) { try { c.req.destroy(); } catch {} }
+      await rt.shutdown();
+    }
+  });
+
+  await rm(home, { recursive: true, force: true });
+  console.log(`\n${passed} checks passed`);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary

Brings `create-canvas-app`'s canvas-kit up to fixes security findings from a red-team pass, and closes a test gap — all while keeping the kit **dependency-free and vendored**. `KIT_VERSION` → `2026-07-07.3`.

Grew the suite from 149 → **157 checks across 8 files**, all green.

## What's in each commit

**1. `feat`: harden kit runtime + refactor client transport** (`4b8ffc5`)
- **Typed messaging** — the runtime now *enforces* each action's `inputSchema` at the boundary (`kit/validate.mjs`, a dependency-free JSON-Schema subset) → `invalid_input` (HTTP 400) before the handler, agent-side too. Optional `stateSchema` validated on mutation with rollback.
- **Security primitive** — `kit/net.mjs` (`assertPublicUrl` / `isBlockedAddress` / `safeFetch`): an SSRF-guarded fetch with a hard timeout, promoted from a copied template snippet into a first-class kit module the data template imports.
- **Storage tiers** — `userStore` / `sessionStore` / `workspaceStore`, all atomic (temp + rename) with a **per-file write queue** that serializes concurrent saves.
- **Client transport** — extracted the DOM-free `connectCanvas` (fetch `/state`, SSE, `invoke`) out of `mountCanvas`, which is now a thin Preact wrapper (public API unchanged) so the transport is unit-testable without a browser.

**Security fixes (devx-hack):**
- `icons.mjs` + `server.mjs` action lookup use `Object.hasOwn` so prototype-named keys (`toString`/`constructor`/`__proto__`) can't resolve as icons or bypass the schema gate (CWE-1321/471).
- `net.mjs` decodes IPv4-mapped IPv6 including the hex form `new URL` normalizes to (`::ffff:7f00:1`), closing an SSRF bypass to loopback + cloud metadata.
- `storage.mjs` fixes a Windows `EPERM` under concurrent saves to one domain.
- `server.mjs` bounds concurrent SSE subscribers per instance (CWE-400).

**2. `test`: add runtime, transport, and validation tests** (`cbfd585`)
- `test/kit-runtime.test.mjs` — validator (incl. prototype-key safety), SSRF guard (incl. IPv4-mapped IPv6), storage concurrency + `sessionStore`, prototype-safe icons, SSE cap.
- `test/client.test.mjs` — the `connectCanvas` transport with stubbed `fetch`/`EventSource`.
- `http.test.mjs` — wire-level `invalid_input` 400 assertion. `package.json` wires the 8-file suite.

**3. `docs`: document validation, net.mjs, storage tiers, and tests** (`75295be`)
- `SKILL.md` + `README.md` cover the enforced `inputSchema`/`stateSchema`, `safeFetch`, the storage tiers, and the two new test suites.

## Notes
- `kit/*.mjs` is byte-mirrored into `reference/decision-log/canvas-kit/` via `scripts/sync-kit.mjs`; `kit-parity.test.mjs` enforces it.
- No new dependencies. Node 18+ (developed on 24). `npm test` runs all 8 suites.

## Test plan
- [x] `npm test` — 157 checks green across 8 suites
- [x] kit ↔ reference byte-parity holds
- [x] Board canvas verified rendering + live SSE re-render after the `mountCanvas` refactor (0 console errors)

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>