### PR TITLE
create-canvas-app: harden safeFetch redirects, session paths, and state rollback

### DIFF
--- a/skills/create-canvas-app/kit/net.mjs
+++ b/skills/create-canvas-app/kit/net.mjs
@@ -82,22 +82,45 @@ export async function assertPublicUrl(url) {
 }
 
 /**
- * SSRF-guarded fetch with a mandatory timeout. Runs assertPublicUrl(url) first,
- * then fetch() with an AbortSignal.timeout so a slow upstream can't hang the
- * panel. Returns the Response as-is (does NOT throw on a non-2xx status — the
- * caller checks res.ok), so it is a drop-in for a guarded fetch().
+ * SSRF-guarded fetch with a mandatory timeout. Runs assertPublicUrl on the URL
+ * and on EVERY redirect hop, so a chosen public host can't 30x-redirect the
+ * request into loopback/metadata/private space. Returns the final Response as-is
+ * (does NOT throw on a non-2xx status — the caller checks res.ok), so it is a
+ * drop-in for a guarded fetch().
+ *
+ * Redirects are followed MANUALLY (redirect:"manual") rather than by fetch's
+ * default redirect:"follow": the default would chase a 3xx Location without
+ * re-running the guard, which silently undoes every check in this module. Here
+ * each hop's target is re-validated before we connect to it.
  * @param {string} url
  * @param {object} [opts]
- * @param {number} [opts.timeoutMs=12000]  abort the request after this many ms
- * @param {object} [opts.headers]          request headers (merged as-is)
- * @param {RequestInit} [opts.rest]        any other fetch init (method, body, …)
+ * @param {number} [opts.timeoutMs=12000]     abort the WHOLE operation (all hops) after this many ms
+ * @param {number} [opts.maxRedirects=5]      how many 3xx hops to follow before giving up
+ * @param {object} [opts.headers]             request headers (merged as-is)
+ * @param {RequestInit} [opts.rest]           any other fetch init (method, body, …)
  * @returns {Promise<Response>}
  */
-export async function safeFetch(url, { timeoutMs = 12000, headers, ...rest } = {}) {
-  await assertPublicUrl(url);
-  return fetch(url, {
-    ...rest,
-    headers: headers ?? {},
-    signal: AbortSignal.timeout(timeoutMs),
-  });
+export async function safeFetch(url, { timeoutMs = 12000, maxRedirects = 5, headers, ...rest } = {}) {
+  // One timeout signal bounds the entire operation, redirects included, so a
+  // chain of slow hops can't multiply the deadline.
+  const signal = AbortSignal.timeout(timeoutMs);
+  let current = url;
+  for (let hop = 0; ; hop++) {
+    await assertPublicUrl(current);
+    const res = await fetch(current, {
+      ...rest,
+      headers: headers ?? {},
+      redirect: "manual",
+      signal,
+    });
+    if (res.status >= 300 && res.status < 400 && res.headers.has("location")) {
+      if (hop >= maxRedirects) throw new Error("Too many redirects");
+      const next = new URL(res.headers.get("location"), current).href;
+      // Discard the redirect body so the connection can be freed before the next hop.
+      try { await res.body?.cancel(); } catch { /* no body / already consumed */ }
+      current = next;
+      continue;
+    }
+    return res;
+  }
 }

--- a/skills/create-canvas-app/kit/server.mjs
+++ b/skills/create-canvas-app/kit/server.mjs
@@ -141,7 +141,12 @@ export function createCanvasRuntime(config) {
     }
     const domainId = ctx?.domainId ?? "default";
     const d = await getDomain(domainId, ctx);
-    const prevState = d.state; // snapshot for stateSchema rollback (below)
+    // Deep snapshot for stateSchema rollback: a handler may mutate state IN PLACE
+    // and return the same object, so a reference copy (prevState = d.state) would
+    // point at the same (now-corrupt) object and restore nothing. structuredClone
+    // gives a real pre-mutation copy. Durable state is JSON-shaped, so it clones
+    // cleanly. Only pay the clone when a stateSchema is actually configured.
+    const prevState = config.stateSchema ? structuredClone(d.state) : undefined;
     let mutated = false;
     const api = {
       get state() { return d.state; },

--- a/skills/create-canvas-app/kit/storage.mjs
+++ b/skills/create-canvas-app/kit/storage.mjs
@@ -99,7 +99,15 @@ export function userStore(extensionName, fileName) {
  * one-off working data). Pass the session id (e.g. from the SDK ctx).
  */
 export function sessionStore(sessionId, extensionName, fileName) {
-  const safeSession = String(sessionId).replace(/[^A-Za-z0-9._-]/g, "_") || "default";
+  // Reduce the session id to a single safe path segment. The charset filter keeps
+  // "." (so dotted ids survive), so we must ALSO collapse any ".." run — otherwise
+  // a session id of ".." would join to one level ABOVE session-state and escape the
+  // per-session root. (sessionId is normally a trusted SDK value; this keeps the
+  // sanitizer honest regardless.)
+  const safeSession =
+    String(sessionId)
+      .replace(/[^A-Za-z0-9._-]/g, "_")
+      .replace(/\.\.+/g, "_") || "default";
   return makeStore(join(copilotHome(), "session-state", safeSession, "extensions", extensionName, fileName));
 }
 

--- a/skills/create-canvas-app/kit/version.mjs
+++ b/skills/create-canvas-app/kit/version.mjs
@@ -10,4 +10,4 @@
 // convention (the skill ships as files, not an npm version); a commit short-sha
 // works too. Re-exported from client.mjs so a canvas can read it at runtime.
 
-export const KIT_VERSION = "2026-07-07.3";
+export const KIT_VERSION = "2026-07-07.4";

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/.kit-version.json
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/.kit-version.json
@@ -1,5 +1,5 @@
 {
-  "version": "2026-07-07.3",
-  "syncedAt": "2026-07-07T16:42:18.366Z",
+  "version": "2026-07-07.4",
+  "syncedAt": "2026-07-07T17:17:56.262Z",
   "source": "create-canvas-app/kit"
 }

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/net.mjs
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/net.mjs
@@ -82,22 +82,45 @@ export async function assertPublicUrl(url) {
 }
 
 /**
- * SSRF-guarded fetch with a mandatory timeout. Runs assertPublicUrl(url) first,
- * then fetch() with an AbortSignal.timeout so a slow upstream can't hang the
- * panel. Returns the Response as-is (does NOT throw on a non-2xx status — the
- * caller checks res.ok), so it is a drop-in for a guarded fetch().
+ * SSRF-guarded fetch with a mandatory timeout. Runs assertPublicUrl on the URL
+ * and on EVERY redirect hop, so a chosen public host can't 30x-redirect the
+ * request into loopback/metadata/private space. Returns the final Response as-is
+ * (does NOT throw on a non-2xx status — the caller checks res.ok), so it is a
+ * drop-in for a guarded fetch().
+ *
+ * Redirects are followed MANUALLY (redirect:"manual") rather than by fetch's
+ * default redirect:"follow": the default would chase a 3xx Location without
+ * re-running the guard, which silently undoes every check in this module. Here
+ * each hop's target is re-validated before we connect to it.
  * @param {string} url
  * @param {object} [opts]
- * @param {number} [opts.timeoutMs=12000]  abort the request after this many ms
- * @param {object} [opts.headers]          request headers (merged as-is)
- * @param {RequestInit} [opts.rest]        any other fetch init (method, body, …)
+ * @param {number} [opts.timeoutMs=12000]     abort the WHOLE operation (all hops) after this many ms
+ * @param {number} [opts.maxRedirects=5]      how many 3xx hops to follow before giving up
+ * @param {object} [opts.headers]             request headers (merged as-is)
+ * @param {RequestInit} [opts.rest]           any other fetch init (method, body, …)
  * @returns {Promise<Response>}
  */
-export async function safeFetch(url, { timeoutMs = 12000, headers, ...rest } = {}) {
-  await assertPublicUrl(url);
-  return fetch(url, {
-    ...rest,
-    headers: headers ?? {},
-    signal: AbortSignal.timeout(timeoutMs),
-  });
+export async function safeFetch(url, { timeoutMs = 12000, maxRedirects = 5, headers, ...rest } = {}) {
+  // One timeout signal bounds the entire operation, redirects included, so a
+  // chain of slow hops can't multiply the deadline.
+  const signal = AbortSignal.timeout(timeoutMs);
+  let current = url;
+  for (let hop = 0; ; hop++) {
+    await assertPublicUrl(current);
+    const res = await fetch(current, {
+      ...rest,
+      headers: headers ?? {},
+      redirect: "manual",
+      signal,
+    });
+    if (res.status >= 300 && res.status < 400 && res.headers.has("location")) {
+      if (hop >= maxRedirects) throw new Error("Too many redirects");
+      const next = new URL(res.headers.get("location"), current).href;
+      // Discard the redirect body so the connection can be freed before the next hop.
+      try { await res.body?.cancel(); } catch { /* no body / already consumed */ }
+      current = next;
+      continue;
+    }
+    return res;
+  }
 }

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/server.mjs
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/server.mjs
@@ -141,7 +141,12 @@ export function createCanvasRuntime(config) {
     }
     const domainId = ctx?.domainId ?? "default";
     const d = await getDomain(domainId, ctx);
-    const prevState = d.state; // snapshot for stateSchema rollback (below)
+    // Deep snapshot for stateSchema rollback: a handler may mutate state IN PLACE
+    // and return the same object, so a reference copy (prevState = d.state) would
+    // point at the same (now-corrupt) object and restore nothing. structuredClone
+    // gives a real pre-mutation copy. Durable state is JSON-shaped, so it clones
+    // cleanly. Only pay the clone when a stateSchema is actually configured.
+    const prevState = config.stateSchema ? structuredClone(d.state) : undefined;
     let mutated = false;
     const api = {
       get state() { return d.state; },

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/storage.mjs
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/storage.mjs
@@ -99,7 +99,15 @@ export function userStore(extensionName, fileName) {
  * one-off working data). Pass the session id (e.g. from the SDK ctx).
  */
 export function sessionStore(sessionId, extensionName, fileName) {
-  const safeSession = String(sessionId).replace(/[^A-Za-z0-9._-]/g, "_") || "default";
+  // Reduce the session id to a single safe path segment. The charset filter keeps
+  // "." (so dotted ids survive), so we must ALSO collapse any ".." run — otherwise
+  // a session id of ".." would join to one level ABOVE session-state and escape the
+  // per-session root. (sessionId is normally a trusted SDK value; this keeps the
+  // sanitizer honest regardless.)
+  const safeSession =
+    String(sessionId)
+      .replace(/[^A-Za-z0-9._-]/g, "_")
+      .replace(/\.\.+/g, "_") || "default";
   return makeStore(join(copilotHome(), "session-state", safeSession, "extensions", extensionName, fileName));
 }
 

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/version.mjs
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/version.mjs
@@ -10,4 +10,4 @@
 // convention (the skill ships as files, not an npm version); a commit short-sha
 // works too. Re-exported from client.mjs so a canvas can read it at runtime.
 
-export const KIT_VERSION = "2026-07-07.3";
+export const KIT_VERSION = "2026-07-07.4";

--- a/skills/create-canvas-app/test/kit-runtime.test.mjs
+++ b/skills/create-canvas-app/test/kit-runtime.test.mjs
@@ -8,7 +8,7 @@ import assert from "node:assert/strict";
 import http from "node:http";
 import { mkdtemp, rm, readdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve, sep } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 const ROOT = fileURLToPath(new URL("..", import.meta.url));
@@ -96,6 +96,12 @@ async function main() {
           inputSchema: { type: "object", properties: { count: { type: "integer" } }, required: ["count"], additionalProperties: false },
           handler: ({ set, input }) => { set((s) => ({ ...s, count: input.count })); return { count: input.count }; },
         },
+        // Same effect as set_count but MUTATES state in place (returns the same
+        // object) — exercises the stateSchema rollback deep-snapshot path.
+        set_count_inplace: {
+          inputSchema: { type: "object", properties: { count: { type: "integer" } }, required: ["count"], additionalProperties: false },
+          handler: ({ set, input }) => { set((s) => { s.count = input.count; return s; }); return { count: input.count }; },
+        },
       },
     });
   }
@@ -137,6 +143,16 @@ async function main() {
     assert.equal((await rt.getState("d")).count, 3, "state must roll back to the last valid value");
   });
 
+  await test("runtime: an IN-PLACE mutation that produces invalid state is rolled back (deep snapshot)", async () => {
+    const rt = makeRuntime();
+    await rt.invoke("set_count_inplace", { count: 3 }, { domainId: "d" }); // valid baseline
+    // The handler mutates the SAME state object and returns it; a reference-copy
+    // snapshot would roll back to the corrupted object. structuredClone must give
+    // a real pre-mutation value to restore.
+    await throwsAsync(() => rt.invoke("set_count_inplace", { count: -1 }, { domainId: "d" }), /invalid state/);
+    assert.equal((await rt.getState("d")).count, 3, "in-place mutation must roll back to the last valid value");
+  });
+
   // ---- net.mjs: SSRF / egress guard (offline; IP literals, no DNS) ---------
   const { isBlockedAddress, assertPublicUrl, safeFetch } = await imp("net.mjs");
 
@@ -170,6 +186,45 @@ async function main() {
     await throwsAsync(() => safeFetch("http://127.0.0.1:1/"), /Blocked/);
   });
 
+  await test("net: safeFetch re-checks the guard on every redirect hop (no SSRF via 30x)", async () => {
+    // A public host that 302-redirects to the metadata endpoint must NOT be chased.
+    // Stub fetch to (a) assert we asked for manual redirects and (b) hand back a
+    // 302 -> Location: link-local. safeFetch must re-run assertPublicUrl on the hop
+    // and throw, and must have called fetch exactly once (never reached the target).
+    const realFetch = globalThis.fetch;
+    let calls = 0;
+    let sawManual = false;
+    globalThis.fetch = async (_url, opts) => {
+      calls++;
+      if (opts && opts.redirect === "manual") sawManual = true;
+      return new Response(null, { status: 302, headers: { location: "http://169.254.169.254/latest/meta-data/" } });
+    };
+    try {
+      await throwsAsync(() => safeFetch("http://8.8.8.8/"), /Blocked/);
+      assert.equal(sawManual, true, "safeFetch must request redirect:'manual'");
+      assert.equal(calls, 1, "must not follow the redirect into blocked space");
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  await test("net: safeFetch follows a redirect to another PUBLIC host and returns its response", async () => {
+    const realFetch = globalThis.fetch;
+    let calls = 0;
+    globalThis.fetch = async (url) => {
+      calls++;
+      if (calls === 1) return new Response(null, { status: 302, headers: { location: "http://9.9.9.9/final" } });
+      return new Response("ok", { status: 200 });
+    };
+    try {
+      const res = await safeFetch("http://8.8.8.8/");
+      assert.equal(res.status, 200);
+      assert.equal(calls, 2, "should have followed exactly one hop");
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
   // ---- storage.mjs: concurrency-safe save + tiers --------------------------
   const home = await mkdtemp(join(tmpdir(), "ck-storage-"));
   process.env.COPILOT_HOME = home;
@@ -190,6 +245,17 @@ async function main() {
   await test("storage: sessionStore is rooted under session-state/<id>/extensions/<name>", () => {
     const store = sessionStore("sess-123", "my-ext", "d.json");
     assert.match(store.file.replace(/\\/g, "/"), /session-state\/sess-123\/extensions\/my-ext\/d\.json$/);
+  });
+
+  await test("storage: sessionStore('..') can't escape the session-state root", () => {
+    // ".." would otherwise join one level above session-state. The sanitizer must
+    // collapse the dot-run so the resolved path stays inside session-state/.
+    const store = sessionStore("..", "my-ext", "d.json");
+    const root = resolve(join(home, "session-state"));
+    assert.ok(
+      resolve(store.file).startsWith(root + sep),
+      `resolved path must stay under session-state (got ${store.file})`,
+    );
   });
 
   // ---- icons.mjs: prototype-safe name resolution ---------------------------


### PR DESCRIPTION
## What & why

Follow-up to #27 (merged). PR #26 was a near-duplicate of #27 built on a parallel branch, but it carried **three genuine robustness fixes that #27 did not include**. Rather than resurrect the conflicting #26, this PR salvages just those three deltas onto current `main`, each with a regression test. #26 will be closed as superseded.

Every change hardens a primitive that shipped in #27.

### 1. `net.mjs` — redirect-SSRF hole in `safeFetch` (the important one)
The merged `safeFetch` validated only the **first** URL, then let `fetch()` auto-follow 3xx redirects with no re-check. A public host could therefore `302` the request into `127.0.0.1` / `169.254.169.254` (cloud metadata) / private space — silently undoing every check in the module.

Now `safeFetch` follows redirects **manually** (`redirect:"manual"`) and re-runs `assertPublicUrl` on **every hop**, under a single operation-wide timeout, with a `maxRedirects` bound (default 5). Redirect bodies are cancelled between hops.

### 2. `storage.mjs` — `..` traversal in `sessionStore`
The sanitizer kept `.` (so dotted ids survive) but didn't collapse `..`, so a session id of `..` would join **one level above** `session-state/` and escape the per-session root. Now it also collapses any `..` run. (`sessionId` is normally a trusted SDK value; this keeps the sanitizer honest regardless.)

### 3. `server.mjs` — no-op `stateSchema` rollback on in-place mutation
Rollback snapshotted state with a **reference copy** (`prevState = d.state`). A handler that mutates state in place and returns the same object would corrupt the snapshot too, so an invalid-state rollback restored nothing. Now snapshots via `structuredClone` (durable state is JSON-shaped) — only when a `stateSchema` is configured.

## Tests
Adds four regression checks to `test/kit-runtime.test.mjs` (19 → 23):
- `safeFetch` re-checks the guard on every redirect hop (no SSRF via 30x)
- `safeFetch` follows a redirect to another **public** host and returns its response
- an **in-place** mutation producing invalid state is rolled back (deep snapshot)
- `sessionStore("..")` can't escape the session-state root

Full suite green — **161 checks**; `kit/ ↔ reference/` byte-parity holds. Bumps `KIT_VERSION` → `2026-07-07.4` and re-syncs the `reference/decision-log/canvas-kit/` mirror.

Supersedes the unique parts of #26.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>