### PR TITLE
feat(create-canvas-app): add new-chat deep-link builder to canvas-kit

### DIFF
--- a/skills/create-canvas-app/SKILL.md
+++ b/skills/create-canvas-app/SKILL.md
@@ -371,6 +371,7 @@ href && html`<a class="ck-btn ck-btn-sm" href=${href} target="_blank" rel="noope
 - `buildSessionDeepLink({ repo, prompt, pr, branch, sourceBranch, parent, mode })`: `session/new`, the primary one. The three branch selectors (`pr`/`branch`/`sourceBranch`) are mutually exclusive; `sourceBranch` opens an existing branch for collaboration, `parent` nests the new session under an existing one.
 - `buildSessionDetailDeepLink(sessionId)`: open an existing session.
 - `buildChatsDeepLink()`: the Chats surface.
+- `buildNewChatDeepLink({ prompt })`: create a new chat and send `prompt` (required, non-empty; confirmation-gated).
 - `buildNewAutomationDeepLink({ name, prompt, trigger, time, day })`: pre-fill the new-automation dialog.
 - `buildIssueDeepLink({ owner, repo, number })` and `buildPullRequestDeepLink({ owner, repo, number })`.
 

--- a/skills/create-canvas-app/kit/client.mjs
+++ b/skills/create-canvas-app/kit/client.mjs
@@ -37,6 +37,7 @@ export {
   buildSessionDeepLink,
   buildSessionDetailDeepLink,
   buildChatsDeepLink,
+  buildNewChatDeepLink,
   buildNewAutomationDeepLink,
   buildIssueDeepLink,
   buildPullRequestDeepLink,

--- a/skills/create-canvas-app/kit/deeplinks.mjs
+++ b/skills/create-canvas-app/kit/deeplinks.mjs
@@ -229,6 +229,28 @@ export function buildChatsDeepLink() {
 }
 
 /**
+ * `ghapp://chats/new?prompt=<text>`: create a NEW chat and send `prompt`. The app
+ * shows a confirmation dialog (the source URL + decoded prompt) before creating the
+ * chat and submitting; denying or dismissing it is a no-op. A non-empty `prompt` is
+ * REQUIRED — returns null without one, so a caller can withhold the control instead
+ * of rendering a dead link. Model, mode, reasoning effort, context tier, and agent
+ * selection all use the app's current defaults (there are no other params). The
+ * value is URL-encoded via URLSearchParams, so untrusted text cannot inject a query
+ * key or change the route; wrap untrusted parts with `quoteUntrusted`, and never put
+ * secrets or sensitive content in `prompt`.
+ * @param {object} parts
+ * @param {string} parts.prompt   required kickoff prompt (wrap untrusted parts with quoteUntrusted)
+ * @returns {string|null}
+ */
+export function buildNewChatDeepLink({ prompt } = {}) {
+  const promptStr = cleanText(prompt);
+  if (!promptStr) return null; // the route requires a non-empty prompt
+  const params = new URLSearchParams();
+  params.set("prompt", promptStr);
+  return safeDeepLinkUrl(`${APP_DEEP_LINK_SCHEME}://chats/new?${params.toString()}`);
+}
+
+/**
  * `ghapp://automations/new`: open the new-automation dialog with fields
  * pre-filled. The dialog is the confirmation step; this never auto-creates a
  * workflow. `trigger` is allowlisted, `time` must be HH:mm, `day` must be 0-6;

--- a/skills/create-canvas-app/kit/version.mjs
+++ b/skills/create-canvas-app/kit/version.mjs
@@ -10,4 +10,4 @@
 // convention (the skill ships as files, not an npm version); a commit short-sha
 // works too. Re-exported from client.mjs so a canvas can read it at runtime.
 
-export const KIT_VERSION = "2026-07-13.1";
+export const KIT_VERSION = "2026-07-20.1";

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/.kit-version.json
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/.kit-version.json
@@ -1,5 +1,5 @@
 {
-  "version": "2026-07-13.1",
-  "syncedAt": "2026-07-13T16:17:13.911Z",
+  "version": "2026-07-20.1",
+  "syncedAt": "2026-07-20T16:11:45.014Z",
   "source": "create-canvas-app/kit"
 }

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/client.mjs
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/client.mjs
@@ -37,6 +37,7 @@ export {
   buildSessionDeepLink,
   buildSessionDetailDeepLink,
   buildChatsDeepLink,
+  buildNewChatDeepLink,
   buildNewAutomationDeepLink,
   buildIssueDeepLink,
   buildPullRequestDeepLink,

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/deeplinks.mjs
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/deeplinks.mjs
@@ -229,6 +229,28 @@ export function buildChatsDeepLink() {
 }
 
 /**
+ * `ghapp://chats/new?prompt=<text>`: create a NEW chat and send `prompt`. The app
+ * shows a confirmation dialog (the source URL + decoded prompt) before creating the
+ * chat and submitting; denying or dismissing it is a no-op. A non-empty `prompt` is
+ * REQUIRED — returns null without one, so a caller can withhold the control instead
+ * of rendering a dead link. Model, mode, reasoning effort, context tier, and agent
+ * selection all use the app's current defaults (there are no other params). The
+ * value is URL-encoded via URLSearchParams, so untrusted text cannot inject a query
+ * key or change the route; wrap untrusted parts with `quoteUntrusted`, and never put
+ * secrets or sensitive content in `prompt`.
+ * @param {object} parts
+ * @param {string} parts.prompt   required kickoff prompt (wrap untrusted parts with quoteUntrusted)
+ * @returns {string|null}
+ */
+export function buildNewChatDeepLink({ prompt } = {}) {
+  const promptStr = cleanText(prompt);
+  if (!promptStr) return null; // the route requires a non-empty prompt
+  const params = new URLSearchParams();
+  params.set("prompt", promptStr);
+  return safeDeepLinkUrl(`${APP_DEEP_LINK_SCHEME}://chats/new?${params.toString()}`);
+}
+
+/**
  * `ghapp://automations/new`: open the new-automation dialog with fields
  * pre-filled. The dialog is the confirmation step; this never auto-creates a
  * workflow. `trigger` is allowlisted, `time` must be HH:mm, `day` must be 0-6;

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/version.mjs
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/version.mjs
@@ -10,4 +10,4 @@
 // convention (the skill ships as files, not an npm version); a commit short-sha
 // works too. Re-exported from client.mjs so a canvas can read it at runtime.
 
-export const KIT_VERSION = "2026-07-13.1";
+export const KIT_VERSION = "2026-07-20.1";

--- a/skills/create-canvas-app/reference/deeplinks.md
+++ b/skills/create-canvas-app/reference/deeplinks.md
@@ -84,6 +84,20 @@ path segments or query keys.
 
 `buildChatsDeepLink()` → `ghapp://chats`
 
+### `chats/new`: create a chat and send a prompt
+
+`buildNewChatDeepLink({ prompt })` → `ghapp://chats/new?prompt=…`
+
+The app shows a confirmation dialog (source URL + decoded prompt); clicking Allow
+creates a new chat and submits the prompt, denying or dismissing is a no-op.
+
+| Param | Required | Rule |
+|---|---|---|
+| `prompt` | Yes | Non-empty kickoff prompt. Wrap untrusted parts with `quoteUntrusted`. Never include secrets. A missing/empty (or whitespace-only) prompt returns `null`. |
+
+Model, mode, reasoning effort, context tier, and agent selection use the app's
+current defaults — `prompt` is the only parameter.
+
 ### `automations/new`: pre-fill the new-automation dialog
 
 `buildNewAutomationDeepLink({ name, prompt, trigger, time, day })`

--- a/skills/create-canvas-app/test/deeplinks.test.mjs
+++ b/skills/create-canvas-app/test/deeplinks.test.mjs
@@ -17,6 +17,7 @@ import {
   buildSessionDeepLink,
   buildSessionDetailDeepLink,
   buildChatsDeepLink,
+  buildNewChatDeepLink,
   buildNewAutomationDeepLink,
   buildIssueDeepLink,
   buildPullRequestDeepLink,
@@ -230,6 +231,39 @@ async function main() {
     assert.equal(buildChatsDeepLink(), "ghapp://chats");
   });
 
+  // ---- buildNewChatDeepLink ------------------------------------------------
+  await test("buildNewChatDeepLink builds ghapp://chats/new with an encoded prompt", () => {
+    const link = buildNewChatDeepLink({ prompt: "Review the <latest> changes & ship" });
+    assert.ok(link.startsWith("ghapp://chats/new?"), link);
+    assert.equal(q(link).get("prompt"), "Review the <latest> changes & ship");
+    // Raw href must be percent-encoded (no literal space / angle brackets).
+    assert.ok(!/[<> ]/.test(link), `link must be encoded: ${link}`);
+  });
+
+  await test("buildNewChatDeepLink requires a non-empty prompt (fail closed)", () => {
+    assert.equal(buildNewChatDeepLink({ prompt: "" }), null);
+    assert.equal(buildNewChatDeepLink({ prompt: "   " }), null); // whitespace-only trims to empty
+    assert.equal(buildNewChatDeepLink({}), null);
+    assert.equal(buildNewChatDeepLink(), null);
+    assert.equal(buildNewChatDeepLink({ prompt: null }), null);
+  });
+
+  await test("buildNewChatDeepLink: hostile prompt text cannot inject a query key or change the route", () => {
+    const link = buildNewChatDeepLink({ prompt: "hi&model=evil&foo=1" });
+    const p = q(link);
+    // The whole hostile string is ONE prompt value; nothing leaked into siblings.
+    assert.equal(p.get("prompt"), "hi&model=evil&foo=1");
+    assert.equal(p.get("model"), null);
+    assert.equal(p.get("foo"), null);
+    assert.equal(new URL(link).host, "chats"); // route unchanged
+    assert.equal(new URL(link).pathname, "/new");
+  });
+
+  await test("buildNewChatDeepLink round-trips a quoted untrusted prompt", () => {
+    const prompt = `Summarize ${quoteUntrusted("t&t <x>")}`;
+    assert.equal(q(buildNewChatDeepLink({ prompt })).get("prompt"), prompt);
+  });
+
   // ---- buildNewAutomationDeepLink ------------------------------------------
   await test("buildNewAutomationDeepLink fills valid fields and drops invalid ones", () => {
     const link = buildNewAutomationDeepLink({
@@ -360,6 +394,7 @@ async function main() {
       "buildSessionDeepLink",
       "buildSessionDetailDeepLink",
       "buildChatsDeepLink",
+      "buildNewChatDeepLink",
       "buildNewAutomationDeepLink",
       "buildIssueDeepLink",
       "buildPullRequestDeepLink",

--- a/skills/create-canvas-app/test/generator.test.mjs
+++ b/skills/create-canvas-app/test/generator.test.mjs
@@ -145,6 +145,7 @@ async function main() {
       "buildSessionDeepLink",
       "buildSessionDetailDeepLink",
       "buildChatsDeepLink",
+      "buildNewChatDeepLink",
       "buildNewAutomationDeepLink",
       "buildIssueDeepLink",
       "buildPullRequestDeepLink",


### PR DESCRIPTION
## What

Adds `buildNewChatDeepLink({ prompt })` to the create-canvas-app canvas-kit, mirroring a new deep-link route in the Copilot host app that creates a new chat and submits a prompt (`ghapp://chats/new?prompt=<text>`).

## Why

A periodic audit of the Copilot host app's canvas surface — the SDK canvas contract, the theme contract, the create-canvas authoring contract, the deep-link route registry, and the example extensions — against the kit's last sync (`KIT_VERSION 2026-07-13.1`) found one warranted change: the host added a public `chats/new` deep-link route. The kit's deep-link builders did not yet expose it, so a canvas author had no safe way to build that link. Everything else on the canvas surface (SDK canvas API, theme contract, authoring contract, vendored lucide icons) was already current, so no other changes were warranted.

## What changed

- **`kit/deeplinks.mjs`** — new `buildNewChatDeepLink({ prompt })`. Requires a non-empty prompt (returns `null` otherwise), URL-encodes via `URLSearchParams`, and funnels through `safeDeepLinkUrl`, so untrusted text cannot inject a query key, add a path segment, or change the route. `prompt` is the only parameter; model, mode, reasoning effort, context tier, and agent all use the app's defaults.
- **`kit/client.mjs`** — re-export the new builder from the single view-facing barrel.
- **`kit/version.mjs`** — bump `KIT_VERSION` `2026-07-13.1` to `2026-07-20.1` (kit bytes changed).
- **`test/deeplinks.test.mjs`** — 4 new cases: encode, fail-closed on empty/whitespace/missing prompt, query-key/route injection, quoted-untrusted round-trip; plus the re-export assertion.
- **`test/generator.test.mjs`** — re-export assertion list.
- **`reference/deeplinks.md`**, **`SKILL.md`** — document the route and builder.
- **`reference/decision-log/canvas-kit/*`** — re-synced byte-mirror and `.kit-version.json`.

## Testing

`npm test` from `skills/create-canvas-app` — all 8 suites green (http, client, kit-parity, deeplinks, generator, tooling, vendor-lucide, kit-runtime). The kit-parity suite confirms the vendored mirror is byte-identical; the new deeplinks tests confirm the fail-closed and injection-safety invariants.

## Follow-up

Because `KIT_VERSION` changed, the downstream extensions that vendor `canvas-kit/` will be re-vendored to `2026-07-20.1` in a separate PR once this lands.