### PR TITLE
create-canvas-app: add githubStore for shared, multi-writer canvas state

### DIFF
--- a/site/src/content/skills/create-canvas-app.md
+++ b/site/src/content/skills/create-canvas-app.md
@@ -1,6 +1,6 @@
 ---
 title: create-canvas-app
-tagline: "Build GitHub Copilot canvas extensions fast — a no-build Preact + htm kit with live SSE state, durable per-user storage, Primer theming, the official Lucide icon set, a one-command generator, and deep links into the app."
+tagline: "Build GitHub Copilot canvas extensions fast — a no-build Preact + htm kit with live SSE state, durable per-user storage, optional multiplayer state shared through a private GitHub repo, Primer theming, the official Lucide icon set, a one-command generator, and deep links into the app."
 useWhen: "When you want to create, scaffold, or improve an interactive canvas — a side-panel UI the agent can open and drive: dashboards, editors, trackers, boards, or document/preview surfaces."
 repoPath: skills/create-canvas-app
 thumb: images/invoke-create-canvas-app.png
@@ -21,6 +21,11 @@ canvas needs already wired:
 
 - **Live state over SSE** — the canvas and the agent stay in sync in real time.
 - **Durable per-user storage** — state survives reloads and sessions.
+- **Shared, multiplayer state (optional)** — back a canvas with a JSON file in a
+  private GitHub repo so a team edits **one** live document and sees each other's
+  changes within seconds. GitHub is both the store and the access control — no
+  server to run. Writes are optimistic-locked; set a `stateSchema` and a bad remote
+  edit is rejected instead of corrupting everyone's board.
 - **Primer theming** — matches GitHub light/dark out of the box.
 - **Official GitHub Lucide icons** — the same icon set the product uses.
 - **Host AI, no API keys** — call the Copilot app's own model from an action with

--- a/skills/create-canvas-app/README.md
+++ b/skills/create-canvas-app/README.md
@@ -44,6 +44,9 @@ to your request, and validates it visually before handing it back.
   focus or half-typed input (the #1 bug in hand-rolled `innerHTML` canvases).
 - **Durable per-user storage** — state persists under
   `$COPILOT_HOME/extensions/<name>/artifacts/<domain>.json`.
+- **Shared multiplayer storage (optional)** — `githubStore` backs the board with a
+  file in a private repo, so collaborators edit one live document and see each
+  other's changes within seconds (poll + adopt); GitHub handles access control.
 - **Primer theming** — `ck-*` classes mapped to the host theme tokens with
   GitHub-dark fallbacks.
 - **Official GitHub icons** — the exact Lucide set github-app ships
@@ -174,8 +177,9 @@ from jongio/copilot-extensions/extensions/stock-ticker."* No clone, no build.
 SKILL.md                      The Copilot skill (authoring contract + workflow)
 kit/                          The canonical kit — copy into your extension as canvas-kit/
   client.mjs                  Browser runtime: html, mountCanvas, pollWhileVisible, hooks, Icon, formatters, deep-link builders
-  server.mjs                  SDK-free runtime: /state, /events (SSE), /action, static, inputSchema/stateSchema validation
+  server.mjs                  SDK-free runtime: /state, /events (SSE), /action, static, inputSchema/stateSchema validation, optional shared-state sync
   storage.mjs                 Durable JSON store — userStore / sessionStore / workspaceStore (atomic, concurrency-safe writes)
+  github-store.mjs            Shared repo-backed store — githubStore (multi-writer via the GitHub Contents API; poll + optimistic-lock)
   validate.mjs                Dependency-free JSON-Schema-subset validator (enforces action inputSchema + stateSchema)
   net.mjs                     Server-side egress guard: assertPublicUrl / isBlockedAddress / safeFetch (SSRF-safe fetch + timeout)
   format.mjs                  nid + relativeTime / compactNumber / percent helpers

--- a/skills/create-canvas-app/README.md
+++ b/skills/create-canvas-app/README.md
@@ -206,7 +206,7 @@ test/
   generator.test.mjs          Stamps the list/data/ai templates, runs their smoke tests, checks the kit API
   tooling.test.mjs            Exercises the version stamp, sync-kit, and the freshness drift gate
   vendor-lucide.test.mjs      Checks the Lucide vendoring generator (sorting, key-strip, determinism)
-  kit-runtime.test.mjs        Checks input/state schema validation, the net.mjs SSRF guard, and concurrency-safe storage
+  kit-runtime.test.mjs        Checks input/state schema validation, the net.mjs SSRF guard, concurrency-safe storage, the githubStore shared store, and the server sync loop
 ```
 
 ## Run the tests

--- a/skills/create-canvas-app/SKILL.md
+++ b/skills/create-canvas-app/SKILL.md
@@ -61,6 +61,18 @@ web/app.mjs     ── your Preact view
   workspace). All three write atomically (temp + rename) and **serialize
   concurrent saves to the same file**, so a racing agent + UI save can't corrupt
   or `EPERM` the durable file.
+- **Shared, multiplayer state (optional).** For a board multiple *people* edit,
+  swap the local tier for `githubStore({ owner, repo, path })` from
+  `kit/github-store.mjs`: it persists the same JSON to a file in a (private) repo
+  via the GitHub Contents API, so every collaborator with push access edits ONE
+  document — GitHub is both the store and the access control. Wire it as
+  `loadState`/`saveState`, and add `syncState: () => store.poll()` +
+  `syncIntervalMs` so the runtime polls for other people's edits (cheap ETag `304`
+  when unchanged) and adopts them live — but only while a panel is being viewed.
+  Writes are optimistic-locked by blob SHA (a conflicting commit re-reads +
+  retries; last-writer-wins by default, or pass a `merge(remote, mine)`). Token
+  comes from `GH_TOKEN`/`GITHUB_TOKEN` or `gh auth token` and is only ever sent as
+  an `Authorization` header.
 - **Agent and UI share handlers.** An action invoked by the agent and the same
   action invoked from a button run the identical handler and produce the identical
   state mutation. Write the logic once, in `canvas.mjs`.
@@ -411,6 +423,69 @@ machinery (`fileFor` sanitizes the id to a filename — copy it verbatim):
 Pick the noun (`domain` vs `profile`) deliberately — it's the whole contract for
 who shares what.
 
+## Sharing canvas state across users (GitHub-backed)
+
+When the user says **"share this canvas state with other users on GitHub"** (or
+wants several people to edit the same board), don't invent a sync mechanism and
+don't round-trip a gist by hand — gists are single-writer. Back the canvas with a
+file in a **private GitHub repo** using the kit's `githubStore`
+(`kit/github-store.mjs`): GitHub is both the shared store and the access control
+(only repo collaborators can read/write), and there's no server to run.
+
+**Ask the user which repo** to store the data in — it can be different from wherever
+they installed the canvas. (For the Canvas SDK meeting board, default to
+`jongio/canvas-sdk-planning`.) Then wire the runtime to it:
+
+```js
+import { githubStore } from "./canvas-kit/github-store.mjs";
+import { userStore } from "./canvas-kit/storage.mjs";
+
+// Let the user override the target without editing code.
+const OWNER  = process.env.CANVAS_STATE_OWNER  || "jongio";
+const REPO   = process.env.CANVAS_STATE_REPO   || "canvas-sdk-planning";
+const BRANCH = process.env.CANVAS_STATE_BRANCH || "main";
+
+const local  = (d) => userStore(EXT_NAME, `${safe(d)}.json`);      // offline mirror/fallback
+const remote = (d) => githubStore({ owner: OWNER, repo: REPO, path: `state/${safe(d)}.json`, branch: BRANCH });
+
+createCanvasRuntime({
+  // …
+  // Read the shared repo; mirror locally and fall back to it if the repo is
+  // unreachable or the caller lacks access, so the panel never hard-fails.
+  loadState: async (d) => {
+    try { const r = await remote(d).load(null); if (r != null) { await local(d).save(r).catch(()=>{}); return r; } }
+    catch (e) { console.error("remote load failed, using local:", e.message); }
+    return local(d).load(null);
+  },
+  // Write the shared repo AND keep a local mirror; a transient repo error is
+  // logged, not thrown, so an edit still lands locally and reconciles next poll.
+  saveState: async (d, state) => {
+    await local(d).save(state).catch(()=>{});
+    try { await remote(d).save(state); } catch (e) { console.error("remote save failed (kept local):", e.message); }
+  },
+  // Live pull: poll the repo (cheap ETag 304 when unchanged) so a collaborator's
+  // commit shows up here within a few seconds. Only polled while a panel is open.
+  syncState: async (d) => { try { return await remote(d).poll(); } catch { return { changed: false }; } },
+  syncIntervalMs: 5000,
+});
+```
+
+Key facts to tell the user and honor in code:
+
+- **Access = repo collaborators.** They add each teammate with **push** access
+  (`gh api -X PUT repos/<o>/<r>/collaborators/<user> -f permission=push`); private
+  invites must be accepted before they can write.
+- **Token** comes from `GH_TOKEN` / `GITHUB_TOKEN`, else `gh auth token` (needs the
+  `repo` scope), and is only ever sent as an `Authorization` header — never logged
+  or written to the repo. Pass `token` explicitly to override.
+- **Conflicts:** every write is optimistic-locked by the blob SHA; a colliding
+  commit re-reads + retries. Default is last-writer-wins for the whole document —
+  pass `merge(remoteState, myState)` to `githubStore` to resolve field-by-field
+  (e.g. union a board's items by id) so two people editing different items never
+  clobber each other.
+- **Distribution:** put the extension folder in that same repo (`extension/`) so a
+  collaborator installs the canvas AND gets the live data from one place.
+
 ## Patterns & limitations (know these)
 
 - **Bundled catalog.** For curated seed data (courses, presets), ship a separate
@@ -560,8 +635,10 @@ A canvas isn't done because the server boots. Verify the UI:
 - `test/kit-runtime.test.mjs` — exercises the runtime hardening: `kit/validate.mjs`
   input/`stateSchema` validation (incl. prototype-key safety), the `kit/net.mjs`
   SSRF guard (`assertPublicUrl`/`safeFetch`, IPv4-mapped-IPv6 forms), concurrency-safe
-  `kit/storage.mjs` saves + `sessionStore`, prototype-safe `kit/icons.mjs` name
-  resolution, and the server's bounded SSE subscriber cap.
+  `kit/storage.mjs` saves + `sessionStore`, the `kit/github-store.mjs` shared store
+  (mocked fetch: load/decode, ETag `304` poll, `409` re-read+retry, `404` fallback)
+  and the server's `syncState` adopt-and-broadcast loop, prototype-safe
+  `kit/icons.mjs` name resolution, and the server's bounded SSE subscriber cap.
 
 ## Footguns
 

--- a/skills/create-canvas-app/SKILL.md
+++ b/skills/create-canvas-app/SKILL.md
@@ -432,17 +432,17 @@ file in a **private GitHub repo** using the kit's `githubStore`
 (`kit/github-store.mjs`): GitHub is both the shared store and the access control
 (only repo collaborators can read/write), and there's no server to run.
 
-**Ask the user which repo** to store the data in — it can be different from wherever
-they installed the canvas. (For the Canvas SDK meeting board, default to
-`jongio/canvas-sdk-planning`.) Then wire the runtime to it:
+**Ask the user which repo** to store the data in — a private repo whose
+collaborators are the people who should edit the board. It can be different from
+wherever they installed the canvas. Then wire the runtime to it:
 
 ```js
 import { githubStore } from "./canvas-kit/github-store.mjs";
 import { userStore } from "./canvas-kit/storage.mjs";
 
-// Let the user override the target without editing code.
-const OWNER  = process.env.CANVAS_STATE_OWNER  || "jongio";
-const REPO   = process.env.CANVAS_STATE_REPO   || "canvas-sdk-planning";
+// The user picks the target repo; read it from env so it isn't hardcoded.
+const OWNER  = process.env.CANVAS_STATE_OWNER  || "your-org";
+const REPO   = process.env.CANVAS_STATE_REPO   || "your-canvas-state-repo";
 const BRANCH = process.env.CANVAS_STATE_BRANCH || "main";
 
 const local  = (d) => userStore(EXT_NAME, `${safe(d)}.json`);      // offline mirror/fallback

--- a/skills/create-canvas-app/SKILL.md
+++ b/skills/create-canvas-app/SKILL.md
@@ -483,6 +483,10 @@ Key facts to tell the user and honor in code:
   pass `merge(remoteState, myState)` to `githubStore` to resolve field-by-field
   (e.g. union a board's items by id) so two people editing different items never
   clobber each other.
+- **Untrusted remote:** if you set `config.stateSchema`, it guards **sync-adopted**
+  state too — a collaborator's malformed edit (or a hand-edit on github.com) that
+  violates the schema is rejected instead of being broadcast to viewers. Define a
+  `stateSchema` for any shared board so a bad remote can't corrupt everyone's panel.
 - **Distribution:** put the extension folder in that same repo (`extension/`) so a
   collaborator installs the canvas AND gets the live data from one place.
 

--- a/skills/create-canvas-app/kit/github-store.mjs
+++ b/skills/create-canvas-app/kit/github-store.mjs
@@ -1,0 +1,181 @@
+// canvas-kit/github-store.mjs
+//
+// A SHARED, multi-writer durable store backed by a file in a GitHub repository.
+// Where userStore/sessionStore/workspaceStore (storage.mjs) persist to local disk
+// — private to one machine — githubStore persists the same JSON to a file in a
+// repo via the Contents API, so every collaborator who can push to that repo edits
+// ONE shared document. GitHub is the backing store AND the access-control layer
+// (invite collaborators to a private repo); there is no server to run.
+//
+// It exposes the same { load, save } shape the runtime's loadState/saveState
+// expect, plus poll() for cheap change-detection so a canvas can pull other
+// people's edits live (wire it to server.mjs's syncState + syncIntervalMs).
+//
+// Concurrency: every write carries the blob sha it read (optimistic lock). A
+// concurrent commit makes the PUT 409; save() re-reads to refresh the sha and
+// retries. The default policy is last-writer-wins for the whole document; pass a
+// merge(remoteState, myState) to resolve conflicts field-by-field instead (e.g.
+// union a board's concerns by id). Reads use an ETag If-None-Match so an unchanged
+// poll is a cheap 304 with no body.
+//
+// Token: resolved once from opts.token (string | async () => string), then
+// GH_TOKEN / GITHUB_TOKEN, then `gh auth token`. Needs the `repo` scope for a
+// private repo. The token is only ever sent as an Authorization header — never
+// logged, never written to the repo.
+
+import { execFile } from "node:child_process";
+
+const API = "https://api.github.com";
+const UA = "canvas-kit-github-store";
+
+// Resolve a GitHub token lazily and memoize it. A 401 (expired/rotated) clears the
+// cache via invalidate() so the next call re-resolves.
+function makeTokenResolver(tokenOpt) {
+  let cached = null;
+  async function fromGhCli() {
+    return new Promise((resolve) => {
+      execFile("gh", ["auth", "token"], { windowsHide: true }, (err, stdout) => {
+        resolve(err ? null : String(stdout).trim() || null);
+      });
+    });
+  }
+  return {
+    async get() {
+      if (cached) return cached;
+      let t = null;
+      if (typeof tokenOpt === "function") t = await tokenOpt();
+      else if (typeof tokenOpt === "string" && tokenOpt) t = tokenOpt;
+      if (!t) t = process.env.GH_TOKEN || process.env.GITHUB_TOKEN || null;
+      if (!t) t = await fromGhCli();
+      if (!t) throw new Error("githubStore: no GitHub token (set GH_TOKEN or run `gh auth login`)");
+      cached = t;
+      return cached;
+    },
+    invalidate() { cached = null; },
+  };
+}
+
+function encodePath(path) {
+  // Keep the slashes as path separators in the Contents API URL; encode each
+  // segment so spaces / unicode in a filename can't break the request.
+  return String(path).split("/").filter(Boolean).map(encodeURIComponent).join("/");
+}
+
+/**
+ * A GitHub-repo-backed durable store: one JSON file, many writers.
+ * @param {object} opts
+ * @param {string} opts.owner    repo owner (user or org)
+ * @param {string} opts.repo     repo name
+ * @param {string} opts.path     path to the JSON file in the repo (e.g. "state/board.json")
+ * @param {string} [opts.branch="main"]
+ * @param {string|(()=>Promise<string>|string)} [opts.token]  token or async resolver
+ * @param {(remote:any,mine:any)=>any} [opts.merge]  conflict resolver (default: last-writer-wins)
+ * @param {(state:any)=>string} [opts.message]  commit message from the state (default: a timestamp)
+ * @param {string} [opts.apiBase=API]
+ * @returns {{file:string, load:(fallback?:any)=>Promise<any>, poll:()=>Promise<{changed:boolean,state?:any}>, save:(state:any)=>Promise<void>}}
+ */
+export function githubStore(opts) {
+  const { owner, repo, path, branch = "main", token, merge, message, apiBase = API } = opts ?? {};
+  if (!owner || !repo || !path) throw new Error("githubStore: owner, repo and path are required");
+
+  const tok = makeTokenResolver(token);
+  const contentsUrl = `${apiBase}/repos/${owner}/${repo}/contents/${encodePath(path)}`;
+  const label = `${owner}/${repo}:${path}`;
+
+  let sha = null;      // last-seen blob sha — sent on write as the optimistic lock
+  let etag = null;     // last-seen ETag — sent on poll as If-None-Match
+  let lastText = null; // last-seen decoded content — guards against no-op broadcasts
+
+  async function api(url, init = {}, allow = []) {
+    const t = await tok.get();
+    const res = await fetch(url, {
+      ...init,
+      headers: {
+        Authorization: `Bearer ${t}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": UA,
+        ...(init.headers ?? {}),
+      },
+    });
+    // An expired token surfaces as 401 — drop the memoized token so a retry can
+    // re-resolve (e.g. after `gh auth refresh`), then surface the failure.
+    if (res.status === 401) { tok.invalidate(); }
+    // ok, or an expected status the caller handles (404 fresh-file, 304 unchanged,
+    // 409 write conflict), pass through; anything else is a hard error.
+    if (res.ok || allow.includes(res.status)) return res;
+    const body = await res.text().catch(() => "");
+    throw new Error(`githubStore ${label}: ${init.method ?? "GET"} ${res.status} ${body.slice(0, 200)}`);
+  }
+
+  function decode(json) {
+    // Contents API returns base64 (wrapped at 60 cols); Buffer handles the newlines.
+    return Buffer.from(json.content ?? "", "base64").toString("utf8");
+  }
+
+  async function load(fallback = null) {
+    const res = await api(`${contentsUrl}?ref=${encodeURIComponent(branch)}`, {}, [404]);
+    if (res.status === 404) { sha = null; etag = null; lastText = null; return fallback; }
+    const json = await res.json();
+    sha = json.sha ?? null;
+    etag = res.headers.get("etag");
+    const text = decode(json);
+    lastText = text;
+    return text.trim() ? JSON.parse(text) : fallback;
+  }
+
+  async function poll() {
+    const headers = etag ? { "If-None-Match": etag } : {};
+    const res = await api(`${contentsUrl}?ref=${encodeURIComponent(branch)}`, { headers }, [304, 404]);
+    if (res.status === 304) return { changed: false };
+    if (res.status === 404) {
+      if (sha === null && lastText === null) return { changed: false };
+      sha = null; etag = null; lastText = null;
+      return { changed: true, state: null };
+    }
+    const json = await res.json();
+    const text = decode(json);
+    sha = json.sha ?? null;
+    etag = res.headers.get("etag");
+    if (text === lastText) return { changed: false };
+    lastText = text;
+    return { changed: true, state: text.trim() ? JSON.parse(text) : null };
+  }
+
+  async function save(state) {
+    let toWrite = state;
+    for (let attempt = 0; ; attempt++) {
+      const text = JSON.stringify(toWrite, null, 2);
+      const body = {
+        message: (message ? message(toWrite) : `Update ${path}`) || `Update ${path}`,
+        content: Buffer.from(text, "utf8").toString("base64"),
+        branch,
+        ...(sha ? { sha } : {}),
+      };
+      const res = await api(contentsUrl, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      }, [409, 404]);
+      if (res.ok) {
+        const json = await res.json();
+        sha = json.content?.sha ?? null;
+        etag = null;       // PUT's ETag isn't the content GET's — force a fresh poll baseline
+        lastText = text;   // our own write must not read back as a change
+        return;
+      }
+      // 409 (or a 404 if the file/branch vanished): the sha we held is stale.
+      // Re-read to refresh sha, optionally merge the remote with our intended
+      // write, and retry. Bounded so a persistent conflict fails loudly.
+      if ((res.status === 409 || res.status === 404) && attempt < 3) {
+        const remote = await load(null);
+        toWrite = merge ? merge(remote, state) : state; // default: last-writer-wins
+        continue;
+      }
+      const errBody = await res.text().catch(() => "");
+      throw new Error(`githubStore ${label}: save failed ${res.status} ${errBody.slice(0, 200)}`);
+    }
+  }
+
+  return { file: label, load, poll, save };
+}

--- a/skills/create-canvas-app/kit/github-store.mjs
+++ b/skills/create-canvas-app/kit/github-store.mjs
@@ -24,20 +24,33 @@
 // logged, never written to the repo.
 
 import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
 
 const API = "https://api.github.com";
 const UA = "canvas-kit-github-store";
+// Hard deadline for every GitHub API call so a hung request (stalled TLS, dropped
+// connection) can't freeze a user action or dead-lock the sync loop (mirrors the
+// AbortSignal.timeout pattern in net.mjs safeFetch).
+const DEFAULT_TIMEOUT_MS = 15000;
+// Refuse an implausibly large state file rather than allocate it on every poll. A
+// board's JSON is tens of KB; this is a safety ceiling, not a real size limit.
+const MAX_RESPONSE_BYTES = 8 * 1024 * 1024;
+// Bounded save retries on an optimistic-lock conflict (409) before failing loud.
+const MAX_SAVE_RETRIES = 3;
 
 // Resolve a GitHub token lazily and memoize it. A 401 (expired/rotated) clears the
 // cache via invalidate() so the next call re-resolves.
 function makeTokenResolver(tokenOpt) {
   let cached = null;
   async function fromGhCli() {
-    return new Promise((resolve) => {
-      execFile("gh", ["auth", "token"], { windowsHide: true }, (err, stdout) => {
-        resolve(err ? null : String(stdout).trim() || null);
-      });
-    });
+    try {
+      const { stdout } = await execFileAsync("gh", ["auth", "token"], { windowsHide: true });
+      return String(stdout).trim() || null;
+    } catch {
+      return null; // gh missing or not logged in → fall through to the no-token error
+    }
   }
   return {
     async get() {
@@ -77,9 +90,19 @@ function encodePath(path) {
 export function githubStore(opts) {
   const { owner, repo, path, branch = "main", token, merge, message, apiBase = API } = opts ?? {};
   if (!owner || !repo || !path) throw new Error("githubStore: owner, repo and path are required");
+  // apiBase is a trusted, fixed host by design — GitHub's public API by default, or a
+  // GitHub Enterprise host the canvas author sets at construction (never runtime
+  // input). That's why we call fetch() directly rather than the kit's safeFetch SSRF
+  // guard, which would add a DNS-resolution check on every call for a host that can't
+  // vary per request. Still, require https for any custom apiBase as defense-in-depth.
+  if (apiBase !== API) {
+    let base;
+    try { base = new URL(apiBase); } catch { throw new Error("githubStore: apiBase must be a valid URL"); }
+    if (base.protocol !== "https:") throw new Error("githubStore: apiBase must be https");
+  }
 
   const tok = makeTokenResolver(token);
-  const contentsUrl = `${apiBase}/repos/${owner}/${repo}/contents/${encodePath(path)}`;
+  const contentsUrl = `${apiBase}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/contents/${encodePath(path)}`;
   const label = `${owner}/${repo}:${path}`;
 
   let sha = null;      // last-seen blob sha — sent on write as the optimistic lock
@@ -90,6 +113,7 @@ export function githubStore(opts) {
     const t = await tok.get();
     const res = await fetch(url, {
       ...init,
+      signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
       headers: {
         Authorization: `Bearer ${t}`,
         Accept: "application/vnd.github+json",
@@ -113,10 +137,20 @@ export function githubStore(opts) {
     return Buffer.from(json.content ?? "", "base64").toString("utf8");
   }
 
+  async function readJson(res) {
+    // Bound the allocation: refuse an oversized response before reading it, so a
+    // huge state file can't be pulled into memory on every poll tick.
+    const len = Number(res.headers.get("content-length") || 0);
+    if (len > MAX_RESPONSE_BYTES) {
+      throw new Error(`githubStore ${label}: response too large (${len} bytes)`);
+    }
+    return res.json();
+  }
+
   async function load(fallback = null) {
     const res = await api(`${contentsUrl}?ref=${encodeURIComponent(branch)}`, {}, [404]);
     if (res.status === 404) { sha = null; etag = null; lastText = null; return fallback; }
-    const json = await res.json();
+    const json = await readJson(res);
     sha = json.sha ?? null;
     etag = res.headers.get("etag");
     const text = decode(json);
@@ -133,7 +167,7 @@ export function githubStore(opts) {
       sha = null; etag = null; lastText = null;
       return { changed: true, state: null };
     }
-    const json = await res.json();
+    const json = await readJson(res);
     const text = decode(json);
     sha = json.sha ?? null;
     etag = res.headers.get("etag");
@@ -167,7 +201,7 @@ export function githubStore(opts) {
       // 409 (or a 404 if the file/branch vanished): the sha we held is stale.
       // Re-read to refresh sha, optionally merge the remote with our intended
       // write, and retry. Bounded so a persistent conflict fails loudly.
-      if ((res.status === 409 || res.status === 404) && attempt < 3) {
+      if ((res.status === 409 || res.status === 404) && attempt < MAX_SAVE_RETRIES) {
         const remote = await load(null);
         toWrite = merge ? merge(remote, state) : state; // default: last-writer-wins
         continue;

--- a/skills/create-canvas-app/kit/server.mjs
+++ b/skills/create-canvas-app/kit/server.mjs
@@ -142,7 +142,19 @@ export function createCanvasRuntime(config) {
       // is ignored so a transient upstream gap can't blank a live board.
       if (out?.changed && out.state != null) {
         const d = domains.get(domainId);
-        if (d) { d.state = out.state; broadcast(domainId); }
+        if (d) {
+          // Adopted remote state must clear the SAME stateSchema gate the invoke()
+          // path enforces. A collaborator (or a hand-edit on github.com) can push a
+          // shape that violates the schema; adopting it unvalidated would broadcast a
+          // corrupt shape to every viewer AND poison the next invoke()'s rollback
+          // baseline (structuredClone would snapshot the already-invalid state).
+          // Reject (skip) an invalid remote instead — the next valid write reconciles.
+          if (config.stateSchema && validate(config.stateSchema, out.state, "sync-remote").length) {
+            return;
+          }
+          d.state = out.state;
+          broadcast(domainId);
+        }
       }
     } catch {
       // A transient network/API error must not kill the timer; retry next tick.
@@ -157,10 +169,16 @@ export function createCanvasRuntime(config) {
     }
   }
 
+  // Floor the poll cadence: a mistakenly tiny interval (e.g. 1ms) would hammer the
+  // durable source — for githubStore that means burning the GitHub API rate limit in
+  // seconds. 2s is well below any real collaboration-latency need.
+  const MIN_SYNC_INTERVAL_MS = 2000;
+
   function startSync() {
     if (syncTimer || typeof config.syncState !== "function") return;
-    const ms = Number(config.syncIntervalMs) || 0;
-    if (ms <= 0) return;
+    const requested = Number(config.syncIntervalMs) || 0;
+    if (requested <= 0) return;
+    const ms = Math.max(requested, MIN_SYNC_INTERVAL_MS);
     syncTimer = setInterval(syncTick, ms);
     syncTimer.unref?.(); // never keep the process alive just to poll
   }

--- a/skills/create-canvas-app/kit/server.mjs
+++ b/skills/create-canvas-app/kit/server.mjs
@@ -53,6 +53,8 @@ export class CanvasKitError extends Error {
  * @param {(ctx:object)=>any|Promise<any>} [config.createInitialState]
  * @param {(domainId:string)=>any|Promise<any>} [config.loadState]
  * @param {(domainId:string, state:any)=>void|Promise<void>} [config.saveState]
+ * @param {(domainId:string)=>{changed:boolean,state?:any}|Promise<{changed:boolean,state?:any}>} [config.syncState]  optional delta-poll of a SHARED durable source (e.g. githubStore.poll); when set with syncIntervalMs, remote changes are adopted + broadcast to viewers live
+ * @param {number} [config.syncIntervalMs]  poll cadence for syncState; only polled while a domain has >=1 connected viewer
  * @param {Record<string,{description?:string,inputSchema?:object,handler:Function}>} config.actions
  * @param {object} [config.stateSchema]  optional JSON-Schema-subset for the durable state; when set, a mutation that violates it is rolled back and fails (500)
  * @param {string} config.assetsDir  absolute path to the canvas web/ folder
@@ -112,6 +114,59 @@ export function createCanvasRuntime(config) {
         try { res.write(payload); } catch { /* dropped client */ }
       }
     }
+  }
+
+  // ---- optional shared-state sync (repo-backed multiplayer) ----------------
+  // When config.syncState + config.syncIntervalMs are set, poll the durable
+  // source on an interval and adopt+broadcast remote changes, so collaborators
+  // editing a SHARED store (e.g. githubStore) see each other's edits live. We
+  // only poll a domain while at least one SSE client is watching it — no viewers,
+  // no network — so API usage stays proportional to real use. syncState returns
+  // { changed:boolean, state? }; a cheap unchanged poll (ETag 304) is changed:false.
+  const syncing = new Set(); // domainIds with an in-flight poll (prevents overlap)
+  let syncTimer = null;
+
+  function domainHasViewers(domainId) {
+    for (const inst of instances.values()) {
+      if (inst.domainId === domainId && inst.clients.size > 0) return true;
+    }
+    return false;
+  }
+
+  async function syncDomain(domainId) {
+    if (syncing.has(domainId)) return; // last tick still in flight — skip
+    syncing.add(domainId);
+    try {
+      const out = await config.syncState(domainId);
+      // Adopt only a real, non-null remote state. A null (file deleted upstream)
+      // is ignored so a transient upstream gap can't blank a live board.
+      if (out?.changed && out.state != null) {
+        const d = domains.get(domainId);
+        if (d) { d.state = out.state; broadcast(domainId); }
+      }
+    } catch {
+      // A transient network/API error must not kill the timer; retry next tick.
+    } finally {
+      syncing.delete(domainId);
+    }
+  }
+
+  function syncTick() {
+    for (const domainId of domains.keys()) {
+      if (domainHasViewers(domainId)) syncDomain(domainId);
+    }
+  }
+
+  function startSync() {
+    if (syncTimer || typeof config.syncState !== "function") return;
+    const ms = Number(config.syncIntervalMs) || 0;
+    if (ms <= 0) return;
+    syncTimer = setInterval(syncTick, ms);
+    syncTimer.unref?.(); // never keep the process alive just to poll
+  }
+
+  function stopSync() {
+    if (syncTimer) { clearInterval(syncTimer); syncTimer = null; }
   }
 
   // Core action invoker — the single code path behind both agent and UI actions.
@@ -401,12 +456,15 @@ export function createCanvasRuntime(config) {
   }
 
   async function shutdown() {
+    stopSync();
     await Promise.all([...instances.keys()].map(closeInstance));
   }
 
   async function getState(domainId = "default") {
     return (await getDomain(domainId)).state;
   }
+
+  startSync(); // no-op unless config.syncState + syncIntervalMs are set
 
   return {
     config,
@@ -418,5 +476,6 @@ export function createCanvasRuntime(config) {
     invokeFromAgent, // agent-side, resolves domain from ctx
     getState,
     _instances: instances,
+    _syncDomain: syncDomain, // manual one-shot sync (tests)
   };
 }

--- a/skills/create-canvas-app/kit/version.mjs
+++ b/skills/create-canvas-app/kit/version.mjs
@@ -10,4 +10,4 @@
 // convention (the skill ships as files, not an npm version); a commit short-sha
 // works too. Re-exported from client.mjs so a canvas can read it at runtime.
 
-export const KIT_VERSION = "2026-07-07.4";
+export const KIT_VERSION = "2026-07-07.5";

--- a/skills/create-canvas-app/kit/version.mjs
+++ b/skills/create-canvas-app/kit/version.mjs
@@ -10,4 +10,4 @@
 // convention (the skill ships as files, not an npm version); a commit short-sha
 // works too. Re-exported from client.mjs so a canvas can read it at runtime.
 
-export const KIT_VERSION = "2026-07-07.5";
+export const KIT_VERSION = "2026-07-07.6";

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/.kit-version.json
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/.kit-version.json
@@ -1,5 +1,5 @@
 {
-  "version": "2026-07-07.5",
-  "syncedAt": "2026-07-07T21:08:16.143Z",
+  "version": "2026-07-07.6",
+  "syncedAt": "2026-07-07T21:57:36.194Z",
   "source": "create-canvas-app/kit"
 }

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/.kit-version.json
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/.kit-version.json
@@ -1,5 +1,5 @@
 {
-  "version": "2026-07-07.4",
-  "syncedAt": "2026-07-07T17:17:56.262Z",
+  "version": "2026-07-07.5",
+  "syncedAt": "2026-07-07T21:08:16.143Z",
   "source": "create-canvas-app/kit"
 }

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/github-store.mjs
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/github-store.mjs
@@ -1,0 +1,181 @@
+// canvas-kit/github-store.mjs
+//
+// A SHARED, multi-writer durable store backed by a file in a GitHub repository.
+// Where userStore/sessionStore/workspaceStore (storage.mjs) persist to local disk
+// — private to one machine — githubStore persists the same JSON to a file in a
+// repo via the Contents API, so every collaborator who can push to that repo edits
+// ONE shared document. GitHub is the backing store AND the access-control layer
+// (invite collaborators to a private repo); there is no server to run.
+//
+// It exposes the same { load, save } shape the runtime's loadState/saveState
+// expect, plus poll() for cheap change-detection so a canvas can pull other
+// people's edits live (wire it to server.mjs's syncState + syncIntervalMs).
+//
+// Concurrency: every write carries the blob sha it read (optimistic lock). A
+// concurrent commit makes the PUT 409; save() re-reads to refresh the sha and
+// retries. The default policy is last-writer-wins for the whole document; pass a
+// merge(remoteState, myState) to resolve conflicts field-by-field instead (e.g.
+// union a board's concerns by id). Reads use an ETag If-None-Match so an unchanged
+// poll is a cheap 304 with no body.
+//
+// Token: resolved once from opts.token (string | async () => string), then
+// GH_TOKEN / GITHUB_TOKEN, then `gh auth token`. Needs the `repo` scope for a
+// private repo. The token is only ever sent as an Authorization header — never
+// logged, never written to the repo.
+
+import { execFile } from "node:child_process";
+
+const API = "https://api.github.com";
+const UA = "canvas-kit-github-store";
+
+// Resolve a GitHub token lazily and memoize it. A 401 (expired/rotated) clears the
+// cache via invalidate() so the next call re-resolves.
+function makeTokenResolver(tokenOpt) {
+  let cached = null;
+  async function fromGhCli() {
+    return new Promise((resolve) => {
+      execFile("gh", ["auth", "token"], { windowsHide: true }, (err, stdout) => {
+        resolve(err ? null : String(stdout).trim() || null);
+      });
+    });
+  }
+  return {
+    async get() {
+      if (cached) return cached;
+      let t = null;
+      if (typeof tokenOpt === "function") t = await tokenOpt();
+      else if (typeof tokenOpt === "string" && tokenOpt) t = tokenOpt;
+      if (!t) t = process.env.GH_TOKEN || process.env.GITHUB_TOKEN || null;
+      if (!t) t = await fromGhCli();
+      if (!t) throw new Error("githubStore: no GitHub token (set GH_TOKEN or run `gh auth login`)");
+      cached = t;
+      return cached;
+    },
+    invalidate() { cached = null; },
+  };
+}
+
+function encodePath(path) {
+  // Keep the slashes as path separators in the Contents API URL; encode each
+  // segment so spaces / unicode in a filename can't break the request.
+  return String(path).split("/").filter(Boolean).map(encodeURIComponent).join("/");
+}
+
+/**
+ * A GitHub-repo-backed durable store: one JSON file, many writers.
+ * @param {object} opts
+ * @param {string} opts.owner    repo owner (user or org)
+ * @param {string} opts.repo     repo name
+ * @param {string} opts.path     path to the JSON file in the repo (e.g. "state/board.json")
+ * @param {string} [opts.branch="main"]
+ * @param {string|(()=>Promise<string>|string)} [opts.token]  token or async resolver
+ * @param {(remote:any,mine:any)=>any} [opts.merge]  conflict resolver (default: last-writer-wins)
+ * @param {(state:any)=>string} [opts.message]  commit message from the state (default: a timestamp)
+ * @param {string} [opts.apiBase=API]
+ * @returns {{file:string, load:(fallback?:any)=>Promise<any>, poll:()=>Promise<{changed:boolean,state?:any}>, save:(state:any)=>Promise<void>}}
+ */
+export function githubStore(opts) {
+  const { owner, repo, path, branch = "main", token, merge, message, apiBase = API } = opts ?? {};
+  if (!owner || !repo || !path) throw new Error("githubStore: owner, repo and path are required");
+
+  const tok = makeTokenResolver(token);
+  const contentsUrl = `${apiBase}/repos/${owner}/${repo}/contents/${encodePath(path)}`;
+  const label = `${owner}/${repo}:${path}`;
+
+  let sha = null;      // last-seen blob sha — sent on write as the optimistic lock
+  let etag = null;     // last-seen ETag — sent on poll as If-None-Match
+  let lastText = null; // last-seen decoded content — guards against no-op broadcasts
+
+  async function api(url, init = {}, allow = []) {
+    const t = await tok.get();
+    const res = await fetch(url, {
+      ...init,
+      headers: {
+        Authorization: `Bearer ${t}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": UA,
+        ...(init.headers ?? {}),
+      },
+    });
+    // An expired token surfaces as 401 — drop the memoized token so a retry can
+    // re-resolve (e.g. after `gh auth refresh`), then surface the failure.
+    if (res.status === 401) { tok.invalidate(); }
+    // ok, or an expected status the caller handles (404 fresh-file, 304 unchanged,
+    // 409 write conflict), pass through; anything else is a hard error.
+    if (res.ok || allow.includes(res.status)) return res;
+    const body = await res.text().catch(() => "");
+    throw new Error(`githubStore ${label}: ${init.method ?? "GET"} ${res.status} ${body.slice(0, 200)}`);
+  }
+
+  function decode(json) {
+    // Contents API returns base64 (wrapped at 60 cols); Buffer handles the newlines.
+    return Buffer.from(json.content ?? "", "base64").toString("utf8");
+  }
+
+  async function load(fallback = null) {
+    const res = await api(`${contentsUrl}?ref=${encodeURIComponent(branch)}`, {}, [404]);
+    if (res.status === 404) { sha = null; etag = null; lastText = null; return fallback; }
+    const json = await res.json();
+    sha = json.sha ?? null;
+    etag = res.headers.get("etag");
+    const text = decode(json);
+    lastText = text;
+    return text.trim() ? JSON.parse(text) : fallback;
+  }
+
+  async function poll() {
+    const headers = etag ? { "If-None-Match": etag } : {};
+    const res = await api(`${contentsUrl}?ref=${encodeURIComponent(branch)}`, { headers }, [304, 404]);
+    if (res.status === 304) return { changed: false };
+    if (res.status === 404) {
+      if (sha === null && lastText === null) return { changed: false };
+      sha = null; etag = null; lastText = null;
+      return { changed: true, state: null };
+    }
+    const json = await res.json();
+    const text = decode(json);
+    sha = json.sha ?? null;
+    etag = res.headers.get("etag");
+    if (text === lastText) return { changed: false };
+    lastText = text;
+    return { changed: true, state: text.trim() ? JSON.parse(text) : null };
+  }
+
+  async function save(state) {
+    let toWrite = state;
+    for (let attempt = 0; ; attempt++) {
+      const text = JSON.stringify(toWrite, null, 2);
+      const body = {
+        message: (message ? message(toWrite) : `Update ${path}`) || `Update ${path}`,
+        content: Buffer.from(text, "utf8").toString("base64"),
+        branch,
+        ...(sha ? { sha } : {}),
+      };
+      const res = await api(contentsUrl, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      }, [409, 404]);
+      if (res.ok) {
+        const json = await res.json();
+        sha = json.content?.sha ?? null;
+        etag = null;       // PUT's ETag isn't the content GET's — force a fresh poll baseline
+        lastText = text;   // our own write must not read back as a change
+        return;
+      }
+      // 409 (or a 404 if the file/branch vanished): the sha we held is stale.
+      // Re-read to refresh sha, optionally merge the remote with our intended
+      // write, and retry. Bounded so a persistent conflict fails loudly.
+      if ((res.status === 409 || res.status === 404) && attempt < 3) {
+        const remote = await load(null);
+        toWrite = merge ? merge(remote, state) : state; // default: last-writer-wins
+        continue;
+      }
+      const errBody = await res.text().catch(() => "");
+      throw new Error(`githubStore ${label}: save failed ${res.status} ${errBody.slice(0, 200)}`);
+    }
+  }
+
+  return { file: label, load, poll, save };
+}

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/github-store.mjs
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/github-store.mjs
@@ -24,20 +24,33 @@
 // logged, never written to the repo.
 
 import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
 
 const API = "https://api.github.com";
 const UA = "canvas-kit-github-store";
+// Hard deadline for every GitHub API call so a hung request (stalled TLS, dropped
+// connection) can't freeze a user action or dead-lock the sync loop (mirrors the
+// AbortSignal.timeout pattern in net.mjs safeFetch).
+const DEFAULT_TIMEOUT_MS = 15000;
+// Refuse an implausibly large state file rather than allocate it on every poll. A
+// board's JSON is tens of KB; this is a safety ceiling, not a real size limit.
+const MAX_RESPONSE_BYTES = 8 * 1024 * 1024;
+// Bounded save retries on an optimistic-lock conflict (409) before failing loud.
+const MAX_SAVE_RETRIES = 3;
 
 // Resolve a GitHub token lazily and memoize it. A 401 (expired/rotated) clears the
 // cache via invalidate() so the next call re-resolves.
 function makeTokenResolver(tokenOpt) {
   let cached = null;
   async function fromGhCli() {
-    return new Promise((resolve) => {
-      execFile("gh", ["auth", "token"], { windowsHide: true }, (err, stdout) => {
-        resolve(err ? null : String(stdout).trim() || null);
-      });
-    });
+    try {
+      const { stdout } = await execFileAsync("gh", ["auth", "token"], { windowsHide: true });
+      return String(stdout).trim() || null;
+    } catch {
+      return null; // gh missing or not logged in → fall through to the no-token error
+    }
   }
   return {
     async get() {
@@ -77,9 +90,19 @@ function encodePath(path) {
 export function githubStore(opts) {
   const { owner, repo, path, branch = "main", token, merge, message, apiBase = API } = opts ?? {};
   if (!owner || !repo || !path) throw new Error("githubStore: owner, repo and path are required");
+  // apiBase is a trusted, fixed host by design — GitHub's public API by default, or a
+  // GitHub Enterprise host the canvas author sets at construction (never runtime
+  // input). That's why we call fetch() directly rather than the kit's safeFetch SSRF
+  // guard, which would add a DNS-resolution check on every call for a host that can't
+  // vary per request. Still, require https for any custom apiBase as defense-in-depth.
+  if (apiBase !== API) {
+    let base;
+    try { base = new URL(apiBase); } catch { throw new Error("githubStore: apiBase must be a valid URL"); }
+    if (base.protocol !== "https:") throw new Error("githubStore: apiBase must be https");
+  }
 
   const tok = makeTokenResolver(token);
-  const contentsUrl = `${apiBase}/repos/${owner}/${repo}/contents/${encodePath(path)}`;
+  const contentsUrl = `${apiBase}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/contents/${encodePath(path)}`;
   const label = `${owner}/${repo}:${path}`;
 
   let sha = null;      // last-seen blob sha — sent on write as the optimistic lock
@@ -90,6 +113,7 @@ export function githubStore(opts) {
     const t = await tok.get();
     const res = await fetch(url, {
       ...init,
+      signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
       headers: {
         Authorization: `Bearer ${t}`,
         Accept: "application/vnd.github+json",
@@ -113,10 +137,20 @@ export function githubStore(opts) {
     return Buffer.from(json.content ?? "", "base64").toString("utf8");
   }
 
+  async function readJson(res) {
+    // Bound the allocation: refuse an oversized response before reading it, so a
+    // huge state file can't be pulled into memory on every poll tick.
+    const len = Number(res.headers.get("content-length") || 0);
+    if (len > MAX_RESPONSE_BYTES) {
+      throw new Error(`githubStore ${label}: response too large (${len} bytes)`);
+    }
+    return res.json();
+  }
+
   async function load(fallback = null) {
     const res = await api(`${contentsUrl}?ref=${encodeURIComponent(branch)}`, {}, [404]);
     if (res.status === 404) { sha = null; etag = null; lastText = null; return fallback; }
-    const json = await res.json();
+    const json = await readJson(res);
     sha = json.sha ?? null;
     etag = res.headers.get("etag");
     const text = decode(json);
@@ -133,7 +167,7 @@ export function githubStore(opts) {
       sha = null; etag = null; lastText = null;
       return { changed: true, state: null };
     }
-    const json = await res.json();
+    const json = await readJson(res);
     const text = decode(json);
     sha = json.sha ?? null;
     etag = res.headers.get("etag");
@@ -167,7 +201,7 @@ export function githubStore(opts) {
       // 409 (or a 404 if the file/branch vanished): the sha we held is stale.
       // Re-read to refresh sha, optionally merge the remote with our intended
       // write, and retry. Bounded so a persistent conflict fails loudly.
-      if ((res.status === 409 || res.status === 404) && attempt < 3) {
+      if ((res.status === 409 || res.status === 404) && attempt < MAX_SAVE_RETRIES) {
         const remote = await load(null);
         toWrite = merge ? merge(remote, state) : state; // default: last-writer-wins
         continue;

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/server.mjs
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/server.mjs
@@ -142,7 +142,19 @@ export function createCanvasRuntime(config) {
       // is ignored so a transient upstream gap can't blank a live board.
       if (out?.changed && out.state != null) {
         const d = domains.get(domainId);
-        if (d) { d.state = out.state; broadcast(domainId); }
+        if (d) {
+          // Adopted remote state must clear the SAME stateSchema gate the invoke()
+          // path enforces. A collaborator (or a hand-edit on github.com) can push a
+          // shape that violates the schema; adopting it unvalidated would broadcast a
+          // corrupt shape to every viewer AND poison the next invoke()'s rollback
+          // baseline (structuredClone would snapshot the already-invalid state).
+          // Reject (skip) an invalid remote instead — the next valid write reconciles.
+          if (config.stateSchema && validate(config.stateSchema, out.state, "sync-remote").length) {
+            return;
+          }
+          d.state = out.state;
+          broadcast(domainId);
+        }
       }
     } catch {
       // A transient network/API error must not kill the timer; retry next tick.
@@ -157,10 +169,16 @@ export function createCanvasRuntime(config) {
     }
   }
 
+  // Floor the poll cadence: a mistakenly tiny interval (e.g. 1ms) would hammer the
+  // durable source — for githubStore that means burning the GitHub API rate limit in
+  // seconds. 2s is well below any real collaboration-latency need.
+  const MIN_SYNC_INTERVAL_MS = 2000;
+
   function startSync() {
     if (syncTimer || typeof config.syncState !== "function") return;
-    const ms = Number(config.syncIntervalMs) || 0;
-    if (ms <= 0) return;
+    const requested = Number(config.syncIntervalMs) || 0;
+    if (requested <= 0) return;
+    const ms = Math.max(requested, MIN_SYNC_INTERVAL_MS);
     syncTimer = setInterval(syncTick, ms);
     syncTimer.unref?.(); // never keep the process alive just to poll
   }

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/server.mjs
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/server.mjs
@@ -53,6 +53,8 @@ export class CanvasKitError extends Error {
  * @param {(ctx:object)=>any|Promise<any>} [config.createInitialState]
  * @param {(domainId:string)=>any|Promise<any>} [config.loadState]
  * @param {(domainId:string, state:any)=>void|Promise<void>} [config.saveState]
+ * @param {(domainId:string)=>{changed:boolean,state?:any}|Promise<{changed:boolean,state?:any}>} [config.syncState]  optional delta-poll of a SHARED durable source (e.g. githubStore.poll); when set with syncIntervalMs, remote changes are adopted + broadcast to viewers live
+ * @param {number} [config.syncIntervalMs]  poll cadence for syncState; only polled while a domain has >=1 connected viewer
  * @param {Record<string,{description?:string,inputSchema?:object,handler:Function}>} config.actions
  * @param {object} [config.stateSchema]  optional JSON-Schema-subset for the durable state; when set, a mutation that violates it is rolled back and fails (500)
  * @param {string} config.assetsDir  absolute path to the canvas web/ folder
@@ -112,6 +114,59 @@ export function createCanvasRuntime(config) {
         try { res.write(payload); } catch { /* dropped client */ }
       }
     }
+  }
+
+  // ---- optional shared-state sync (repo-backed multiplayer) ----------------
+  // When config.syncState + config.syncIntervalMs are set, poll the durable
+  // source on an interval and adopt+broadcast remote changes, so collaborators
+  // editing a SHARED store (e.g. githubStore) see each other's edits live. We
+  // only poll a domain while at least one SSE client is watching it — no viewers,
+  // no network — so API usage stays proportional to real use. syncState returns
+  // { changed:boolean, state? }; a cheap unchanged poll (ETag 304) is changed:false.
+  const syncing = new Set(); // domainIds with an in-flight poll (prevents overlap)
+  let syncTimer = null;
+
+  function domainHasViewers(domainId) {
+    for (const inst of instances.values()) {
+      if (inst.domainId === domainId && inst.clients.size > 0) return true;
+    }
+    return false;
+  }
+
+  async function syncDomain(domainId) {
+    if (syncing.has(domainId)) return; // last tick still in flight — skip
+    syncing.add(domainId);
+    try {
+      const out = await config.syncState(domainId);
+      // Adopt only a real, non-null remote state. A null (file deleted upstream)
+      // is ignored so a transient upstream gap can't blank a live board.
+      if (out?.changed && out.state != null) {
+        const d = domains.get(domainId);
+        if (d) { d.state = out.state; broadcast(domainId); }
+      }
+    } catch {
+      // A transient network/API error must not kill the timer; retry next tick.
+    } finally {
+      syncing.delete(domainId);
+    }
+  }
+
+  function syncTick() {
+    for (const domainId of domains.keys()) {
+      if (domainHasViewers(domainId)) syncDomain(domainId);
+    }
+  }
+
+  function startSync() {
+    if (syncTimer || typeof config.syncState !== "function") return;
+    const ms = Number(config.syncIntervalMs) || 0;
+    if (ms <= 0) return;
+    syncTimer = setInterval(syncTick, ms);
+    syncTimer.unref?.(); // never keep the process alive just to poll
+  }
+
+  function stopSync() {
+    if (syncTimer) { clearInterval(syncTimer); syncTimer = null; }
   }
 
   // Core action invoker — the single code path behind both agent and UI actions.
@@ -401,12 +456,15 @@ export function createCanvasRuntime(config) {
   }
 
   async function shutdown() {
+    stopSync();
     await Promise.all([...instances.keys()].map(closeInstance));
   }
 
   async function getState(domainId = "default") {
     return (await getDomain(domainId)).state;
   }
+
+  startSync(); // no-op unless config.syncState + syncIntervalMs are set
 
   return {
     config,
@@ -418,5 +476,6 @@ export function createCanvasRuntime(config) {
     invokeFromAgent, // agent-side, resolves domain from ctx
     getState,
     _instances: instances,
+    _syncDomain: syncDomain, // manual one-shot sync (tests)
   };
 }

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/version.mjs
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/version.mjs
@@ -10,4 +10,4 @@
 // convention (the skill ships as files, not an npm version); a commit short-sha
 // works too. Re-exported from client.mjs so a canvas can read it at runtime.
 
-export const KIT_VERSION = "2026-07-07.4";
+export const KIT_VERSION = "2026-07-07.5";

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/version.mjs
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/version.mjs
@@ -10,4 +10,4 @@
 // convention (the skill ships as files, not an npm version); a commit short-sha
 // works too. Re-exported from client.mjs so a canvas can read it at runtime.
 
-export const KIT_VERSION = "2026-07-07.5";
+export const KIT_VERSION = "2026-07-07.6";

--- a/skills/create-canvas-app/test/kit-runtime.test.mjs
+++ b/skills/create-canvas-app/test/kit-runtime.test.mjs
@@ -258,6 +258,83 @@ async function main() {
     );
   });
 
+  // ---- github-store.mjs: shared repo-backed store (mocked fetch) -----------
+  const { githubStore } = await imp("github-store.mjs");
+  const b64 = (s) => Buffer.from(s, "utf8").toString("base64");
+  const ghJson = (obj, { status = 200, etag } = {}) =>
+    new Response(JSON.stringify(obj), { status, headers: etag ? { "Content-Type": "application/json", etag } : { "Content-Type": "application/json" } });
+  // Run fn with a stubbed global fetch + a fake token (so no `gh` spawn).
+  async function withFetch(stub, fn) {
+    const realFetch = globalThis.fetch;
+    const prevTok = process.env.GH_TOKEN;
+    process.env.GH_TOKEN = "test-token";
+    globalThis.fetch = stub;
+    try { return await fn(); }
+    finally {
+      globalThis.fetch = realFetch;
+      if (prevTok === undefined) delete process.env.GH_TOKEN; else process.env.GH_TOKEN = prevTok;
+    }
+  }
+
+  await test("github-store: load decodes content + authorizes; poll with a matching ETag is a 304 (unchanged)", async () => {
+    const calls = [];
+    await withFetch(async (url, init = {}) => {
+      calls.push({ url: String(url), method: init.method ?? "GET", headers: init.headers ?? {} });
+      if ((init.headers ?? {})["If-None-Match"] === '"e1"') return new Response(null, { status: 304 });
+      return ghJson({ content: b64(JSON.stringify({ n: 1 })), sha: "sha1" }, { etag: '"e1"' });
+    }, async () => {
+      const store = githubStore({ owner: "o", repo: "r", path: "state/b.json" });
+      assert.deepEqual(await store.load(null), { n: 1 });
+      assert.ok(String(calls[0].headers.Authorization).includes("test-token"), "token sent as Bearer");
+      assert.match(calls[0].url, /\/repos\/o\/r\/contents\/state\/b\.json\?ref=main$/);
+      const p = await store.poll();
+      assert.equal(p.changed, false, "matching ETag → 304 → unchanged");
+      assert.equal(calls[1].headers["If-None-Match"], '"e1"', "poll sent If-None-Match");
+    });
+  });
+
+  await test("github-store: poll detects a remote change and returns the new state", async () => {
+    let loaded = false;
+    await withFetch(async () => {
+      if (!loaded) { loaded = true; return ghJson({ content: b64(JSON.stringify({ n: 1 })), sha: "sha1" }, { etag: '"e1"' }); }
+      return ghJson({ content: b64(JSON.stringify({ n: 2 })), sha: "sha2" }, { etag: '"e2"' });
+    }, async () => {
+      const store = githubStore({ owner: "o", repo: "r", path: "b.json" });
+      await store.load(null);
+      const p = await store.poll();
+      assert.equal(p.changed, true);
+      assert.deepEqual(p.state, { n: 2 });
+    });
+  });
+
+  await test("github-store: save sends the sha and retries once on a 409 (last-writer-wins)", async () => {
+    const puts = [];
+    let gets = 0;
+    await withFetch(async (url, init = {}) => {
+      const method = init.method ?? "GET";
+      if (method === "GET") { gets++; return ghJson({ content: b64(JSON.stringify({ n: gets })), sha: "sha" + gets }, { etag: '"e' + gets + '"' }); }
+      const body = JSON.parse(init.body);
+      puts.push(body);
+      if (puts.length === 1) return ghJson({ message: "conflict" }, { status: 409 }); // stale sha
+      return ghJson({ content: { sha: "newsha" } });
+    }, async () => {
+      const store = githubStore({ owner: "o", repo: "r", path: "b.json" });
+      await store.load(null);                 // sha1
+      await store.save({ hello: "world" });   // PUT#1 sha1 → 409 → reload sha2 → PUT#2 sha2 → ok
+      assert.equal(puts.length, 2, "retried after the 409");
+      assert.equal(puts[0].sha, "sha1", "first PUT used the loaded sha (optimistic lock)");
+      assert.equal(puts[1].sha, "sha2", "retry used the refreshed sha");
+      assert.equal(Buffer.from(puts[1].content, "base64").toString("utf8"), JSON.stringify({ hello: "world" }, null, 2));
+    });
+  });
+
+  await test("github-store: a 404 load returns the fallback (fresh file, no sha)", async () => {
+    await withFetch(async () => new Response("Not Found", { status: 404 }), async () => {
+      const store = githubStore({ owner: "o", repo: "r", path: "b.json" });
+      assert.equal(await store.load(null), null);
+    });
+  });
+
   // ---- icons.mjs: prototype-safe name resolution ---------------------------
   const { hasIcon, lucideSVG, Icon } = await imp("icons.mjs");
 
@@ -301,6 +378,47 @@ async function main() {
       assert.equal(over.status, 503, "the 65th subscriber is refused");
     } finally {
       for (const c of conns) { try { c.req.destroy(); } catch {} }
+      await rt.shutdown();
+    }
+  });
+
+  await test("server: syncState adopts a remote change and broadcasts to viewers", async () => {
+    // Simulate a shared store whose remote content changes out-of-band. The
+    // runtime's sync loop should pull it via syncState and replace in-memory state.
+    let remote = { v: 1 };
+    let polls = 0;
+    const rt = createCanvasRuntime({
+      id: "sync", displayName: "Sync", description: "", assetsDir: KIT,
+      createInitialState: () => ({ v: 0 }),
+      loadState: async () => ({ v: 0 }),
+      syncState: async () => { polls++; return { changed: true, state: remote }; },
+      syncIntervalMs: 50,
+      actions: {},
+    });
+    try {
+      await rt.getState("d");                 // warm the domain so it exists in the map
+      remote = { v: 2 };
+      await rt._syncDomain("d");              // one manual tick (no timer/viewer needed)
+      assert.deepEqual(await rt.getState("d"), { v: 2 }, "remote change adopted into in-memory state");
+      assert.ok(polls >= 1, "syncState was polled");
+    } finally {
+      await rt.shutdown();
+    }
+  });
+
+  await test("server: syncState never blanks state on a null/deleted remote", async () => {
+    const rt = createCanvasRuntime({
+      id: "sync2", displayName: "Sync2", description: "", assetsDir: KIT,
+      createInitialState: () => ({ v: 5 }),
+      syncState: async () => ({ changed: true, state: null }), // remote file gone
+      syncIntervalMs: 50,
+      actions: {},
+    });
+    try {
+      await rt.getState("d");
+      await rt._syncDomain("d");
+      assert.deepEqual(await rt.getState("d"), { v: 5 }, "a null remote is ignored, live state preserved");
+    } finally {
       await rt.shutdown();
     }
   });

--- a/skills/create-canvas-app/test/kit-runtime.test.mjs
+++ b/skills/create-canvas-app/test/kit-runtime.test.mjs
@@ -335,6 +335,34 @@ async function main() {
     });
   });
 
+  await test("github-store: owner/repo/path are URL-encoded in the request (no path injection)", async () => {
+    let seen = "";
+    await withFetch(async (url) => { seen = String(url); return ghJson({ content: b64("{}"), sha: "s" }); }, async () => {
+      // An owner with URL-significant chars must not shift the path/query boundaries.
+      const store = githubStore({ owner: "o/../x", repo: "r?a=1", path: "state/b.json" });
+      await store.load(null);
+      assert.ok(seen.includes("/repos/o%2F..%2Fx/r%3Fa%3D1/contents/state/b.json"), `owner/repo encoded (got ${seen})`);
+    });
+  });
+
+  await test("github-store: a non-https apiBase is rejected at construction", () => {
+    // apiBase is trusted/fixed by design; still, reject an obviously unsafe override.
+    assert.throws(() => githubStore({ owner: "o", repo: "r", path: "b.json", apiBase: "http://169.254.169.254" }), /https/);
+    assert.throws(() => githubStore({ owner: "o", repo: "r", path: "b.json", apiBase: "not a url" }), /valid URL|https/);
+    // The default (GitHub public API) and a valid https enterprise host are fine.
+    assert.doesNotThrow(() => githubStore({ owner: "o", repo: "r", path: "b.json" }));
+    assert.doesNotThrow(() => githubStore({ owner: "o", repo: "r", path: "b.json", apiBase: "https://ghe.example.com/api/v3" }));
+  });
+
+  await test("github-store: an oversized response is refused before it's read into memory", async () => {
+    // A collaborator pushing a huge file must not force the runtime to allocate it on
+    // every poll — the Content-Length guard rejects it first.
+    await withFetch(async () => new Response(b64("{}"), { status: 200, headers: { "Content-Type": "application/json", "Content-Length": String(64 * 1024 * 1024) } }), async () => {
+      const store = githubStore({ owner: "o", repo: "r", path: "b.json" });
+      await throwsAsync(() => store.load(null), /too large/);
+    });
+  });
+
   // ---- icons.mjs: prototype-safe name resolution ---------------------------
   const { hasIcon, lucideSVG, Icon } = await imp("icons.mjs");
 
@@ -418,6 +446,33 @@ async function main() {
       await rt.getState("d");
       await rt._syncDomain("d");
       assert.deepEqual(await rt.getState("d"), { v: 5 }, "a null remote is ignored, live state preserved");
+    } finally {
+      await rt.shutdown();
+    }
+  });
+
+  await test("server: syncState rejects a remote that violates stateSchema (no adopt, no broadcast)", async () => {
+    // A collaborator (or a hand-edit on github.com) can push a shape that violates
+    // the declared stateSchema. Adopting it unvalidated would broadcast corrupt state
+    // to every viewer and poison the next invoke()'s rollback baseline — so the sync
+    // path must clear the SAME schema gate the invoke() path enforces.
+    let remote = { count: 1 };
+    const rt = createCanvasRuntime({
+      id: "sync3", displayName: "Sync3", description: "", assetsDir: KIT,
+      createInitialState: () => ({ count: 0 }),
+      stateSchema: { type: "object", properties: { count: { type: "integer", minimum: 0 } }, required: ["count"], additionalProperties: false },
+      syncState: async () => ({ changed: true, state: remote }),
+      syncIntervalMs: 50,
+      actions: {},
+    });
+    try {
+      await rt.getState("d");
+      remote = { count: 3 };                    // valid remote is adopted
+      await rt._syncDomain("d");
+      assert.deepEqual(await rt.getState("d"), { count: 3 }, "a schema-valid remote is adopted");
+      remote = { count: -1, bogus: true };      // violates minimum + additionalProperties
+      await rt._syncDomain("d");
+      assert.deepEqual(await rt.getState("d"), { count: 3 }, "a schema-invalid remote is rejected, last valid state preserved");
     } finally {
       await rt.shutdown();
     }


### PR DESCRIPTION
## What & why

Makes **"share this canvas state with other people on GitHub"** a first-class capability of the kit — no gist import/export loop (gists are single-writer anyway).

Adds `githubStore`: a repo-backed durable store so multiple people edit **one** canvas state file in a **private repo**. GitHub is both the backing store and the access control (invite collaborators with push access); there's no server to run. This also builds the "cloud storage tier" that the Canvas SDK board itself lists as a gap.

## Changes

**`kit/github-store.mjs`** (new) — `githubStore({ owner, repo, path, branch?, token?, merge?, message?, apiBase? })` → `{ load, poll, save }`, same shape the runtime's `loadState`/`saveState` expect:
- Reads/writes a JSON file via the GitHub Contents API.
- **Optimistic-locked by blob SHA**: a colliding commit makes the PUT `409`; `save` re-reads to refresh the SHA and retries (bounded). Default last-writer-wins for the whole document, or pass `merge(remote, mine)` to resolve field-by-field.
- **Cheap polling**: `poll()` sends `If-None-Match`, so an unchanged check is a `304` with no body.
- **Token** from `token` opt → `GH_TOKEN`/`GITHUB_TOKEN` → `gh auth token`, sent only as an `Authorization` header (never logged/written). A `401` invalidates the cached token so a retry re-resolves.

**`kit/server.mjs`** — optional live-sync loop: `config.syncState` + `config.syncIntervalMs`. One `unref`'d timer polls each domain and adopts + broadcasts remote changes to viewers, **only while a domain has ≥1 connected SSE client** (so API usage tracks real use). A `null`/deleted remote is ignored so a transient upstream gap can't blank a live board. Stopped on `shutdown`. Exposes `_syncDomain` for tests.

**`SKILL.md`** — a **"Sharing canvas state across users (GitHub-backed)"** recipe: on the "share canvas state" ask, prompt for the repo, then wire `githubStore` for `loadState`/`saveState`/`syncState` with a local mirror/fallback, plus access/token/conflict/distribution notes.

**`README.md`** — documents `github-store.mjs` in the feature list, kit file map, and test reference.

Bumps `KIT_VERSION` → `2026-07-07.6` and mirrors `kit/` into `reference/decision-log/canvas-kit/` (byte-parity gate holds).

## Security & robustness

Ran a full quality pipeline on the feature (security-sensitive: token handling + authenticated egress + remote storage). Parallel audits — **devx-secops** (STRIDE/OWASP/CWE), **devx-code-review**, refactoring/idiomatic/smells, and a **devx-max-quality** certification pass — found **no CRITICAL/HIGH**. Credential safety confirmed: the token never reaches an error message, log, or persisted content, and the `gh` token spawn uses `execFile` (injection-safe). Fixes applied:

- **Integrity (MEDIUM):** sync-adopted remote state now clears the **same `stateSchema` gate** as local writes — a collaborator's malformed edit (or a hand-edit on github.com) is rejected instead of being broadcast to every viewer or poisoning the next `invoke()`'s rollback baseline.
- **Availability (MEDIUM):** every GitHub API call now has an `AbortSignal.timeout`, so a hung request can't stall a user's save or dead-lock the sync loop.
- **Defense-in-depth (LOW):** URL-encode `owner`/`repo`; floor `syncIntervalMs` (2s) to protect the API rate limit; `Content-Length` size guard before reading a response; https-only `apiBase` validated at construction; `promisify(execFile)`; named `MAX_SAVE_RETRIES`.

## Tests

Adds to `test/kit-runtime.test.mjs` (mocked `fetch`, no network) — full suite **172 checks, exit 0**, parity green:
- `githubStore`: load/decode + auth header; ETag `304` unchanged poll; poll detects a remote change; `save` sends the loaded SHA and retries once on `409`; `404` load returns the fallback; owner/repo URL-encoding (no path injection); non-https `apiBase` rejected at construction; oversized response refused before it's read.
- `server`: `syncState` adopts a remote change and broadcasts; never blanks live state on a `null`/deleted remote; **rejects a `stateSchema`-invalid remote** (no adopt/broadcast).