### PR TITLE
docs(create-canvas-app): document instanceId format constraint

### DIFF
--- a/skills/create-canvas-app/SKILL.md
+++ b/skills/create-canvas-app/SKILL.md
@@ -568,6 +568,10 @@ A canvas isn't done because the server boots. Verify the UI:
 - **Never** repaint with `innerHTML`; render through Preact so pushes don't eat
   keystrokes.
 - **Never** key state by `instanceId` — key by domain so panels stay in sync.
+- **Never** hand `open_canvas` an `instanceId` outside `^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`
+  — ≤128 chars, an alphanumeric first character, then only `A-Za-z0-9._-`. A malformed
+  handle (leading `-`/`_`, spaces, over-long) is rejected by the runtime with
+  `Invalid canvas instance ID` before your canvas ever opens.
 - **Never** hand-roll or CDN-load icons — use `/kit/client.mjs`'s `Icon`.
 - **Never** put SDK imports outside `extension.mjs`.
 - **Never** pass `strokeWidth` to `Icon` or invent pixel sizes off the scale.


### PR DESCRIPTION
## What

Adds one footgun to the create-canvas-app `SKILL.md` documenting the `instanceId` format the Copilot host app enforces:

> The runtime validates `instanceId` against `^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$` (≤128 chars, alphanumeric first character, then only `A-Za-z0-9._-`) and rejects a malformed handle (leading `-`/`_`, spaces, over-long) with `Invalid canvas instance ID`.

## Why

This is the one canvas-surface contract detail the skill's docs didn't mirror. The skill's own validation workflow has the agent call `open_canvas` with a caller-chosen `instanceId`, so a malformed handle fails before the canvas opens. The note is placed next to the existing "never key state by `instanceId`" footgun so it reinforces (rather than dilutes) the domain-keying guidance.

Result of a full comparison of the current canvas surface (SDK canvas API, theme contract, authoring contract, session scope, host-AI bridge, deep links) against the skill: everything else is already in sync. The SDK canvas API and theme contract are stable, and the only host movement in the window (immersive full-screen) was reverted upstream, so nothing there warrants a change.

## Scope

- **Docs-only.** No `canvas-kit` bytes change → `KIT_VERSION` stays `2026-07-07.4`, and the vendored reference mirror is untouched.

## Verification

- `npm test` (full create-canvas-app suite) passes, including `kit-parity`, `tooling` (version/sync/freshness), and `kit-runtime` — confirming the kit and its vendored mirror are unchanged.