### PR TITLE
feat(create-canvas-app): add session-restart deep-link builder to canvas-kit

### DIFF
--- a/skills/create-canvas-app/kit/client.mjs
+++ b/skills/create-canvas-app/kit/client.mjs
@@ -36,6 +36,7 @@ export {
   hostedLauncherUrl,
   buildSessionDeepLink,
   buildSessionDetailDeepLink,
+  buildSessionRestartDeepLink,
   buildChatsDeepLink,
   buildNewChatDeepLink,
   buildNewAutomationDeepLink,

--- a/skills/create-canvas-app/kit/deeplinks.mjs
+++ b/skills/create-canvas-app/kit/deeplinks.mjs
@@ -223,6 +223,31 @@ export function buildSessionDetailDeepLink(sessionId) {
   return safeDeepLinkUrl(`${APP_DEEP_LINK_SCHEME}://sessions/${sessionId}`);
 }
 
+/**
+ * `ghapp://sessions/:sessionId/restart`: restart a session's Copilot CLI process
+ * — kill the child process and spawn a fresh one, the same operation as the
+ * `/restart-session` slash command. Reach for this when a canvas needs the app to
+ * pick up process-start-resolved state (MCP servers, extensions resolved at
+ * launch) that a plain `plugins.reload()` / `skills.reload()` re-reads from disk
+ * but can't actually respawn.
+ *
+ * The route is DESTRUCTIVE (queued input and any in-flight response are discarded)
+ * and a global entry point, so the app ALWAYS shows a confirmation dialog before
+ * restarting and never navigates or self-approves — the canvas only BUILDS the
+ * URL. The id is resolved against the app's own live sessions, so an id that is
+ * not a session on this device (or one that runs on a remote host) is rejected
+ * before the dialog rather than prompting for something known to fail. `sessionId`
+ * must be the same safe token shape as {@link buildSessionDetailDeepLink} (so it
+ * can't smuggle extra path segments or query keys); returns null otherwise, so a
+ * caller can withhold the control instead of rendering a dead link.
+ * @param {string} sessionId
+ * @returns {string|null}
+ */
+export function buildSessionRestartDeepLink(sessionId) {
+  if (!isSafeSessionId(sessionId)) return null;
+  return safeDeepLinkUrl(`${APP_DEEP_LINK_SCHEME}://sessions/${sessionId}/restart`);
+}
+
 /** `ghapp://chats`: open the Chats surface. */
 export function buildChatsDeepLink() {
   return safeDeepLinkUrl(`${APP_DEEP_LINK_SCHEME}://chats`);

--- a/skills/create-canvas-app/kit/version.mjs
+++ b/skills/create-canvas-app/kit/version.mjs
@@ -10,4 +10,4 @@
 // convention (the skill ships as files, not an npm version); a commit short-sha
 // works too. Re-exported from client.mjs so a canvas can read it at runtime.
 
-export const KIT_VERSION = "2026-07-20.1";
+export const KIT_VERSION = "2026-08-25.1";

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/.kit-version.json
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/.kit-version.json
@@ -1,5 +1,5 @@
 {
-  "version": "2026-07-20.1",
-  "syncedAt": "2026-07-20T16:11:45.014Z",
+  "version": "2026-08-25.1",
+  "syncedAt": "2026-08-25T16:31:18.567Z",
   "source": "create-canvas-app/kit"
 }

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/client.mjs
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/client.mjs
@@ -36,6 +36,7 @@ export {
   hostedLauncherUrl,
   buildSessionDeepLink,
   buildSessionDetailDeepLink,
+  buildSessionRestartDeepLink,
   buildChatsDeepLink,
   buildNewChatDeepLink,
   buildNewAutomationDeepLink,

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/deeplinks.mjs
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/deeplinks.mjs
@@ -223,6 +223,31 @@ export function buildSessionDetailDeepLink(sessionId) {
   return safeDeepLinkUrl(`${APP_DEEP_LINK_SCHEME}://sessions/${sessionId}`);
 }
 
+/**
+ * `ghapp://sessions/:sessionId/restart`: restart a session's Copilot CLI process
+ * — kill the child process and spawn a fresh one, the same operation as the
+ * `/restart-session` slash command. Reach for this when a canvas needs the app to
+ * pick up process-start-resolved state (MCP servers, extensions resolved at
+ * launch) that a plain `plugins.reload()` / `skills.reload()` re-reads from disk
+ * but can't actually respawn.
+ *
+ * The route is DESTRUCTIVE (queued input and any in-flight response are discarded)
+ * and a global entry point, so the app ALWAYS shows a confirmation dialog before
+ * restarting and never navigates or self-approves — the canvas only BUILDS the
+ * URL. The id is resolved against the app's own live sessions, so an id that is
+ * not a session on this device (or one that runs on a remote host) is rejected
+ * before the dialog rather than prompting for something known to fail. `sessionId`
+ * must be the same safe token shape as {@link buildSessionDetailDeepLink} (so it
+ * can't smuggle extra path segments or query keys); returns null otherwise, so a
+ * caller can withhold the control instead of rendering a dead link.
+ * @param {string} sessionId
+ * @returns {string|null}
+ */
+export function buildSessionRestartDeepLink(sessionId) {
+  if (!isSafeSessionId(sessionId)) return null;
+  return safeDeepLinkUrl(`${APP_DEEP_LINK_SCHEME}://sessions/${sessionId}/restart`);
+}
+
 /** `ghapp://chats`: open the Chats surface. */
 export function buildChatsDeepLink() {
   return safeDeepLinkUrl(`${APP_DEEP_LINK_SCHEME}://chats`);

--- a/skills/create-canvas-app/reference/decision-log/canvas-kit/version.mjs
+++ b/skills/create-canvas-app/reference/decision-log/canvas-kit/version.mjs
@@ -10,4 +10,4 @@
 // convention (the skill ships as files, not an npm version); a commit short-sha
 // works too. Re-exported from client.mjs so a canvas can read it at runtime.
 
-export const KIT_VERSION = "2026-07-20.1";
+export const KIT_VERSION = "2026-08-25.1";

--- a/skills/create-canvas-app/reference/decision-log/web/app.mjs
+++ b/skills/create-canvas-app/reference/decision-log/web/app.mjs
@@ -16,6 +16,7 @@ import {
   relativeTime,
   buildSessionDeepLink,
   buildSessionDetailDeepLink,
+  buildSessionRestartDeepLink,
   buildChatsDeepLink,
   buildNewAutomationDeepLink,
   buildIssueDeepLink,
@@ -123,6 +124,7 @@ function AppIntegrations({ state, invoke }) {
   const issueUrl = repo ? linkFor(buildIssueDeepLink({ owner, repo: name, number: num })) : null;
   const prUrl = repo ? linkFor(buildPullRequestDeepLink({ owner, repo: name, number: num })) : null;
   const sessionUrl = linkFor(buildSessionDetailDeepLink(sessionId.trim()));
+  const restartUrl = linkFor(buildSessionRestartDeepLink(sessionId.trim()));
 
   return html`
     <div class="ck-card dl-integrations ck-col">
@@ -188,6 +190,7 @@ function AppIntegrations({ state, invoke }) {
           onInput=${(e) => setSessionId(e.target.value)}
         />
         <${LinkButton} href=${sessionUrl} icon="app-window" label="Open session" title="Open an existing session by its id" />
+        <${LinkButton} href=${restartUrl} icon="rotate-ccw" label="Restart" title="Restart this session's Copilot CLI process (confirmation-gated)" />
       </div>
     </div>
   `;

--- a/skills/create-canvas-app/reference/deeplinks.md
+++ b/skills/create-canvas-app/reference/deeplinks.md
@@ -80,6 +80,24 @@ opens the session.
 `sessionId` must be a safe token (`[A-Za-z0-9._-]`, `<=256` chars) so it cannot add
 path segments or query keys.
 
+### `sessions/:sessionId/restart`: restart a session's Copilot CLI process
+
+`buildSessionRestartDeepLink(sessionId)` → `ghapp://sessions/<id>/restart`
+
+Restarts the session's Copilot CLI process — kills the child process and spawns a
+fresh one, the same operation as the `/restart-session` slash command. Use it when
+a canvas needs the app to pick up process-start-resolved state (MCP servers,
+extensions resolved at launch) that a plain `plugins.reload()` / `skills.reload()`
+re-reads from disk but can't respawn.
+
+This route is **destructive** (queued input and any in-flight response are
+discarded) and a global entry point, so it is **always confirmation-gated**: the
+app never navigates directly or self-approves the way `sessions/:sessionId` may for
+a session it already tracks. The id is resolved against the app's own live
+sessions, so an unknown id — or one running on a remote host that can't be
+restarted locally — is rejected before the dialog. `sessionId` uses the same safe
+token shape as `sessions/:sessionId`.
+
 ### `chats`: open Chats
 
 `buildChatsDeepLink()` → `ghapp://chats`

--- a/skills/create-canvas-app/test/deeplinks.test.mjs
+++ b/skills/create-canvas-app/test/deeplinks.test.mjs
@@ -16,6 +16,7 @@ import {
   hostedLauncherUrl,
   buildSessionDeepLink,
   buildSessionDetailDeepLink,
+  buildSessionRestartDeepLink,
   buildChatsDeepLink,
   buildNewChatDeepLink,
   buildNewAutomationDeepLink,
@@ -226,6 +227,22 @@ async function main() {
     assert.equal(buildSessionDetailDeepLink(123), null);
   });
 
+  // ---- buildSessionRestartDeepLink -----------------------------------------
+  await test("buildSessionRestartDeepLink builds ghapp://sessions/:id/restart", () => {
+    assert.equal(buildSessionRestartDeepLink("abc-123_4.5"), "ghapp://sessions/abc-123_4.5/restart");
+  });
+
+  await test("buildSessionRestartDeepLink rejects unsafe ids", () => {
+    assert.equal(buildSessionRestartDeepLink(""), null);
+    assert.equal(buildSessionRestartDeepLink("a/b"), null); // no extra path segments (incl. a forged /restart)
+    assert.equal(buildSessionRestartDeepLink("a b"), null);
+    assert.equal(buildSessionRestartDeepLink("a?x=1"), null);
+    assert.equal(buildSessionRestartDeepLink("."), null);
+    assert.equal(buildSessionRestartDeepLink(".."), null);
+    assert.equal(buildSessionRestartDeepLink("x".repeat(257)), null);
+    assert.equal(buildSessionRestartDeepLink(123), null);
+  });
+
   // ---- buildChatsDeepLink --------------------------------------------------
   await test("buildChatsDeepLink builds ghapp://chats", () => {
     assert.equal(buildChatsDeepLink(), "ghapp://chats");
@@ -393,6 +410,7 @@ async function main() {
       "hostedLauncherUrl",
       "buildSessionDeepLink",
       "buildSessionDetailDeepLink",
+      "buildSessionRestartDeepLink",
       "buildChatsDeepLink",
       "buildNewChatDeepLink",
       "buildNewAutomationDeepLink",


### PR DESCRIPTION
## What

Adds a new deep-link builder to the `create-canvas-app` skill's canvas-kit:

```js
buildSessionRestartDeepLink(sessionId) // → "ghapp://sessions/<id>/restart"
```

It mirrors the existing `buildSessionDetailDeepLink` and lets a canvas extension request that the Copilot host app **restart a session's CLI process** — the same operation as the `/restart-session` slash command. This closes the last remaining gap between the kit's deep-link surface and the host app's current route set: the host recently added a `sessions/:sessionId/restart` route specifically so an unprivileged extension canvas can *request* a restart. The canvas only builds the URL; the host validates the id against its own live sessions and always shows a confirmation dialog before the destructive action.

## Why

Keeps the vendored canvas-kit in sync with the host app's canvas surface as of the latest review. The restart route was the one warranted addition — the SDK `canvas.ts`, the theme contract, and the authoring contract were all unchanged since the last sync, so no other kit changes were needed.

## Changes

- **`kit/deeplinks.mjs`** — new `buildSessionRestartDeepLink`, reusing `isSafeSessionId` + `safeDeepLinkUrl` (fails closed to `null` on any unsafe id).
- **`kit/client.mjs`** — re-export the builder on the browser client surface.
- **`kit/version.mjs`** — bump `KIT_VERSION` `2026-07-20.1` → `2026-08-25.1` (kit bytes changed).
- **`test/deeplinks.test.mjs`** — valid case + fail-closed rejection of path/query smuggling (`a/b`, `a?x=1`), dot segments (`.`, `..`), over-length, and non-string ids; updated the client re-export assertion.
- **`reference/deeplinks.md`** — document the new route.
- **`reference/decision-log/web/app.mjs`** — wire a "Restart" control into the reference demo so it keeps exercising every deep-link builder.
- **`reference/decision-log/canvas-kit/**`** — re-synced vendored copy (byte-identical to `kit/`, marker stamped `2026-08-25.1`).

## Verification

- `npm test` — **186 checks pass**, exit 0 (all 8 suites: http, client, kit-parity, deeplinks, generator, tooling, vendor-lucide, kit-runtime).
- `check-kit-freshness.mjs reference/decision-log` — exit 0 (vendored copy fresh at `2026-08-25.1`).
- Security review: no exploitable findings — validation mirrors the safe sibling; the constrained id charset excludes `/ : ? # % \` and whitespace, so no traversal, scheme/host injection, or query/fragment smuggling is possible; demo `href` binding is auto-escaped.
- Code review: no significant findings; vendored copy confirmed byte-identical.

## Scope

Internal tooling change (P2) to a skill's vendored SDK; no runtime product behavior beyond the new pure, input-validating builder function.

Co-authored-by: Copilot App &lt;223556219+Copilot@users.noreply.github.com&gt;