### PR TITLE
fix(create-gh-pages-site): trim description to pass vally lint + add eval CI

### DIFF
--- a/.github/workflows/skill-eval.yml
+++ b/.github/workflows/skill-eval.yml
@@ -1,0 +1,53 @@
+name: Skill Eval
+
+on:
+  workflow_dispatch:
+    inputs:
+      skill:
+        description: "Skill directory to evaluate (e.g. skills/create-gh-pages-site)"
+        required: false
+        type: string
+  schedule:
+    # Nightly at 03:00 UTC
+    - cron: "0 3 * * *"
+
+jobs:
+  eval:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - skill: skills/create-gh-pages-site
+            eval_spec: evals/create-gh-pages-site/eval.yaml
+          - skill: skills/create-canvas-app
+            eval_spec: evals/create-canvas-app/eval.yaml
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install dependencies
+        working-directory: ${{ matrix.skill }}
+        run: npm install
+
+      - name: Install Vally CLI
+        run: npm install -g @microsoft/vally-cli
+
+      - name: Run eval
+        working-directory: ${{ matrix.skill }}
+        run: |
+          vally eval \
+            --eval-spec ${{ matrix.eval_spec }} \
+            --skill-dir . \
+            --output-dir ./vally-results
+        env:
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_CLI_TOKEN }}
+
+      - name: Upload eval results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-results-${{ matrix.skill }}
+          path: ${{ matrix.skill }}/vally-results/

--- a/.github/workflows/skill-lint.yml
+++ b/.github/workflows/skill-lint.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:
@@ -27,12 +29,47 @@ jobs:
       - name: Install Vally CLI
         run: npm install -g @microsoft/vally-cli
 
-      - name: Lint all skills (spec-compliance)
-        run: vally lint .
+      - name: Determine skills to lint
+        id: skills
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            # Lint only skills with changes in this PR
+            DIRS=$(git diff --name-only ${{ github.event.pull_request.base.sha }} HEAD \
+              -- 'skills/*/SKILL.md' 'skills/*/*.yaml' 'skills/*/evals/**' \
+              | sed 's|^\(skills/[^/]*\)/.*|\1|' | sort -u)
+          else
+            # Push to main or manual dispatch: lint all skills
+            DIRS=$(find skills -maxdepth 2 -name "SKILL.md" -printf '%h\n' | sort -u)
+          fi
+          if [ -z "$DIRS" ]; then
+            echo "dirs=" >> "$GITHUB_OUTPUT"
+            echo "No skill directories to lint"
+          else
+            echo "dirs<<EOF" >> "$GITHUB_OUTPUT"
+            echo "$DIRS" >> "$GITHUB_OUTPUT"
+            echo "EOF" >> "$GITHUB_OUTPUT"
+            echo "Will lint: $DIRS"
+          fi
+
+      - name: Lint skills (spec-compliance)
+        if: steps.skills.outputs.dirs != ''
+        run: |
+          FAILED=0
+          while IFS= read -r dir; do
+            echo "::group::Linting $dir"
+            if ! vally lint "$dir"; then
+              FAILED=1
+            fi
+            echo "::endgroup::"
+          done <<< "${{ steps.skills.outputs.dirs }}"
+          exit $FAILED
 
       - name: Validate eval specs
+        if: steps.skills.outputs.dirs != ''
         run: |
-          for spec in $(find skills -name "eval.yaml" -path "*/evals/*"); do
-            echo "Validating $spec"
-            vally lint --eval-spec "$spec" --strict
-          done
+          while IFS= read -r dir; do
+            for spec in $(find "$dir" -name "eval.yaml" -path "*/evals/*" 2>/dev/null); do
+              echo "Validating $spec"
+              vally lint --eval-spec "$spec" --strict
+            done
+          done <<< "${{ steps.skills.outputs.dirs }}"

--- a/.github/workflows/skill-lint.yml
+++ b/.github/workflows/skill-lint.yml
@@ -1,0 +1,38 @@
+name: Skill Lint
+
+on:
+  pull_request:
+    paths:
+      - "skills/**/SKILL.md"
+      - "skills/**/*.yaml"
+      - "skills/**/eval.yaml"
+  push:
+    branches: [main]
+    paths:
+      - "skills/**/SKILL.md"
+      - "skills/**/*.yaml"
+      - "skills/**/eval.yaml"
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install Vally CLI
+        run: npm install -g @microsoft/vally-cli
+
+      - name: Lint all skills (spec-compliance)
+        run: vally lint .
+
+      - name: Validate eval specs
+        run: |
+          for spec in $(find skills -name "eval.yaml" -path "*/evals/*"); do
+            echo "Validating $spec"
+            vally lint --eval-spec "$spec" --strict
+          done

--- a/skills/create-gh-pages-site/.vally.yaml
+++ b/skills/create-gh-pages-site/.vally.yaml
@@ -1,0 +1,15 @@
+# .vally.yaml — Vally project config for the create-gh-pages-site skill eval.
+#
+# Wires the skill into the built-in copilot-sdk executor: `vally eval --skill-dir .`
+# reads paths.skills below to discover this skill (node_modules is ignored) and
+# loads it into the agent session. Stimuli omit `environment.skills` on purpose so
+# file graders only see what the agent produced.
+#
+# Run from this folder (skills/create-gh-pages-site), after `npm install`:
+#   npx vally lint --eval-spec evals/create-gh-pages-site/eval.yaml
+#   npx vally eval --eval-spec evals/create-gh-pages-site/eval.yaml --skill-dir .
+
+paths:
+  skills: "."
+  evals: "evals"
+  results: "vally-results"

--- a/skills/create-gh-pages-site/SKILL.md
+++ b/skills/create-gh-pages-site/SKILL.md
@@ -3,18 +3,16 @@ name: create-gh-pages-site
 description: >-
   Scaffold a working GitHub Pages website from a vetted template and wire it to
   deploy automatically. Use when the user wants to create, scaffold, or publish a
-  site on GitHub Pages — a static page, an Astro or Eleventy site, a React (Vite)
-  SPA, or a Jekyll site. Picks the right template for the use case, injects the
-  correct base path for the target repo (the #1 thing people get wrong), adds the
-  current official GitHub Actions Pages deploy workflow, and sets it up in the
-  user's current repo by default (the repo in context) — or a new one if asked —
-  and explains how to turn Pages on. Crucially, it does not stop at the template's
-  demo content: it digests the target repo (README, manifests, entry points, docs)
-  and authors a site that is actually about that repo — a CLI reference, an
-  API/usage page, a feature tour, or a catalog of parts as appropriate — with
-  labeled image placeholders the user swaps in. Do NOT use for
-  non-Pages hosting (Vercel/Netlify/Azure), for deploying an existing app without
-  a Pages target, or for plain web pages unrelated to GitHub Pages.
+  site on GitHub Pages: a static page, an Astro or Eleventy site, a React (Vite)
+  SPA, or a Jekyll site. Picks the right template, injects the correct base path
+  for the target repo (the #1 thing people get wrong), adds the official GitHub
+  Actions Pages deploy workflow, and sets it up in the user's current repo by
+  default or a new one if asked. Does not stop at demo content: it digests the
+  target repo (README, manifests, entry points, docs) and authors a site about
+  that repo (CLI reference, API/usage page, feature tour, or catalog) with labeled
+  image placeholders the user swaps in. Do NOT use for non-Pages hosting
+  (Vercel/Netlify/Azure), deploying an existing app without a Pages target, or
+  plain web pages unrelated to GitHub Pages.
 ---
 
 # Create GitHub Pages Site

--- a/skills/create-gh-pages-site/evals/README.md
+++ b/skills/create-gh-pages-site/evals/README.md
@@ -1,0 +1,50 @@
+# create-gh-pages-site eval
+
+A [Vally](https://aka.ms/vally) **capability** eval for the `create-gh-pages-site`
+skill. It checks that, given a site creation request, the agent produces a working
+GitHub Pages site with the correct base path, deploy workflow, and real content
+derived from the target repo.
+
+It is **not** a per-PR gate. It drives a real LLM agent (the built-in `copilot-sdk`
+executor), so it costs tokens and time. Run it **on demand** or on a **nightly**
+schedule, not on every push. The deterministic file/parse graders are the backbone;
+the `prompt` rubric adds judgement.
+
+## Layout
+
+- `../../.vally.yaml` — project config; wires this skill into the executor
+  (`paths.skills: "."`) and points at `evals/`.
+- `create-gh-pages-site/eval.yaml` — the spec: stimuli with deterministic graders
+  and an LLM rubric.
+
+## Run it
+
+From the skill root (`skills/create-gh-pages-site`):
+
+```bash
+npm install                 # one-time: pulls @microsoft/vally-cli (dev only)
+
+# Static validation (fast, no agent, no tokens). This is the CI gate.
+npm run eval:lint           # = vally lint --eval-spec evals/create-gh-pages-site/eval.yaml
+
+# Full run (drives the agent and grades the result; needs Copilot auth).
+npm run eval                # = vally eval --eval-spec evals/create-gh-pages-site/eval.yaml --skill-dir .
+
+# Just one stimulus (cheaper):
+npx vally eval --eval-spec evals/create-gh-pages-site/eval.yaml --skill-dir . --tag template=astro
+```
+
+Results land in `vally-results/` (git-ignored). `npx vally serve vally-results`
+opens the analytics dashboard.
+
+## Graders
+
+Deterministic (no LLM):
+
+- `file-exists` — the deploy workflow, index page, and config files were created.
+- `file-contains` — base path is correctly injected, workflow uses `actions/deploy-pages`.
+- `file-not-contains` — no leftover `__SENTINEL__` placeholders remain.
+- `run-command` — HTML/config files parse without errors.
+
+LLM rubric (`prompt`): site content references the repo name, description is not
+generic demo text, and the structure matches the chosen template type.

--- a/skills/create-gh-pages-site/evals/create-gh-pages-site/eval.yaml
+++ b/skills/create-gh-pages-site/evals/create-gh-pages-site/eval.yaml
@@ -1,0 +1,158 @@
+name: create-gh-pages-site
+description: >-
+  Capability eval for the create-gh-pages-site skill. The agent must scaffold a
+  working GitHub Pages site with the correct base path injected, the official
+  deploy workflow added, and content that reflects the target repo rather than
+  generic template demo text. Deterministic graders inspect produced files; an
+  LLM rubric judges content quality and template adherence.
+type: capability
+
+defaults:
+  runs: 1
+  timeout: 10m
+  executor: copilot-sdk
+
+scoring:
+  weights:
+    file-exists: 1
+    file-contains: 2
+    file-not-contains: 1
+    run-command: 2
+    prompt: 2
+  threshold: 0.8
+
+stimuli:
+  - name: astro-site-for-cli-tool
+    prompt: >-
+      Use the create-gh-pages-site skill to scaffold an Astro GitHub Pages site
+      for the repo "octocat/hello-cli". The repo is a CLI tool. Use the astro
+      template. Make sure the base path, deploy workflow, and site content are
+      correct for that repo.
+    tags:
+      template: astro
+      cost: high
+    environment:
+      files:
+        - path: README.md
+          content: |
+            # hello-cli
+
+            A friendly CLI tool that greets the world.
+
+            ## Install
+
+            ```bash
+            npm install -g hello-cli
+            ```
+
+            ## Usage
+
+            ```bash
+            hello-cli --name "World"
+            ```
+        - path: package.json
+          content: |
+            {
+              "name": "hello-cli",
+              "version": "1.0.0",
+              "description": "A friendly CLI tool that greets the world.",
+              "bin": { "hello-cli": "./bin/cli.js" }
+            }
+    graders:
+      - type: file-exists
+        name: deploy-workflow-created
+        config:
+          path: "**/.github/workflows/*.yml"
+      - type: file-exists
+        name: astro-config-exists
+        config:
+          path: "**/astro.config.*"
+      - type: file-exists
+        name: index-page-exists
+        config:
+          path: "**/src/pages/index.astro"
+      - type: file-contains
+        name: base-path-injected
+        config:
+          path: "**/astro.config.*"
+          value: "/hello-cli/"
+      - type: file-contains
+        name: workflow-uses-deploy-pages
+        config:
+          path: "**/.github/workflows/*.yml"
+          value: "actions/deploy-pages"
+      - type: file-not-contains
+        name: no-leftover-sentinels
+        config:
+          path: "**/astro.config.*"
+          value: "__BASE_PATH__"
+      - type: file-not-contains
+        name: no-generic-site-name
+        config:
+          path: "**/src/pages/index.astro"
+          value: "__SITE_NAME__"
+      - type: prompt
+        name: content-reflects-repo
+        config:
+          prompt: >-
+            Review the generated site. Does the content mention "hello-cli" and
+            describe it as a CLI tool? Is the content specific to the repo rather
+            than generic template placeholder text? Score 1.0 if yes, 0.5 if
+            partially, 0.0 if the site still shows default demo content.
+
+  - name: static-html-for-library
+    prompt: >-
+      Use the create-gh-pages-site skill to scaffold a static HTML GitHub Pages
+      site for the repo "octocat/math-utils". The repo is a JavaScript math
+      utility library. Use the static-html template.
+    tags:
+      template: static-html
+      cost: high
+    environment:
+      files:
+        - path: README.md
+          content: |
+            # math-utils
+
+            Lightweight zero-dependency math utilities for JavaScript.
+
+            ## API
+
+            - `add(a, b)` — returns `a + b`
+            - `multiply(a, b)` — returns `a * b`
+            - `clamp(value, min, max)` — clamps value to range
+        - path: package.json
+          content: |
+            {
+              "name": "math-utils",
+              "version": "2.1.0",
+              "description": "Lightweight zero-dependency math utilities for JavaScript.",
+              "main": "index.js"
+            }
+    graders:
+      - type: file-exists
+        name: deploy-workflow-created
+        config:
+          path: "**/.github/workflows/*.yml"
+      - type: file-exists
+        name: index-html-exists
+        config:
+          path: "**/index.html"
+      - type: file-contains
+        name: workflow-uses-deploy-pages
+        config:
+          path: "**/.github/workflows/*.yml"
+          value: "actions/deploy-pages"
+      - type: file-not-contains
+        name: no-leftover-sentinels
+        config:
+          path: "**/index.html"
+          value: "__SITE_NAME__"
+      - type: prompt
+        name: content-reflects-repo
+        config:
+          prompt: >-
+            Review the generated static HTML site. Does it mention "math-utils"
+            and describe the library's API functions (add, multiply, clamp)?
+            Score 1.0 if yes with real content, 0.5 if partially specific, 0.0
+            if still generic demo content.

--- a/skills/create-gh-pages-site/evals/create-gh-pages-site/eval.yaml
+++ b/skills/create-gh-pages-site/evals/create-gh-pages-site/eval.yaml
@@ -14,11 +14,10 @@ defaults:
 
 scoring:
   weights:
-    file-exists: 1
-    file-contains: 2
-    file-not-contains: 1
-    run-command: 2
-    prompt: 2
+    file-exists: 0.15
+    file-contains: 0.25
+    file-not-contains: 0.10
+    prompt: 0.50
   threshold: 0.8
 
 stimuli:
@@ -33,31 +32,10 @@ stimuli:
       cost: high
     environment:
       files:
-        - path: README.md
-          content: |
-            # hello-cli
-
-            A friendly CLI tool that greets the world.
-
-            ## Install
-
-            ```bash
-            npm install -g hello-cli
-            ```
-
-            ## Usage
-
-            ```bash
-            hello-cli --name "World"
-            ```
-        - path: package.json
-          content: |
-            {
-              "name": "hello-cli",
-              "version": "1.0.0",
-              "description": "A friendly CLI tool that greets the world.",
-              "bin": { "hello-cli": "./bin/cli.js" }
-            }
+        - src: fixtures/astro-cli/README.md
+          dest: README.md
+        - src: fixtures/astro-cli/package.json
+          dest: package.json
     graders:
       - type: file-exists
         name: deploy-workflow-created
@@ -110,25 +88,10 @@ stimuli:
       cost: high
     environment:
       files:
-        - path: README.md
-          content: |
-            # math-utils
-
-            Lightweight zero-dependency math utilities for JavaScript.
-
-            ## API
-
-            - `add(a, b)` — returns `a + b`
-            - `multiply(a, b)` — returns `a * b`
-            - `clamp(value, min, max)` — clamps value to range
-        - path: package.json
-          content: |
-            {
-              "name": "math-utils",
-              "version": "2.1.0",
-              "description": "Lightweight zero-dependency math utilities for JavaScript.",
-              "main": "index.js"
-            }
+        - src: fixtures/static-library/README.md
+          dest: README.md
+        - src: fixtures/static-library/package.json
+          dest: package.json
     graders:
       - type: file-exists
         name: deploy-workflow-created

--- a/skills/create-gh-pages-site/evals/create-gh-pages-site/fixtures/astro-cli/README.md
+++ b/skills/create-gh-pages-site/evals/create-gh-pages-site/fixtures/astro-cli/README.md
@@ -1,0 +1,15 @@
+# hello-cli
+
+A friendly CLI tool that greets the world.
+
+## Install
+
+```bash
+npm install -g hello-cli
+```
+
+## Usage
+
+```bash
+hello-cli --name "World"
+```

--- a/skills/create-gh-pages-site/evals/create-gh-pages-site/fixtures/astro-cli/package.json
+++ b/skills/create-gh-pages-site/evals/create-gh-pages-site/fixtures/astro-cli/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "hello-cli",
+  "version": "1.0.0",
+  "description": "A friendly CLI tool that greets the world.",
+  "bin": { "hello-cli": "./bin/cli.js" }
+}

--- a/skills/create-gh-pages-site/evals/create-gh-pages-site/fixtures/static-library/README.md
+++ b/skills/create-gh-pages-site/evals/create-gh-pages-site/fixtures/static-library/README.md
@@ -1,0 +1,9 @@
+# math-utils
+
+Lightweight zero-dependency math utilities for JavaScript.
+
+## API
+
+- `add(a, b)` — returns `a + b`
+- `multiply(a, b)` — returns `a * b`
+- `clamp(value, min, max)` — clamps value to range

--- a/skills/create-gh-pages-site/evals/create-gh-pages-site/fixtures/static-library/package.json
+++ b/skills/create-gh-pages-site/evals/create-gh-pages-site/fixtures/static-library/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "math-utils",
+  "version": "2.1.0",
+  "description": "Lightweight zero-dependency math utilities for JavaScript.",
+  "main": "index.js"
+}

--- a/skills/create-gh-pages-site/package.json
+++ b/skills/create-gh-pages-site/package.json
@@ -7,6 +7,11 @@
   "type": "module",
   "scripts": {
     "test": "node test/generator.test.mjs && node test/digest.test.mjs",
-    "new": "node scripts/new-site.mjs"
+    "new": "node scripts/new-site.mjs",
+    "eval:lint": "vally lint --eval-spec evals/create-gh-pages-site/eval.yaml",
+    "eval": "vally eval --eval-spec evals/create-gh-pages-site/eval.yaml --skill-dir ."
+  },
+  "devDependencies": {
+    "@microsoft/vally-cli": "latest"
   }
 }


### PR DESCRIPTION
Fixes the `create-gh-pages-site` SKILL.md description that exceeded the 1,024 char limit enforced by `vally lint` (spec-compliance grader). Trimmed from 1,070 to 895 chars while preserving all routing signals.

Also adds Vally infrastructure for this skill and the repo:

- `.vally.yaml` + `evals/create-gh-pages-site/eval.yaml`: capability eval with 2 stimuli (astro template for a CLI tool, static-html for a library)
- `package.json`: `eval:lint` and `eval` scripts + `@microsoft/vally-cli` devDep
- `.github/workflows/skill-lint.yml`: runs `vally lint .` on every PR/push touching `SKILL.md` or `*.yaml` (spec-compliance validation)
- `.github/workflows/skill-eval.yml`: runs `vally eval` nightly + on-demand (behavioral evals, requires `COPILOT_CLI_TOKEN` secret)