### PR TITLE
canvas-kit: add source_branch + parent to session deep-link builder

### DIFF
--- a/skills/create-canvas-app/SKILL.md
+++ b/skills/create-canvas-app/SKILL.md
@@ -354,8 +354,10 @@ const href = buildSessionDeepLink({
   repo: "owner/repo",                              // required, validated owner/repo
   prompt: `Work on ${quoteUntrusted(item.title)}`, // wrap untrusted text
   mode: "interactive",                             // plan | interactive | autopilot
-  // pr: 42          -> a PR number (cannot be combined with branch)
-  // branch: "main"  -> a base branch (cannot be combined with pr)
+  // pr: 42                   -> a PR number (excludes branch / sourceBranch)
+  // branch: "main"           -> base ref for a NEW worktree branch (excludes pr / sourceBranch)
+  // sourceBranch: "feat/x"   -> open an EXISTING branch directly (excludes pr / branch)
+  // parent: "abc-123"        -> nest under an existing session (excludes pr / sourceBranch)
 });
 
 href && html`<a class="ck-btn ck-btn-sm" href=${href} target="_blank" rel="noopener noreferrer">
@@ -366,7 +368,7 @@ href && html`<a class="ck-btn ck-btn-sm" href=${href} target="_blank" rel="noope
 **The full builder set** (each validates its input and returns a normalized
 `ghapp://` URL, or null on bad input):
 
-- `buildSessionDeepLink({ repo, prompt, pr, branch, mode })`: `session/new`, the primary one.
+- `buildSessionDeepLink({ repo, prompt, pr, branch, sourceBranch, parent, mode })`: `session/new`, the primary one. The three branch selectors (`pr`/`branch`/`sourceBranch`) are mutually exclusive; `sourceBranch` opens an existing branch for collaboration, `parent` nests the new session under an existing one.
 - `buildSessionDetailDeepLink(sessionId)`: open an existing session.
 - `buildChatsDeepLink()`: the Chats surface.
 - `buildNewAutomationDeepLink({ name, prompt, trigger, time, day })`: pre-fill the new-automation dialog.

--- a/skills/create-canvas-app/kit/deeplinks.mjs
+++ b/skills/create-canvas-app/kit/deeplinks.mjs
@@ -54,6 +54,21 @@ function isRepoName(v) {
   );
 }
 
+// A safe session/workspace id: 1-256 chars of [A-Za-z0-9._-], excluding the dot
+// segments "." and ".." (which WHATWG URL parsing would otherwise collapse into an
+// id-less path). Shared by the `sessions/:sessionId` route and `session/new`'s
+// `parent` param, which the app documents as taking that same id shape.
+function isSafeSessionId(v) {
+  return (
+    typeof v === "string" &&
+    v.length > 0 &&
+    v.length <= 256 &&
+    v !== "." &&
+    v !== ".." &&
+    SAFE_ID_RE.test(v)
+  );
+}
+
 /**
  * True when `value` is a valid `owner/repo` full name, matching github-app's own
  * validation. Exposed so a canvas can check a repo before offering a link (and so
@@ -138,33 +153,56 @@ export function quoteUntrusted(value) {
 
 /**
  * Build a `ghapp://session/new` deep link: the primary way a canvas opens a
- * session in the app. `repo` is required and validated as owner/repo; `pr` must
- * be a positive integer and cannot be combined with `branch`; `mode` must be one
- * of plan|interactive|autopilot. All values are URL-encoded via URLSearchParams,
- * so untrusted text cannot inject a query key. Returns null when the inputs can't
- * form a valid link, so a caller can withhold the control instead of rendering a
- * dead one. Do NOT put secrets or sensitive content in `prompt`.
+ * session in the app. `repo` is required and validated as owner/repo. The three
+ * branch selectors are mutually exclusive — at most one of `pr` (a positive
+ * integer), `branch` (base ref for a freshly generated worktree branch), or
+ * `sourceBranch` (open an EXISTING branch directly, e.g. a collaboration link).
+ * `parent` nests the new session under an existing workspace id (same id shape as
+ * buildSessionDetailDeepLink); it cannot combine with `pr` or `sourceBranch`, but
+ * may combine with `branch`. `mode` must be one of plan|interactive|autopilot. All
+ * values are URL-encoded via URLSearchParams, so untrusted text cannot inject a
+ * query key. Returns null when the inputs can't form a valid link, so a caller can
+ * withhold the control instead of rendering a dead one. Do NOT put secrets or
+ * sensitive content in `prompt`.
  * @param {object} parts
  * @param {string} parts.repo            required "owner/repo"
  * @param {string} [parts.prompt]        kickoff prompt (wrap untrusted parts with quoteUntrusted)
- * @param {number|string} [parts.pr]     positive PR number (mutually exclusive with branch)
- * @param {string} [parts.branch]        base branch (mutually exclusive with pr)
+ * @param {number|string} [parts.pr]     positive PR number (excludes branch / sourceBranch)
+ * @param {string} [parts.branch]        base branch for a NEW worktree branch (excludes pr / sourceBranch)
+ * @param {string} [parts.sourceBranch]  open an EXISTING branch directly (excludes pr / branch)
+ * @param {string} [parts.parent]        workspace id to nest under (excludes pr / sourceBranch; may combine with branch)
  * @param {string} [parts.mode]          plan | interactive | autopilot
  * @returns {string|null}
  */
-export function buildSessionDeepLink({ repo, prompt, pr, branch, mode } = {}) {
+export function buildSessionDeepLink({ repo, prompt, pr, branch, sourceBranch, parent, mode } = {}) {
   if (!isRepoFullName(repo)) return null;
 
   const prNum = toPositiveInt(pr);
   if (pr != null && pr !== "" && prNum == null) return null; // pr given but invalid
   const branchStr = cleanLine(branch);
-  if (prNum != null && branchStr) return null; // pr + branch are mutually exclusive
+  const sourceBranchStr = cleanLine(sourceBranch);
+  // The three branch selectors are mutually exclusive: at most one may be set.
+  const selectors = (prNum != null ? 1 : 0) + (branchStr ? 1 : 0) + (sourceBranchStr ? 1 : 0);
+  if (selectors > 1) return null;
+
+  // `parent` nests the new session under an existing workspace id. Reject a
+  // given-but-malformed id (fail closed), and enforce the contract: `parent`
+  // cannot combine with `pr` or `source_branch` (it may combine with `branch`).
+  let parentId = null;
+  if (parent != null && parent !== "") {
+    if (!isSafeSessionId(parent)) return null;
+    if (prNum != null || sourceBranchStr) return null;
+    parentId = parent;
+  }
+
   if (mode != null && mode !== "" && !SESSION_MODES.has(mode)) return null;
 
   const params = new URLSearchParams();
   params.set("repo", repo);
   if (prNum != null) params.set("pr", String(prNum));
   else if (branchStr) params.set("branch", branchStr);
+  else if (sourceBranchStr) params.set("source_branch", sourceBranchStr);
+  if (parentId) params.set("parent", parentId);
   const promptStr = cleanText(prompt);
   if (promptStr) params.set("prompt", promptStr);
   if (mode && SESSION_MODES.has(mode)) params.set("mode", mode);
@@ -181,16 +219,7 @@ export function buildSessionDeepLink({ repo, prompt, pr, branch, mode } = {}) {
  * @returns {string|null}
  */
 export function buildSessionDetailDeepLink(sessionId) {
-  if (
-    typeof sessionId !== "string" ||
-    sessionId.length === 0 ||
-    sessionId.length > 256 ||
-    sessionId === "." ||
-    sessionId === ".." ||
-    !SAFE_ID_RE.test(sessionId)
-  ) {
-    return null;
-  }
+  if (!isSafeSessionId(sessionId)) return null;
   return safeDeepLinkUrl(`${APP_DEEP_LINK_SCHEME}://sessions/${sessionId}`);
 }
 

--- a/skills/create-canvas-app/kit/version.mjs
+++ b/skills/create-canvas-app/kit/version.mjs
@@ -10,4 +10,4 @@
 // convention (the skill ships as files, not an npm version); a commit short-sha
 // works too. Re-exported from client.mjs so a canvas can read it at runtime.
 
-export const KIT_VERSION = "2026-07-07.6";
+export const KIT_VERSION = "2026-07-10.1";

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/.kit-version.json
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/.kit-version.json
@@ -1,5 +1,5 @@
 {
-  "version": "2026-07-07.6",
-  "syncedAt": "2026-07-07T21:57:36.194Z",
+  "version": "2026-07-10.1",
+  "syncedAt": "2026-07-10T16:18:58.810Z",
   "source": "create-canvas-app/kit"
 }

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/deeplinks.mjs
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/deeplinks.mjs
@@ -54,6 +54,21 @@ function isRepoName(v) {
   );
 }
 
+// A safe session/workspace id: 1-256 chars of [A-Za-z0-9._-], excluding the dot
+// segments "." and ".." (which WHATWG URL parsing would otherwise collapse into an
+// id-less path). Shared by the `sessions/:sessionId` route and `session/new`'s
+// `parent` param, which the app documents as taking that same id shape.
+function isSafeSessionId(v) {
+  return (
+    typeof v === "string" &&
+    v.length > 0 &&
+    v.length <= 256 &&
+    v !== "." &&
+    v !== ".." &&
+    SAFE_ID_RE.test(v)
+  );
+}
+
 /**
  * True when `value` is a valid `owner/repo` full name, matching github-app's own
  * validation. Exposed so a canvas can check a repo before offering a link (and so
@@ -138,33 +153,56 @@ export function quoteUntrusted(value) {
 
 /**
  * Build a `ghapp://session/new` deep link: the primary way a canvas opens a
- * session in the app. `repo` is required and validated as owner/repo; `pr` must
- * be a positive integer and cannot be combined with `branch`; `mode` must be one
- * of plan|interactive|autopilot. All values are URL-encoded via URLSearchParams,
- * so untrusted text cannot inject a query key. Returns null when the inputs can't
- * form a valid link, so a caller can withhold the control instead of rendering a
- * dead one. Do NOT put secrets or sensitive content in `prompt`.
+ * session in the app. `repo` is required and validated as owner/repo. The three
+ * branch selectors are mutually exclusive — at most one of `pr` (a positive
+ * integer), `branch` (base ref for a freshly generated worktree branch), or
+ * `sourceBranch` (open an EXISTING branch directly, e.g. a collaboration link).
+ * `parent` nests the new session under an existing workspace id (same id shape as
+ * buildSessionDetailDeepLink); it cannot combine with `pr` or `sourceBranch`, but
+ * may combine with `branch`. `mode` must be one of plan|interactive|autopilot. All
+ * values are URL-encoded via URLSearchParams, so untrusted text cannot inject a
+ * query key. Returns null when the inputs can't form a valid link, so a caller can
+ * withhold the control instead of rendering a dead one. Do NOT put secrets or
+ * sensitive content in `prompt`.
  * @param {object} parts
  * @param {string} parts.repo            required "owner/repo"
  * @param {string} [parts.prompt]        kickoff prompt (wrap untrusted parts with quoteUntrusted)
- * @param {number|string} [parts.pr]     positive PR number (mutually exclusive with branch)
- * @param {string} [parts.branch]        base branch (mutually exclusive with pr)
+ * @param {number|string} [parts.pr]     positive PR number (excludes branch / sourceBranch)
+ * @param {string} [parts.branch]        base branch for a NEW worktree branch (excludes pr / sourceBranch)
+ * @param {string} [parts.sourceBranch]  open an EXISTING branch directly (excludes pr / branch)
+ * @param {string} [parts.parent]        workspace id to nest under (excludes pr / sourceBranch; may combine with branch)
  * @param {string} [parts.mode]          plan | interactive | autopilot
  * @returns {string|null}
  */
-export function buildSessionDeepLink({ repo, prompt, pr, branch, mode } = {}) {
+export function buildSessionDeepLink({ repo, prompt, pr, branch, sourceBranch, parent, mode } = {}) {
   if (!isRepoFullName(repo)) return null;
 
   const prNum = toPositiveInt(pr);
   if (pr != null && pr !== "" && prNum == null) return null; // pr given but invalid
   const branchStr = cleanLine(branch);
-  if (prNum != null && branchStr) return null; // pr + branch are mutually exclusive
+  const sourceBranchStr = cleanLine(sourceBranch);
+  // The three branch selectors are mutually exclusive: at most one may be set.
+  const selectors = (prNum != null ? 1 : 0) + (branchStr ? 1 : 0) + (sourceBranchStr ? 1 : 0);
+  if (selectors > 1) return null;
+
+  // `parent` nests the new session under an existing workspace id. Reject a
+  // given-but-malformed id (fail closed), and enforce the contract: `parent`
+  // cannot combine with `pr` or `source_branch` (it may combine with `branch`).
+  let parentId = null;
+  if (parent != null && parent !== "") {
+    if (!isSafeSessionId(parent)) return null;
+    if (prNum != null || sourceBranchStr) return null;
+    parentId = parent;
+  }
+
   if (mode != null && mode !== "" && !SESSION_MODES.has(mode)) return null;
 
   const params = new URLSearchParams();
   params.set("repo", repo);
   if (prNum != null) params.set("pr", String(prNum));
   else if (branchStr) params.set("branch", branchStr);
+  else if (sourceBranchStr) params.set("source_branch", sourceBranchStr);
+  if (parentId) params.set("parent", parentId);
   const promptStr = cleanText(prompt);
   if (promptStr) params.set("prompt", promptStr);
   if (mode && SESSION_MODES.has(mode)) params.set("mode", mode);
@@ -181,16 +219,7 @@ export function buildSessionDeepLink({ repo, prompt, pr, branch, mode } = {}) {
  * @returns {string|null}
  */
 export function buildSessionDetailDeepLink(sessionId) {
-  if (
-    typeof sessionId !== "string" ||
-    sessionId.length === 0 ||
-    sessionId.length > 256 ||
-    sessionId === "." ||
-    sessionId === ".." ||
-    !SAFE_ID_RE.test(sessionId)
-  ) {
-    return null;
-  }
+  if (!isSafeSessionId(sessionId)) return null;
   return safeDeepLinkUrl(`${APP_DEEP_LINK_SCHEME}://sessions/${sessionId}`);
 }
 

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/version.mjs
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/version.mjs
@@ -10,4 +10,4 @@
 // convention (the skill ships as files, not an npm version); a commit short-sha
 // works too. Re-exported from client.mjs so a canvas can read it at runtime.
 
-export const KIT_VERSION = "2026-07-07.6";
+export const KIT_VERSION = "2026-07-10.1";

--- a/skills/create-canvas-app/reference/deeplinks.md
+++ b/skills/create-canvas-app/reference/deeplinks.md
@@ -53,16 +53,22 @@ dead link), except where noted that an invalid optional value is dropped.
 
 ### `session/new`: create a session
 
-`buildSessionDeepLink({ repo, prompt, pr, branch, mode })`
+`buildSessionDeepLink({ repo, prompt, pr, branch, sourceBranch, parent, mode })`
 → `ghapp://session/new?repo=owner/repo&…`
 
 | Param | Required | Rule |
 |---|---|---|
 | `repo` | Yes | `owner/repo`. Owner `<=39` chars, `[A-Za-z0-9]` with internal hyphens (no leading/trailing hyphen). Repo `<=100` chars, `[A-Za-z0-9._-]`, not `.` or `..`. |
 | `prompt` | No | Kickoff prompt. Wrap untrusted parts with `quoteUntrusted`. Never include secrets. |
-| `pr` | No | Positive integer. Cannot be combined with `branch`. |
-| `branch` | No | Base branch for the worktree. Cannot be combined with `pr`. |
+| `pr` | No | Positive integer. Cannot be combined with `branch` or `sourceBranch`. |
+| `branch` | No | Base branch for a freshly generated worktree branch. Cannot be combined with `pr` or `sourceBranch`. |
+| `sourceBranch` | No | Emits `source_branch`: open an *existing* branch directly (no new branch is created) — for collaboration links. Cannot be combined with `pr` or `branch`. |
+| `parent` | No | Workspace id of an existing session to nest the new one under (same token shape as `sessions/:sessionId`). Cannot be combined with `pr` or `sourceBranch`; may combine with `branch`. A malformed id returns `null`. |
 | `mode` | No | `plan`, `interactive`, or `autopilot`. |
+
+The three branch selectors (`pr`, `branch`, `sourceBranch`) are mutually exclusive:
+at most one may be set. `parent` only applies when creating a new session from a repo
+or base branch, so it cannot combine with `pr` or `sourceBranch`.
 
 If the repo is not yet a project, the app clones it first (after confirmation), then
 opens the session.

--- a/skills/create-canvas-app/test/deeplinks.test.mjs
+++ b/skills/create-canvas-app/test/deeplinks.test.mjs
@@ -146,6 +146,69 @@ async function main() {
     assert.equal(p.get("prompt"), prompt);
   });
 
+  await test("buildSessionDeepLink accepts sourceBranch (emits source_branch)", () => {
+    const p = q(buildSessionDeepLink({ repo: "a/b", sourceBranch: "feature/collab" }));
+    assert.equal(p.get("source_branch"), "feature/collab");
+    assert.equal(p.get("branch"), null);
+    assert.equal(p.get("pr"), null);
+  });
+
+  await test("buildSessionDeepLink accepts parent (emits parent)", () => {
+    const p = q(buildSessionDeepLink({ repo: "a/b", parent: "abc-123_4.5" }));
+    assert.equal(p.get("parent"), "abc-123_4.5");
+    assert.equal(p.get("repo"), "a/b");
+  });
+
+  await test("buildSessionDeepLink allows parent + branch together", () => {
+    const p = q(buildSessionDeepLink({ repo: "a/b", parent: "ws-1", branch: "main" }));
+    assert.equal(p.get("parent"), "ws-1");
+    assert.equal(p.get("branch"), "main");
+    assert.equal(p.get("source_branch"), null);
+  });
+
+  await test("buildSessionDeepLink allows parent + prompt + mode together", () => {
+    const p = q(
+      buildSessionDeepLink({ repo: "a/b", parent: "ws-1", prompt: "look", mode: "plan" }),
+    );
+    assert.equal(p.get("parent"), "ws-1");
+    assert.equal(p.get("prompt"), "look");
+    assert.equal(p.get("mode"), "plan");
+  });
+
+  await test("buildSessionDeepLink enforces the branch-selector mutual exclusion", () => {
+    // At most one of pr / branch / source_branch may be set.
+    assert.equal(buildSessionDeepLink({ repo: "a/b", pr: 1, sourceBranch: "x" }), null);
+    assert.equal(buildSessionDeepLink({ repo: "a/b", branch: "x", sourceBranch: "y" }), null);
+    assert.equal(
+      buildSessionDeepLink({ repo: "a/b", pr: 1, branch: "x", sourceBranch: "y" }),
+      null,
+    );
+  });
+
+  await test("buildSessionDeepLink rejects parent combined with pr or source_branch", () => {
+    assert.equal(buildSessionDeepLink({ repo: "a/b", parent: "ws-1", pr: 5 }), null);
+    assert.equal(buildSessionDeepLink({ repo: "a/b", parent: "ws-1", sourceBranch: "x" }), null);
+  });
+
+  await test("buildSessionDeepLink rejects a malformed parent id (fail closed)", () => {
+    for (const bad of ["a b", "a/b", "a?x=1", ".", "..", "a#b", "x".repeat(257), 123]) {
+      assert.equal(buildSessionDeepLink({ repo: "a/b", parent: bad }), null, JSON.stringify(bad));
+    }
+  });
+
+  await test("hostile sourceBranch/parent text cannot inject a query key or change the route", () => {
+    // sourceBranch is a structured single-line param: it is URLSearchParams-encoded,
+    // so '&'/'=' stay inside the value and never leak into sibling params.
+    const link = buildSessionDeepLink({ repo: "a/b", sourceBranch: "x&pr=999&evil=1" });
+    const p = q(link);
+    assert.equal(p.get("source_branch"), "x&pr=999&evil=1");
+    assert.equal(p.get("pr"), null);
+    assert.equal(p.get("evil"), null);
+    assert.equal(new URL(link).host, "session"); // route unchanged
+    // A parent carrying URL metacharacters is not a safe id: rejected outright.
+    assert.equal(buildSessionDeepLink({ repo: "a/b", parent: "x&evil=1" }), null);
+  });
+
   // ---- buildSessionDetailDeepLink ------------------------------------------
   await test("buildSessionDetailDeepLink builds ghapp://sessions/:id", () => {
     assert.equal(buildSessionDetailDeepLink("abc-123_4.5"), "ghapp://sessions/abc-123_4.5");


### PR DESCRIPTION
## What

Aligns the canvas-kit's session deep-link builder with the Copilot host app's **public** `session/new` deep-link contract, which added two query parameters since the skill's last kit sync (`2026-07-07.6`):

- **`source_branch`** — open an *existing* branch directly as the session branch (no new branch is created), for collaboration links. Mutually exclusive with `pr` and `branch`.
- **`parent`** — workspace id of an existing session to nest the new one under (child in the sidebar). Same id shape as the `sessions/:sessionId` route. Mutually exclusive with `pr` and `source_branch`; may combine with `branch`.

## Changes

- `kit/deeplinks.mjs`: `buildSessionDeepLink` gains `sourceBranch` (emits `source_branch`) and `parent`, enforcing the contract's mutual-exclusivity rules (the three branch selectors `pr`/`branch`/`sourceBranch` are mutually exclusive; `parent` excludes `pr`/`sourceBranch`). Extracted a shared `isSafeSessionId` helper, now reused by `buildSessionDetailDeepLink` (DRY).
- `kit/version.mjs`: `KIT_VERSION` → `2026-07-10.1` (kit bytes changed).
- Re-mirrored the kit into `reference/decision-log/canvas-kit/` (byte-parity + freshness green).
- Docs: `reference/deeplinks.md` param table + `SKILL.md` builder list/example updated for both params.
- Tests: 9 new cases in `test/deeplinks.test.mjs` (emit, `parent`+`branch` combo, mutual-exclusion rejections, malformed-`parent` fail-closed, injection/route-integrity).

## Validation

- `npm test` — all 8 suites pass (deeplinks 37/37; kit-parity + freshness green at `2026-07-10.1`).
- Security-focused code review: no injection/route-change/prototype-pollution vectors; fail-closed on malformed input; backward compatible with existing `repo/pr/branch/prompt/mode` calls.

## Notes

- Additive and backward compatible — existing builder calls are unchanged.
- Other canvas-surface contract files (SDK canvas typings, theme contract, authoring contract, example extensions) were verified unchanged since the last sync — no action needed there.

Refs #31