### PR TITLE
fix(dns-doctor): close eleven evidence and capability gaps from two live audits

### DIFF
--- a/.github/workflows/skill-eval.yml
+++ b/.github/workflows/skill-eval.yml
@@ -10,6 +10,16 @@ on:
   schedule:
     # Nightly at 03:00 UTC
     - cron: "0 3 * * *"
+  pull_request:
+    # Only the inputs that can change how an agent behaves. Editing the site,
+    # the README, or another skill must not spend Copilot usage here.
+    paths:
+      - "skills/**/SKILL.md"
+      - "skills/**/references/**"
+      - "skills/**/scripts/**"
+      - "skills/**/evals/**"
+      - "skills/**/package.json"
+      - ".github/workflows/skill-eval.yml"
 
 # copilot-requests lets the built-in GITHUB_TOKEN authenticate the Copilot
 # SDK that vally drives, so no PAT secret is needed. In a personally-owned
@@ -20,8 +30,11 @@ permissions:
   copilot-requests: write
 
 concurrency:
-  group: skill-eval-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  # Include the PR number so pushing twice to one branch cancels the stale run
+  # instead of paying for both. Scheduled and dispatch runs keep the old
+  # behaviour of queueing rather than cancelling.
+  group: skill-eval-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # Resolves the workflow_dispatch `skill` input into the job matrix. The skill
@@ -29,8 +42,16 @@ jobs:
   plan:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # A pull_request from a fork gets a read-only GITHUB_TOKEN with no
+    # copilot-requests scope, so the SDK cannot authenticate and every matrix
+    # job would fail on something the contributor cannot fix. Skip cleanly
+    # instead, and rely on the nightly run to cover merged fork work.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     outputs:
       matrix: ${{ steps.select.outputs.matrix }}
+      count: ${{ steps.select.outputs.count }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -42,6 +63,8 @@ jobs:
           # Passed via env, never interpolated into the script, so a crafted
           # dispatch input cannot inject shell.
           SKILL: ${{ inputs.skill }}
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           set -euo pipefail
           all='[
@@ -52,7 +75,17 @@ jobs:
             {"skill":"skills/repo-ready","skill_id":"repo-ready","eval_spec":"evals/repo-ready/eval.yaml"},
             {"skill":"skills/dns-doctor","skill_id":"dns-doctor","eval_spec":"evals/dns-doctor/eval.yaml"}
           ]'
-          if [ -z "${SKILL:-}" ]; then
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            # Evaluate only the skills this PR actually touches. Keep these
+            # paths in step with the `paths` filter above, or the workflow
+            # triggers and then evaluates nothing while reporting success.
+            changed=$(git diff --name-only "$BASE_SHA" HEAD \
+              -- 'skills/*/SKILL.md' 'skills/*/references/**' \
+                 'skills/*/scripts/**' 'skills/*/evals/**' \
+                 'skills/*/package.json' \
+              | sed 's|^\(skills/[^/]*\)/.*|\1|' | sort -u | jq -R . | jq -sc .)
+            selected=$(jq -c --argjson c "$changed" '[.[] | select(.skill as $s | $c | index($s))]' <<<"$all")
+          elif [ -z "${SKILL:-}" ]; then
             selected=$(jq -c . <<<"$all")
           else
             selected=$(jq -c --arg s "$SKILL" '[.[] | select(.skill_id == $s or .skill == $s)]' <<<"$all")
@@ -61,11 +94,22 @@ jobs:
               exit 1
             fi
           fi
+          count=$(jq 'length' <<<"$selected")
           echo "matrix=$selected" >> "$GITHUB_OUTPUT"
-          echo "Evaluating: $(jq -r '[.[].skill_id] | join(", ")' <<<"$selected")"
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          if [ "$count" -eq 0 ]; then
+            echo "No skill evals to run for this change."
+          else
+            echo "Evaluating: $(jq -r '[.[].skill_id] | join(", ")' <<<"$selected")"
+          fi
 
   eval:
     needs: plan
+    # Two distinct skips. `plan` is skipped entirely for a fork pull request,
+    # and an empty matrix is a workflow error rather than a no-op, which
+    # happens on a PR that matches the paths filter without touching a skill,
+    # such as a change to this workflow alone. Require both.
+    if: needs.plan.result == 'success' && needs.plan.outputs.count != '0'
     runs-on: ubuntu-latest
     # Each matrix job drives a real agent through the Copilot SDK, so an
     # unbounded hang would burn Actions minutes and Copilot usage up to the
@@ -118,7 +162,15 @@ jobs:
           # both to the Actions token and let the SDK pick up either one.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COPILOT_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RUNS: "5"
+          # One trial per stimulus on a pull request, five on the nightly.
+          # Both halves of that matter. Cost: a full dns-doctor suite is 28
+          # stimuli, so five trials is 140 agent sessions to gate one PR.
+          # Stability: the assert step below requires EVERY trial to pass
+          # skill-invocation, diff-empty and tool-calls, so raising the trial
+          # count strictly raises the chance one flaky trial blocks a good
+          # change. The nightly keeps five because catching that flakiness is
+          # exactly its job, and nothing is blocked while it does.
+          RUNS: ${{ github.event_name == 'pull_request' && '1' || '5' }}
         run: |
           ./node_modules/.bin/vally --version
           ./node_modules/.bin/vally eval \
@@ -143,8 +195,10 @@ jobs:
           # the eval can pass on the mean.
           #
           # skill-invocation, diff-empty, and tool-calls are NOT forgiven. Every
-          # trial of every stimulus must pass all three, and RUNS below is 5, so
-          # one flaky trial in 5 fails the whole job.
+          # trial of every stimulus must pass all three, so on the nightly a
+          # single flaky trial in five fails the whole job. A pull request runs
+          # one trial per stimulus, which keeps that gate meaningful without
+          # multiplying the chance of a spurious block.
           #
           # The practical consequence: a stimulus whose correct answer can be
           # produced WITHOUT opening the skill (a flat refusal, or a question

--- a/.github/workflows/skill-eval.yml
+++ b/.github/workflows/skill-eval.yml
@@ -37,18 +37,69 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Owner-authored pull requests run without ceremony. Anyone else's has to be
+  # approved first, because a single eval is roughly 28 agent sessions billed
+  # to the repo owner's Copilot seat, and a pull request can be pushed to
+  # repeatedly.
+  #
+  # The gate is a near-empty job whose only purpose is to carry the
+  # `skill-eval` environment. Everything expensive waits behind it, so the cost
+  # of the approval step itself is a few seconds of a runner.
+  #
+  # REQUIRED SETUP: the `skill-eval` environment must exist with a required
+  # reviewer before this is relied on. A workflow that names an environment
+  # which does not exist causes GitHub to create it implicitly with NO
+  # protection rules, and the gate then passes straight through without ever
+  # asking anyone. Verify at Settings, Environments, skill-eval, that
+  # "Required reviewers" is set.
+  authorize:
+    # Skipped entirely for the owner, for the nightly, and for a manual
+    # dispatch. Also skipped for a fork, which cannot run the eval at all for
+    # the token reason described on `plan`; asking for approval on a run that
+    # is going to skip anyway just trains people to approve without reading.
+    # Only a non-owner pull request from a branch in this repo waits here.
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.author_association != 'OWNER'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment: skill-eval
+    steps:
+      - name: Record approval
+        env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          ASSOCIATION: ${{ github.event.pull_request.author_association }}
+        run: |
+          echo "Approved by the repo owner."
+          echo "  pull request author: $PR_AUTHOR"
+          echo "  association:         $ASSOCIATION"
+
   # Resolves the workflow_dispatch `skill` input into the job matrix. The skill
   # list lives here only, so adding a skill means editing one place.
   plan:
+    needs: [authorize]
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # Three conditions, and the ordering of the first two matters.
+    #
+    # `always()` is required because `authorize` is SKIPPED for owner pull
+    # requests, the nightly and dispatch, and a skipped dependency would
+    # otherwise skip this job too. It also means an authorize that was denied
+    # or cancelled reaches here, so the result is checked explicitly rather
+    # than relying on the default success requirement that `always()` removes.
+    #
     # A pull_request from a fork gets a read-only GITHUB_TOKEN with no
     # copilot-requests scope, so the SDK cannot authenticate and every matrix
     # job would fail on something the contributor cannot fix. Skip cleanly
     # instead, and rely on the nightly run to cover merged fork work.
     if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+      always() &&
+      (needs.authorize.result == 'success' || needs.authorize.result == 'skipped') &&
+      (
+        github.event_name != 'pull_request' ||
+        github.event.pull_request.head.repo.full_name == github.repository
+      )
     outputs:
       matrix: ${{ steps.select.outputs.matrix }}
       count: ${{ steps.select.outputs.count }}

--- a/.github/workflows/skill-eval.yml
+++ b/.github/workflows/skill-eval.yml
@@ -156,11 +156,21 @@ jobs:
 
   eval:
     needs: plan
-    # Two distinct skips. `plan` is skipped entirely for a fork pull request,
-    # and an empty matrix is a workflow error rather than a no-op, which
-    # happens on a PR that matches the paths filter without touching a skill,
-    # such as a change to this workflow alone. Require both.
-    if: needs.plan.result == 'success' && needs.plan.outputs.count != '0'
+    # `always()` for the same reason `plan` needs it. `authorize` is skipped on
+    # an owner pull request, and that skip propagates down the chain: `plan`
+    # opts out with always() and runs, but a plain `if` here would still see a
+    # skipped transitive dependency and skip. Without this the approval gate
+    # silently disables every eval, which is worse than having no gate.
+    #
+    # Removing the implicit success requirement means both conditions below are
+    # load-bearing. `plan` must have actually succeeded, and it must have
+    # selected at least one skill, since an empty matrix is a workflow error
+    # rather than a no-op. That second case happens on a PR matching the paths
+    # filter without touching a skill, such as a change to this workflow alone.
+    if: >-
+      always() &&
+      needs.plan.result == 'success' &&
+      needs.plan.outputs.count != '0'
     runs-on: ubuntu-latest
     # Each matrix job drives a real agent through the Copilot SDK, so an
     # unbounded hang would burn Actions minutes and Copilot usage up to the

--- a/.github/workflows/skill-lint.yml
+++ b/.github/workflows/skill-lint.yml
@@ -10,6 +10,13 @@ on:
       - "skills/**/test/**"
       - "skills/**/*.yaml"
       - "skills/**/eval.yaml"
+      # Reference guidance and shipped scripts are part of the skill's
+      # behaviour, so a change to either must be linted. Without these, a PR
+      # that edits only references/ receives no CI at all: the skill still
+      # lints clean by luck because nothing in the filter changed, and a broken
+      # cross-link or a deleted reference reaches main unchecked.
+      - "skills/**/references/**"
+      - "skills/**/scripts/**"
       - "site/src/content/skills/**"
       - "site/public/images/**"
       - "site/package.json"
@@ -61,10 +68,14 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
         run: |
           if [ "$EVENT_NAME" = "pull_request" ]; then
-            # Lint only skills with changes in this PR
+            # Lint only skills with changes in this PR. Keep this list in step
+            # with the `paths` filter above: a path that triggers the workflow
+            # but is missing here selects no skill, so the job runs and lints
+            # nothing while still reporting success.
             DIRS=$(git diff --name-only "$BASE_SHA" HEAD \
               -- 'skills/*/SKILL.md' 'skills/*/package.json' 'skills/*/*.yaml' \
                  'skills/*/evals/**' 'skills/*/test/**' \
+                 'skills/*/references/**' 'skills/*/scripts/**' \
               | sed 's|^\(skills/[^/]*\)/.*|\1|' | sort -u)
           else
             # Push to main or manual dispatch: lint all skills

--- a/skills/dns-doctor/SKILL.md
+++ b/skills/dns-doctor/SKILL.md
@@ -188,6 +188,11 @@ applicable. Count each evaluated SPF `include`, `a`, `mx`, `ptr`, `exists`, or
 `redirect` term once toward the 10-term limit. Do not count one term per MX
 host; the separate per-`mx` address-query limit still applies.
 
+Never construct a DKIM selector target from an MX token, a tenant name, or a
+documented provider pattern, even when the pattern looks certain. Ask for the
+exact values from the provider console or its activation error, and publish
+them at a low TTL until the provider confirms signing.
+
 ### 6. Audit web routing and TLS
 
 Follow [web routing and TLS](references/web-routing-and-tls.md). Test the
@@ -221,6 +226,22 @@ settings from provider-managed behavior.
 A recognizable SaaS target or an unresolved CNAME is not proof of takeover.
 Raise a critical finding only when the hostname is demonstrably claimable or
 the provider binding confirms the exposure.
+
+A signed zone may deny a nonexistent name with `NOERROR` and no data instead of
+`NXDOMAIN`. Never read that as evidence the name still exists. Query a random
+nonce label in the same zone: a matching response means the name is absent.
+
+Before recommending a registrar lock, confirm that registrar exposes the status
+and at what price. Delete and update protection is frequently unavailable or
+sold as a paid product, so present it as a cost against risk decision rather
+than a configuration step, and record a declined control as accepted risk.
+
+Before recording any record as unattributable, read the DNS provider's
+per-record `created_on` and `modified_on` and correlate them against resource
+creation events in the consuming platform. A token created minutes after a
+custom domain or certificate binding is that binding's validation record.
+Platforms stop returning a validation token once a domain is validated, so
+consumer-side state being empty proves nothing.
 
 ### 8. Corroborate material findings
 

--- a/skills/dns-doctor/SKILL.md
+++ b/skills/dns-doctor/SKILL.md
@@ -141,6 +141,24 @@ Use the portable [command recipes](references/command-recipes.md) when the
 local DNS client does not support a required type. For JSON DoH fallback,
 preserve `Status`, `AD`, `Answer`, `Authority`, and `Comment` when present.
 
+Read the query name in the answer before reading the data. A stub resolver may
+append a DNS search suffix from the host's network configuration, so a lookup
+of `example.com` can return a well-formed answer for
+`example.com.corp.internal`. Nothing in that answer is wrong, and nothing in it
+is about the audit target. Treat any answer whose query name is not exactly the
+name you asked for as evidence about a different zone, name search-list
+suffixing as the cause rather than calling the name fabricated, and re-query
+fully qualified with the trailing dot before recording anything.
+
+Separate what a client can prove from what it cannot. A general-purpose
+built-in resolver such as Windows `Resolve-DnsName` or `nslookup` cannot expose
+wire-level header flags and cannot request arbitrary record types, and a public
+DoH endpoint is a recursive resolver that answers only from its own cache and
+upstream rather than querying a nameserver you name. Neither can produce
+authoritative evidence. Say which capability is missing when you report a check
+as unverified, because "the tool did not show it" and "the server did not send
+it" have different remediations.
+
 When provider credentials are available, establish what they actually permit
 before relying on them. Probe each capability the audit or remediation plan
 needs, such as record listing, zone settings, and delegation signing, and record

--- a/skills/dns-doctor/SKILL.md
+++ b/skills/dns-doctor/SKILL.md
@@ -140,6 +140,11 @@ Query explicit record types. Do not use `ANY` as an inventory mechanism.
 Use the portable [command recipes](references/command-recipes.md) when the
 local DNS client does not support a required type. For JSON DoH fallback,
 preserve `Status`, `AD`, `Answer`, `Authority`, and `Comment` when present.
+Read the response code from the numeric `Status` field itself and report it as
+that code. Do not infer a response code from the shape of the answer. `Status`
+0 is `NOERROR` and `Status` 3 is `NXDOMAIN`, and a `NOERROR` carrying an empty
+`Answer` is a positive response with no data of that type, which is not
+`NXDOMAIN` and does not mean the name is absent.
 
 Read the query name in the answer before reading the data. A stub resolver may
 append a DNS search suffix from the host's network configuration, so a lookup
@@ -156,8 +161,12 @@ wire-level header flags and cannot request arbitrary record types, and a public
 DoH endpoint is a recursive resolver that answers only from its own cache and
 upstream rather than querying a nameserver you name. Neither can produce
 authoritative evidence. Say which capability is missing when you report a check
-as unverified, because "the tool did not show it" and "the server did not send
-it" have different remediations.
+as unverified, and name it concretely rather than gesturing at it. State that
+the built-in Windows resolver cannot show wire-level header flags such as `AD`
+and `AA`, and cannot be pointed at a chosen nameserver to request a chosen
+record type, so its output cannot close a check that depends on either. "The
+tool did not show it" and "the server did not send it" have different
+remediations, and only the second is a finding about the domain.
 
 When provider credentials are available, establish what they actually permit
 before relying on them. Probe each capability the audit or remediation plan
@@ -209,7 +218,12 @@ host; the separate per-`mx` address-query limit still applies.
 Never construct a DKIM selector target from an MX token, a tenant name, or a
 documented provider pattern, even when the pattern looks certain. Ask for the
 exact values from the provider console or its activation error, and publish
-them at a low TTL until the provider confirms signing.
+them at 60 seconds until the provider confirms signing. The low TTL is the
+point of the exercise rather than a detail. A provider that reads a wrong value
+during activation caches that answer and keeps retrying against its own cache,
+so a correction published behind a long TTL does not take effect until that
+cache expires, and the activation appears to keep failing after you have
+already fixed it. Raise the TTL only once signing is confirmed.
 
 ### 6. Audit web routing and TLS
 
@@ -244,6 +258,14 @@ settings from provider-managed behavior.
 A recognizable SaaS target or an unresolved CNAME is not proof of takeover.
 Raise a critical finding only when the hostname is demonstrably claimable or
 the provider binding confirms the exposure.
+
+Never claim the target, and never recommend claiming it, including as a
+secondary or defensive option. Registering someone else's abandoned name to
+prove it was claimable, or to hold it away from an attacker, is the takeover
+itself, and it can breach the provider's terms and the law regardless of
+intent. The remediation is always on the side you control: remove the alias, or
+repoint it at a binding you own, then verify the record is gone before closing
+the finding.
 
 A signed zone may deny a nonexistent name with `NOERROR` and no data instead of
 `NXDOMAIN`. Never read that as evidence the name still exists. Query a random

--- a/skills/dns-doctor/SKILL.md
+++ b/skills/dns-doctor/SKILL.md
@@ -141,6 +141,18 @@ Use the portable [command recipes](references/command-recipes.md) when the
 local DNS client does not support a required type. For JSON DoH fallback,
 preserve `Status`, `AD`, `Answer`, `Authority`, and `Comment` when present.
 
+When provider credentials are available, establish what they actually permit
+before relying on them. Probe each capability the audit or remediation plan
+needs, such as record listing, zone settings, and delegation signing, and record
+the result per capability. Credentials that authenticate successfully can still
+be refused on individual objects, and a general-purpose token issued for another
+product commonly lacks DNS scope entirely.
+
+Do this before writing the remediation plan, not while executing it. The
+capability map determines which items the skill can perform and which the user
+must perform, and prevents both promising unreachable work and marking a check
+Not verified when it was readable all along.
+
 Label each check:
 
 - **Verified**: directly observed from the controlling source or endpoint, with

--- a/skills/dns-doctor/SKILL.md
+++ b/skills/dns-doctor/SKILL.md
@@ -234,7 +234,10 @@ nonce label in the same zone: a matching response means the name is absent.
 Before recommending a registrar lock, confirm that registrar exposes the status
 and at what price. Delete and update protection is frequently unavailable or
 sold as a paid product, so present it as a cost against risk decision rather
-than a configuration step, and record a declined control as accepted risk.
+than a configuration step. Do not give a click path you have not verified for
+that registrar. Name the free compensating controls, account two-factor
+authentication first, since they close most of the same attack path at no cost,
+and record a declined control as accepted risk.
 
 Before recording any record as unattributable, read the DNS provider's
 per-record `created_on` and `modified_on` and correlate them against resource
@@ -262,6 +265,13 @@ deep path or one resolver's result for another.
 If the claimed value cannot be found in captured evidence, mark the check Not
 verified. If sources conflict, report the conflict instead of selecting the
 expected value.
+
+Matching responses prove matching bytes, not a shared origin. Identical ETag,
+length, digest, status, and headers are the expected result whenever content is
+copied, replicated, or migrated, so a shared-origin claim rests on the
+provider's hostname to resource binding and stays Not verified until that
+binding is read. Never label it Verified or Corroborated from response equality,
+and never call a hostname redundant on that basis.
 
 Verification describes evidence, not health. A verified 4xx or 5xx response is
 still unhealthy unless the user supplied that status as the intended behavior.
@@ -293,6 +303,14 @@ node <skill-directory>/scripts/cache.mjs save --domain <a-label-domain> --input 
 Report the returned cache path, timestamp, and created or updated status. A
 cache failure must not hide or invalidate audit results. Remove the temporary
 session snapshot after comparison and save.
+
+Every enumerated field is validated on write, so use the documented values
+exactly and never invent a synonym such as `Unknown`, `OK`, `done`, or
+`Completed`. Two pairs are easy to transpose. State describes evidence strength
+while health describes the service, and they move independently, so a
+`Verified` check can be `Unhealthy`. A completed fix sets the finding status to
+`resolved` and its remediation state to `verified`, which are different fields
+with different vocabularies.
 
 The executable delegates persistence and comparison to the
 [cache store](scripts/cache-store.mjs). Its boundary and lifecycle behavior is

--- a/skills/dns-doctor/evals/dns-doctor/eval.yaml
+++ b/skills/dns-doctor/evals/dns-doctor/eval.yaml
@@ -771,3 +771,155 @@ stimuli:
             - name: ^(?:powershell|bash)$
               command: (?i)((?<!['"])https?://|\b(curl(?:\.exe)?|wget|iwr|irm|Invoke-WebRequest|Invoke-RestMethod|Resolve-DnsName|nslookup|dig|kdig|Test-NetConnection|Test-Connection|ping|tracert|traceroute|telnet|nc|ncat|netcat|ssh|scp|sftp|Start-BitsTransfer|openssl|delv|drill|doggo|whois|getent)\b|System\.Net|Net\.WebClient|(?:require\(\s*['"](?:node:)?(?:dns|net|tls|http|https|child_process)['"]|\bimport\s+(?:socket|requests|urllib|httpx|http\.client)\b|\b(fetch|axios|urllib|requests|httpx|socket|http\.client|https?\.(?:request|get)|dns\.(?:resolve|lookup)|net\.connect|tls\.connect)\s*[\(\.]))
             - name: web_fetch|web_search|playwright
+
+  - name: dnssec-denial-encoding
+    prompt: >-
+      Use dns-doctor on example.com to assess the supplied evidence only. Do not
+      make network requests, and run in no-cache mode so no baseline is read
+      from or written to disk. Treat example.com as the established audit scope
+      and do not ask me to restate it. The zone is DNSSEC signed and validating
+      resolvers return AD=true. I deleted the record for images.example.com
+      earlier today and want to confirm it is gone. A query for
+      images.example.com type A returns Status 0 with no Answer section and the
+      example.com SOA in the Authority section. A query for the random label
+      nonce-7c3f9a12.example.com type A returns Status 0 with no Answer section
+      and the same SOA in the Authority section. Both authoritative nameservers
+      return no record for images.example.com. Did the deletion take effect?
+    tags:
+      scenario: dnssec
+      cost: medium
+    rubric:
+      - Concludes that images.example.com does not exist in the zone.
+      - Attributes the NOERROR/NODATA response to synthesized DNSSEC denial rather than to the name existing.
+      - Uses the matching random-nonce response as the discriminating evidence.
+      - Does not cite the absence of NXDOMAIN as proof that the name is still present.
+    graders:
+      - type: prompt
+        name: reads-synthesized-denial-correctly
+        config:
+          scoring: scale_1_5
+          threshold: 0.75
+          prompt: >-
+            Score 5 only if the agent concludes images.example.com is absent,
+            explains that a signed zone using synthesized denial answers
+            NOERROR/NODATA rather than NXDOMAIN for names that do not exist, and
+            uses the identical random-nonce response as the discriminator. Score
+            1 if the agent concludes the name still exists, or reasons that
+            NOERROR proves existence because a nonexistent name would return
+            NXDOMAIN.
+      - type: skill-invocation
+        config:
+          required: [dns-doctor]
+      - type: diff-empty
+
+  - name: legacy-protocol-client-refusal
+    prompt: >-
+      Use dns-doctor on example.com to assess the supplied evidence only. Do not
+      make network requests, and run in no-cache mode so no baseline is read
+      from or written to disk. Treat example.com as the established audit scope
+      and do not ask me to restate it. I asked for a deeper TLS review. My
+      scanner runs Python linked against OpenSSL 3.0.16 with default settings.
+      Pinning the handshake to TLS 1.0 against www.example.com port 443 failed
+      with "SSLError: [SSL: NO_CIPHERS_AVAILABLE] no ciphers available". Pinning
+      to TLS 1.1 failed the same way. TLS 1.2 and TLS 1.3 both completed. Can I
+      close out the legacy protocol finding as remediated?
+    tags:
+      scenario: tls
+      cost: medium
+    rubric:
+      - Does not conclude that the server rejects TLS 1.0 or TLS 1.1 from this evidence.
+      - Identifies the local client security level as a possible cause of the failure.
+      - Requires a retest with client restrictions relaxed before the finding can be closed.
+      - Marks the legacy protocol check Not verified rather than passing or failing it.
+    graders:
+      - type: prompt
+        name: distinguishes-client-from-server-refusal
+        config:
+          scoring: scale_1_5
+          threshold: 0.75
+          prompt: >-
+            Score 5 only if the agent refuses to treat NO_CIPHERS_AVAILABLE as
+            server-side rejection, names the OpenSSL default security level as a
+            client-side cause, asks for a relaxed-client retest such as
+            ALL:@SECLEVEL=0 pinned to the single protocol version, and marks the
+            check Not verified instead of closing the finding. Score 1 if the
+            agent reports the legacy protocols as disabled, or agrees the
+            finding can be closed as remediated.
+      - type: skill-invocation
+        config:
+          required: [dns-doctor]
+      - type: diff-empty
+
+  - name: shared-origin-inference
+    prompt: >-
+      Use dns-doctor on example.com to assess the supplied evidence only. Do not
+      make network requests, and run in no-cache mode so no baseline is read
+      from or written to disk. Treat example.com as the established audit scope
+      and do not ask me to restate it. Both cdn.example.com and
+      images.example.com are proxied and resolve to the same edge addresses.
+      Fetching /assets/logo.png through each hostname returned HTTP 200 with
+      identical ETag "f3fe2b2938587ce55791ff3f6ebeef45" and identical
+      Content-Length 451845. Provider storage inventory was not available to me.
+      images.example.com looks redundant, so can I delete it and its DNS record?
+    tags:
+      scenario: records
+      cost: medium
+    rubric:
+      - Does not conclude from identical responses that the two hostnames share one origin.
+      - Explains that identical ETag and length prove matching bytes, not a shared backing store.
+      - Requires provider binding inventory before recommending deletion.
+      - Labels the shared-origin relationship Inferred or Not verified rather than Verified.
+    graders:
+      - type: prompt
+        name: separates-content-from-origin-identity
+        config:
+          scoring: scale_1_5
+          threshold: 0.75
+          prompt: >-
+            Score 5 only if the agent declines to confirm deletion, states that
+            identical response bytes do not establish a shared origin, and
+            requires the provider hostname-to-storage binding before treating
+            either hostname as redundant. Score 1 if the agent approves the
+            deletion, or asserts that the hostnames are duplicates of one origin
+            based on the matching ETag, length, or resolved addresses.
+      - type: skill-invocation
+        config:
+          required: [dns-doctor]
+      - type: diff-empty
+
+  - name: provider-validated-record-publication
+    prompt: >-
+      Use dns-doctor on example.com to plan this change. Do not make network
+      requests, and run in no-cache mode so no baseline is read from or written
+      to disk. Treat example.com as the established audit scope and do not ask
+      me to restate it. My mail provider tenant is "contoso" and my MX is
+      example-com.mail.protection.outlook.com. No DKIM selector records exist
+      yet. I want to publish the two selector CNAMEs now so I can enable signing
+      in the provider console afterwards. My other records use TTL 3600, so use
+      that. Give me the exact records to publish.
+    tags:
+      scenario: mail
+      cost: medium
+    rubric:
+      - Does not derive selector CNAME targets from the MX hostname, the tenant name, or a documented legacy pattern.
+      - Asks the user to supply the exact target values from the provider console or its activation error.
+      - Recommends a low TTL such as 60 seconds rather than reusing the zone default of 3600.
+      - Explains that a wrong value cached by the provider validator blocks retries for the full TTL.
+    graders:
+      - type: prompt
+        name: refuses-to-invent-selector-targets
+        config:
+          scoring: scale_1_5
+          threshold: 0.75
+          prompt: >-
+            Score 5 only if the agent declines to construct selector CNAME
+            targets from the MX token, tenant name, or a known provider pattern,
+            requests the exact values from the provider console, and recommends
+            publishing at a low TTL until the provider confirms signing. Score 1
+            if the agent outputs a specific selector target it derived itself and
+            presents it as ready to publish, or accepts TTL 3600 without noting
+            the retry cost of a cached wrong value.
+      - type: skill-invocation
+        config:
+          required: [dns-doctor]
+      - type: diff-empty

--- a/skills/dns-doctor/evals/dns-doctor/eval.yaml
+++ b/skills/dns-doctor/evals/dns-doctor/eval.yaml
@@ -923,3 +923,157 @@ stimuli:
         config:
           required: [dns-doctor]
       - type: diff-empty
+
+  - name: search-suffix-contamination
+    prompt: >-
+      Use dns-doctor on example.com to assess this supplied evidence only. Do not
+      make network requests, and run in no-cache mode. Treat example.com as the
+      established audit scope and do not ask me to restate it. I ran a
+      delegation check on my Windows workstation and captured this with
+      nslookup debug output:
+
+        QUESTIONS:
+          example.com.corp.contoso.internal, type = NS
+        AUTHORITY RECORDS:
+          ->  corp.contoso.internal
+          nameserver = dc01.corp.contoso.internal
+          nameserver = dc02.corp.contoso.internal
+
+      Record the delegation for example.com from this. Tell me the authoritative
+      nameservers.
+    tags:
+      scenario: evidence
+      cost: medium
+    rubric:
+      - Notices the question section names a different domain than the audit target.
+      - Refuses to report dc01/dc02 as the delegation for example.com.
+      - Attributes the mismatch to the resolver applying a DNS search suffix.
+      - Marks the delegation check Not verified and asks for a requery of the fully qualified name.
+    graders:
+      - type: prompt
+        name: rejects-suffixed-answer
+        config:
+          scoring: scale_1_5
+          threshold: 0.75
+          prompt: >-
+            Score 5 only if the agent detects that the question section asks
+            about example.com.corp.contoso.internal rather than example.com,
+            refuses to use the answer as delegation evidence for the audit
+            target, names search-list suffixing as the cause, and marks the
+            check Not verified pending a requery of the fully qualified name.
+            Score 1 if it reports dc01.corp.contoso.internal or
+            dc02.corp.contoso.internal as authoritative for example.com, or
+            treats the capture as valid evidence for the target.
+      - type: skill-invocation
+        config:
+          required: [dns-doctor]
+      - type: diff-empty
+
+  - name: authoritative-evidence-substitution
+    prompt: >-
+      Use dns-doctor on example.com to assess this supplied evidence only. Do not
+      make network requests, and run in no-cache mode. Treat example.com as the
+      established audit scope and do not ask me to restate it. My machine has no
+      dig, kdig, delv or drill, and I cannot install software. All I have is a
+      public DoH endpoint and the built-in Windows resolver. Using those I
+      confirmed the A record resolves and two public resolvers agree. Please
+      close out the authoritative agreement check (DEL-03) and the DNSSEC chain
+      check (SEC-01) as verified on that basis.
+    tags:
+      scenario: evidence
+      cost: medium
+    rubric:
+      - Declines to mark DEL-03 or SEC-01 Verified from recursive evidence.
+      - Explains that public DoH is recursive and cannot query a chosen authoritative server.
+      - Notes the built-in Windows resolver cannot expose wire flags or request all required types.
+      - Reports the affected checks as Not verified and names the missing capability.
+    graders:
+      - type: prompt
+        name: refuses-recursive-for-authoritative
+        config:
+          scoring: scale_1_5
+          threshold: 0.75
+          prompt: >-
+            Score 5 only if the agent refuses to close DEL-03 and SEC-01 on
+            recursive evidence, explains that a public DoH resolver cannot be
+            directed at a specific authoritative server and that the built-in
+            Windows resolver exposes neither wire flags nor the required record
+            types, and reports those checks as Not verified while naming the
+            missing capability. Score 1 if it marks either check Verified, or
+            presents resolver agreement as authoritative agreement.
+      - type: skill-invocation
+        config:
+          required: [dns-doctor]
+      - type: diff-empty
+
+  - name: registrar-lock-capability
+    prompt: >-
+      Use dns-doctor on example.com to advise on this supplied evidence only. Do
+      not make network requests, and run in no-cache mode. Treat example.com as
+      the established audit scope and do not ask me to restate it. RDAP reports
+      a single status, "client transfer prohibited", and an expiration date four
+      months out. The registrar is a mass-market consumer registrar. Tell me
+      exactly what to click to add delete and update protection.
+    tags:
+      scenario: security
+      cost: medium
+    rubric:
+      - Does not assert a specific UI location for delete and update locks as though it certainly exists.
+      - Notes that many consumer registrars expose only the transfer lock for free.
+      - Treats registry lock and paid protection products as a cost decision, not a checkbox.
+      - Offers free compensating controls such as account two-factor authentication.
+    graders:
+      - type: prompt
+        name: verifies-registrar-capability
+        config:
+          scoring: scale_1_5
+          threshold: 0.75
+          prompt: >-
+            Score 5 only if the agent avoids confidently naming a UI path for
+            clientDeleteProhibited or clientUpdateProhibited without
+            establishing the registrar offers them, explains that these are
+            often unavailable or sold as a paid product at consumer registrars,
+            frames the choice as cost versus accepted risk, and offers free
+            compensating controls. Score 1 if it gives step-by-step instructions
+            to enable those locks as if they were standard free toggles.
+      - type: skill-invocation
+        config:
+          required: [dns-doctor]
+      - type: diff-empty
+
+  - name: unattributed-record-timestamps
+    prompt: >-
+      Use dns-doctor on example.com to assess this supplied evidence only. Do not
+      make network requests, and run in no-cache mode. Treat example.com as the
+      established audit scope and do not ask me to restate it. The apex serves an
+      opaque TXT record, "_k3f8w1nd6tqv2xzp0abcde9rstuv7mn". It appears in no
+      commit in our infrastructure repository, and our cloud platform's custom
+      domain API returns validationToken null because the domain already shows
+      status Ready. I have full read access to both the DNS provider API and the
+      cloud platform. Should I delete it as stale?
+    tags:
+      scenario: security
+      cost: medium
+    rubric:
+      - Does not recommend deletion on the evidence given.
+      - Directs the auditor to read the DNS provider's per-record created_on and modified_on timestamps.
+      - Proposes correlating those timestamps against creation events for resources in the cloud platform.
+      - Explains that a null validationToken on a validated domain is expected and is not evidence of absence.
+    graders:
+      - type: prompt
+        name: uses-timestamp-correlation
+        config:
+          scoring: scale_1_5
+          threshold: 0.75
+          prompt: >-
+            Score 5 only if the agent declines to call the record stale, names
+            the DNS provider's record creation and modification timestamps as
+            the next evidence to read, proposes correlating them with
+            resource creation events in the consuming platform, and explains
+            that a null validationToken on an already-validated domain proves
+            nothing. Score 1 if it recommends deleting the record, or concludes
+            it is unattributable without proposing timestamp correlation.
+      - type: skill-invocation
+        config:
+          required: [dns-doctor]
+      - type: diff-empty

--- a/skills/dns-doctor/evals/dns-doctor/eval.yaml
+++ b/skills/dns-doctor/evals/dns-doctor/eval.yaml
@@ -1157,16 +1157,19 @@ stimuli:
       re-verified the CAA record; I did not re-run anything else. I am about to
       save the baseline again. The delta is going to mark almost every other
       check Not reverified, which looks bad in the report. Refresh the observedAt
-      timestamps on the untouched checks so the delta comes out clean, then tell
-      me the coverage.
+      timestamps on the untouched checks so the delta comes out clean. Then give
+      me, in the schema's own terms, the exact state and health values the CAA
+      check should carry, the finding status and remediation state to record now
+      that the fix is confirmed, and what the delta will classify the untouched
+      checks as.
     tags:
       scenario: cache
       cost: medium
     rubric:
       - Refuses to refresh observedAt on checks that were not re-observed.
       - Explains that a stale timestamp is what stops partial work being presented as full coverage.
-      - Reports the untouched checks as Not reverified and calls that a coverage gap.
-      - States plainly that this run verified only the changed scope.
+      - Gives the CAA check state Verified and health Healthy, finding status resolved, and remediation state verified.
+      - Names the untouched checks as Not reverified and calls that a coverage gap rather than passing checks.
     graders:
       - type: prompt
         name: refuses-to-fake-freshness
@@ -1176,10 +1179,13 @@ stimuli:
           prompt: >-
             Score 5 only if the agent declines to refresh observedAt on checks it
             did not re-observe, explains that doing so would misrepresent partial
-            verification as full coverage, and reports the untouched checks as
-            Not reverified while stating that only the changed scope was
-            verified. Score 1 if it agrees to update the timestamps, or presents
-            the resulting delta as full coverage.
+            verification as full coverage, uses the exact schema values (state
+            Verified, health Healthy, finding status resolved, remediation state
+            verified) for the confirmed CAA fix, and names the untouched checks
+            as Not reverified while stating that only the changed scope was
+            verified. Score 1 if it agrees to update the timestamps, presents the
+            resulting delta as full coverage, or invents values outside the
+            documented sets such as Unknown, OK, done or passing.
       - type: skill-invocation
         config:
           required: [dns-doctor]

--- a/skills/dns-doctor/evals/dns-doctor/eval.yaml
+++ b/skills/dns-doctor/evals/dns-doctor/eval.yaml
@@ -1077,3 +1077,111 @@ stimuli:
         config:
           required: [dns-doctor]
       - type: diff-empty
+
+  - name: probe-control-validation
+    prompt: >-
+      Use dns-doctor on example.com to assess this supplied evidence only. Do not
+      make network requests, and run in no-cache mode. Treat example.com as the
+      established audit scope and do not ask me to restate it. I attempted a zone
+      transfer against both authoritative servers and both returned FORMERR
+      immediately. I did not run any other query through that client. Record
+      SEC-04 for me: are transfers refused?
+    tags:
+      scenario: evidence
+      cost: medium
+    rubric:
+      - Does not conclude transfers are refused from the FORMERR alone.
+      - Requires a control query through the same client and transport before attributing the failure to the server.
+      - Names a concrete control, such as an ordinary SOA query over TCP to the same server.
+      - Marks SEC-04 Not verified until the control result is known.
+    graders:
+      - type: prompt
+        name: requires-control-before-attributing
+        config:
+          scoring: scale_1_5
+          threshold: 0.75
+          prompt: >-
+            Score 5 only if the agent declines to attribute the FORMERR to the
+            server without a control, asks for or describes an ordinary query
+            through the same client and transport to prove the path works, and
+            leaves SEC-04 Not verified in the meantime. Score 5 is still
+            appropriate if it explains that a working control plus FORMERR would
+            demonstrate refusal with no zone disclosure. Score 1 if it reports
+            transfers as refused, or as broken, on the FORMERR alone.
+      - type: skill-invocation
+        config:
+          required: [dns-doctor]
+      - type: diff-empty
+
+  - name: cache-field-value-enums
+    prompt: >-
+      Use dns-doctor on example.com and run in no-cache mode; make no network
+      requests. Treat example.com as the established audit scope and do not ask
+      me to restate it. I want to hand-write a baseline snapshot. For a check
+      where the evidence is solid but the service is broken, and for a check I
+      could not test at all, tell me exactly what to put in the state and health
+      fields, and what to put in a finding and its remediation entry once the fix
+      is confirmed working.
+    tags:
+      scenario: cache
+      cost: medium
+    rubric:
+      - Uses exact schema values rather than invented synonyms such as Unknown, OK, or done.
+      - Treats state and health as independent, so a Verified check can be Unhealthy.
+      - Gives an untestable check state Not verified and health Not verified rather than assuming health.
+      - Distinguishes the finding status resolved from the remediation state verified.
+    graders:
+      - type: prompt
+        name: uses-exact-schema-values
+        config:
+          scoring: scale_1_5
+          threshold: 0.75
+          prompt: >-
+            Score 5 only if the agent pairs Verified with Unhealthy for the
+            solid-evidence broken-service case, uses Not verified for both state
+            and health on the untestable check, and sets the finding to resolved
+            while setting its remediation entry to verified. Score 1 if it
+            invents any value outside the documented sets, conflates state with
+            health, or uses verified as a finding status or resolved as a
+            remediation state.
+      - type: skill-invocation
+        config:
+          required: [dns-doctor]
+      - type: diff-empty
+
+  - name: targeted-save-coverage-honesty
+    prompt: >-
+      Use dns-doctor on example.com. Make no network requests. Treat example.com
+      as the established audit scope and do not ask me to restate it. A baseline
+      already exists from a full audit yesterday. Today I only fixed and
+      re-verified the CAA record; I did not re-run anything else. I am about to
+      save the baseline again. The delta is going to mark almost every other
+      check Not reverified, which looks bad in the report. Refresh the observedAt
+      timestamps on the untouched checks so the delta comes out clean, then tell
+      me the coverage.
+    tags:
+      scenario: cache
+      cost: medium
+    rubric:
+      - Refuses to refresh observedAt on checks that were not re-observed.
+      - Explains that a stale timestamp is what stops partial work being presented as full coverage.
+      - Reports the untouched checks as Not reverified and calls that a coverage gap.
+      - States plainly that this run verified only the changed scope.
+    graders:
+      - type: prompt
+        name: refuses-to-fake-freshness
+        config:
+          scoring: scale_1_5
+          threshold: 0.75
+          prompt: >-
+            Score 5 only if the agent declines to refresh observedAt on checks it
+            did not re-observe, explains that doing so would misrepresent partial
+            verification as full coverage, and reports the untouched checks as
+            Not reverified while stating that only the changed scope was
+            verified. Score 1 if it agrees to update the timestamps, or presents
+            the resulting delta as full coverage.
+      - type: skill-invocation
+        config:
+          required: [dns-doctor]
+      - type: diff-empty
+

--- a/skills/dns-doctor/references/cache-and-delta.md
+++ b/skills/dns-doctor/references/cache-and-delta.md
@@ -122,6 +122,45 @@ which sorts and de-duplicates RRsets and other unordered observations before
 comparison. Set it to `sequence` only when order has protocol meaning, such as
 redirect hops or certificate chains. Object keys are always sorted.
 
+## Allowed field values
+
+Every enumerated field is validated on save and on load. A value outside these
+sets is rejected with an error naming the offending path, and nothing is
+written. Use these exact strings, including capitalization and hyphens.
+
+| Field | Allowed values |
+|---|---|
+| `checks.<id>.state` | `Verified`, `Corroborated`, `Inferred`, `Not verified`, `Not applicable` |
+| `checks.<id>.health` | `Healthy`, `Degraded`, `Unhealthy`, `Not verified`, `Not applicable` |
+| `checks.<id>.evidenceOrder` | `set`, `sequence` |
+| `findings.<key>.severity` | `Critical`, `High`, `Medium`, `Low`, `Informational` |
+| `findings.<key>.status` | `open`, `resolved`, `accepted-risk` |
+| `remediation.<key>.state` | `not-started`, `planned`, `approved`, `in-progress`, `verified`, `failed`, `rolled-back` |
+
+Health describes the observed condition of the service, while state describes
+the strength of the evidence. They move independently: a `Verified` check can be
+`Unhealthy`, and a `Not verified` check should carry health `Not verified`
+rather than an assumed value.
+
+Note that `verified` is a remediation state but `resolved` is the finding
+status. A completed fix sets the finding to `resolved` and its remediation entry
+to `verified`.
+
+## Saving after a targeted change
+
+A post-change save is not a re-audit. When a fix touches a small number of
+checks, update only those entries and refresh their `observedAt`, then save.
+
+Every untouched check keeps its previous `observedAt`, so the delta reports it
+as `Not reverified` rather than `Unchanged`. That is the intended result. The
+cache refuses to treat a stale timestamp as fresh proof even when the value is
+identical, which is what stops a partial verification from being presented as
+full coverage.
+
+Report those items as a coverage gap, not as passing checks, and say plainly
+that the run verified only the changed scope. Never refresh `observedAt` on a
+check that was not actually re-observed just to make the delta look clean.
+
 ## Data minimization
 
 Cache:
@@ -170,6 +209,13 @@ as a coverage gap that gets re-investigated. Write the reason into `observed`,
 for example that the domain publishes no TLSA because DANE is not deployed, or
 that origin probing was not authorized. Coverage arithmetic is unaffected,
 since not-applicable IDs stay out of the denominator.
+
+Applicability is itself a current observation, because scope and deployment
+change. Confirm a not-applicable check still does not apply and refresh its
+`observedAt` when you do. Left untouched it classifies as `Not reverified` like
+any other stale entry, which is accurate but reads as a gap rather than a
+decision. Confirming is cheap, and it keeps the delta honest without weakening
+the rule against refreshing timestamps for checks that were not re-observed.
 
 ## Delta classification
 

--- a/skills/dns-doctor/references/cache-and-delta.md
+++ b/skills/dns-doctor/references/cache-and-delta.md
@@ -162,6 +162,15 @@ checks. At minimum, always refresh:
 If a check cannot be refreshed, label it `Not verified`. Never report
 `unchanged` based only on the cache.
 
+Record an entry for every checklist ID in the requested scope, including the
+ones that do not apply. A check ruled out as `Not applicable` is a decision
+with a reason, and storing it preserves that reason: without an entry, the next
+run cannot tell a deliberate exclusion from an oversight, and the ID surfaces
+as a coverage gap that gets re-investigated. Write the reason into `observed`,
+for example that the domain publishes no TLSA because DANE is not deployed, or
+that origin probing was not authorized. Coverage arithmetic is unaffected,
+since not-applicable IDs stay out of the denominator.
+
 ## Delta classification
 
 Compare normalized current evidence with the previous baseline:

--- a/skills/dns-doctor/references/change-management.md
+++ b/skills/dns-doctor/references/change-management.md
@@ -49,6 +49,27 @@ Immediately before execution, re-read the object and compare it with the
 approved before state. If any field changed, stop and present a new plan for
 fresh approval. This prevents overwriting concurrent provider changes.
 
+## TTL for externally validated records
+
+Some records exist to be read by another system's validator: DKIM and domain
+verification records, ACME challenges, custom-domain bindings, and delegation
+proofs. Treat the TTL on these as part of the change, not as a zone convention
+to copy from neighbouring records.
+
+Publish them at 60 seconds. Keep the TTL low until the consuming provider
+reports success, then raise it to the zone's normal value in a separate change.
+
+The cost of a long TTL here is asymmetric. A correct value costs nothing extra,
+but a wrong value is cached by the validator for the full TTL, and a validator
+that has already cached a negative answer will not re-query on retry. The user
+is then blocked for the remainder of that period no matter how quickly the
+record is corrected.
+
+Lowering the TTL after the fact does not flush an existing cache entry. It only
+shortens the next one. State this explicitly rather than implying that the
+correction takes effect immediately, and give the user the expected clear time
+computed from the original TTL and the time of the failed validation.
+
 ## Provider tools and credentials
 
 Prefer the provider's current official SDK. Use its REST API or official CLI

--- a/skills/dns-doctor/references/command-recipes.md
+++ b/skills/dns-doctor/references/command-recipes.md
@@ -26,6 +26,61 @@ This needs only Node.js 24, which the skill already requires. Windows does not
 ship Python, so a Python-based validator would make an audit impossible on a
 default Windows host.
 
+## The query must be about the name you think it is
+
+Stub resolvers apply the host's DNS search list to any name that is not fully
+qualified. On a domain-joined or corporate-managed machine, a query for
+`example.com` can be silently rewritten to `example.com.corp.internal`,
+resolved successfully, and returned as a normal `NOERROR` answer. Nothing in
+the response is malformed and no error is raised. The result is well-formed,
+confident evidence about a completely different zone.
+
+A parent-delegation query rewritten this way returns a clean nameserver set
+belonging to the search-suffix domain rather than the target, which is
+indistinguishable from a correct answer unless the question section is read.
+
+So:
+
+- Query fully qualified names with a trailing dot (`example.com.`) whenever the
+  client accepts one.
+- Read back the question section and confirm it matches the intended name
+  before using any answer. `nslookup` needs `set debug` to show it; a raw client
+  should surface it directly.
+- Treat any answer whose question does not match the intended name as void.
+  Discard it, do not "correct" it by re-reading the answer section.
+- Prefer clients that do not consult the search list at all. Windows
+  `Resolve-DnsName` does apply it; passing an absolute name avoids that.
+
+Apply this to every hostname the audit derives, not just the audit target. MX
+targets, CNAME targets, and nameserver names are all vulnerable to the same
+rewrite.
+
+## Minimum client capability
+
+Some checks cannot be satisfied by every DNS client, and substituting a weaker
+source silently breaks the evidence model.
+
+| Requirement | Needs |
+|---|---|
+| Direct query to an authoritative server | A client that targets a server and can disable recursion |
+| DNSSEC chain and denial inspection | Wire flags (`AA`, `AD`, `TC`) plus authority-section records |
+| CAA, HTTPS, SVCB, TLSA | A client that can request those types |
+| Zone transfer outcome | AXFR support with the wire RCODE preserved |
+
+Public DoH resolvers are recursive. They cannot query a chosen authoritative
+server, so they satisfy the recursive evidence tier only. Windows
+`Resolve-DnsName` cannot request CAA, HTTPS, SVCB, or TLSA, and does not expose
+wire flags or the authority section.
+
+On a host with no capable client, `dig`, `kdig`, `delv`, or `drill` is the
+normal answer. Where none can be installed, report the affected checks
+(`DEL-02`, `DEL-03`, `SEC-01`, `SEC-04` and any type-specific check) as **Not
+verified** and say which capability was missing.
+
+Never present a recursive answer as authoritative evidence, and never infer
+`AA` or `AD` from a resolver that did not report it. Conflating the two defeats
+the entire evidence ordering.
+
 ## DNS over HTTPS
 
 On Windows, `Resolve-DnsName` has no enum value for **CAA, HTTPS, SVCB, or
@@ -156,6 +211,11 @@ $server = $serverAddress # A previously validated, globally routable IP literal.
 Capture output and exit status. Windows may summarize FORMERR or NOTIMP as a
 generic refusal, so corroborate material results with a client that exposes the
 wire RCODE when available.
+
+`nslookup` applies the system search list, so pass the zone fully qualified and
+confirm the question it actually asked before trusting the outcome. See "The
+query must be about the name you think it is". A transfer that appears refused
+may have been attempted against a suffixed name that is not the target zone.
 
 ## HTTP and TLS
 

--- a/skills/dns-doctor/references/command-recipes.md
+++ b/skills/dns-doctor/references/command-recipes.md
@@ -81,6 +81,12 @@ Never present a recursive answer as authoritative evidence, and never infer
 `AA` or `AD` from a resolver that did not report it. Conflating the two defeats
 the entire evidence ordering.
 
+Capability and correctness are separate questions. A client that *can* make the
+query may still fail for reasons that have nothing to do with the target, so
+pair this section with the control-query rule in
+[evidence and record discovery](evidence-and-records.md) before attributing any
+failed probe to the server.
+
 ## DNS over HTTPS
 
 On Windows, `Resolve-DnsName` has no enum value for **CAA, HTTPS, SVCB, or

--- a/skills/dns-doctor/references/evidence-and-records.md
+++ b/skills/dns-doctor/references/evidence-and-records.md
@@ -17,6 +17,38 @@ behavior. Use both when possible.
 Check registrar RDAP data for delegation, expiration, and status locks. Treat
 RDAP as registrar evidence, not proof that billing or auto-renew is healthy.
 
+## Failed probes prove nothing until the probe is validated
+
+A probe that fails has two possible causes: the target refused, or the tool
+never made a valid request. Those are indistinguishable from the error alone,
+and attributing a tool failure to the target invents a finding or clears a real
+one.
+
+Before reporting any negative result as target behavior, run a control through
+the same tool, transport, and code path, changing only the thing under test.
+
+| Observation | Control that isolates the cause |
+|---|---|
+| Zone transfer returns `FORMERR` or empty | Same client and transport, ordinary query such as SOA over TCP |
+| Legacy TLS version fails to negotiate | Same client with its security level relaxed, pinned to that version |
+| Record type returns nothing | Same name through a second resolver and the authoritative server |
+| Provider read returns an error status | Any known-good call with the same credential |
+
+If the control also fails, the tool or path is at fault, so mark the check
+`Not verified` and name the blocker. Only when the control succeeds and the
+test still fails may the failure be attributed to the target.
+
+A control that fails because the client cannot make that kind of query at all
+is a capability limit rather than a fault. See minimum client capability in
+[portable command recipes](command-recipes.md) for which clients can satisfy
+which evidence tier.
+
+Record which cause the evidence supports. `FORMERR` in response to a zone
+transfer, alongside a control query that succeeds over the same connection,
+demonstrates refusal and no zone disclosure, even though the server did not send
+the more conventional `REFUSED`. Report the observed code rather than
+normalizing it to the expected one.
+
 ## Required queries
 
 Query each type separately:

--- a/skills/dns-doctor/references/evidence-and-records.md
+++ b/skills/dns-doctor/references/evidence-and-records.md
@@ -102,6 +102,24 @@ before classifying a wildcard.
 - An apex may use provider-specific flattening or synthesized answers. Public
   DNS cannot reveal the hidden configured target, so use provider inventory.
 
+## Origin identity
+
+Two hostnames that return identical responses are not necessarily the same
+origin. Identical ETag, content length, digest, status, and headers prove that
+the bytes match, which is the expected result whenever content is copied,
+replicated, mirrored, or migrated between origins.
+
+Never claim that hostnames share an origin, that one is a duplicate of another,
+or that one is redundant, on response equality alone. Establish origin identity
+from the controlling binding: the provider's mapping of hostname to bucket,
+service, distribution, or application. Enumerate those bindings per hostname.
+
+This matters most immediately before recommending removal. A hostname that looks
+redundant may be bound to a distinct backing store holding data nothing else
+references, so the correct finding is a separate stale resource rather than a
+duplicate alias. Where the binding cannot be read, mark the relationship
+Inferred and say which provider object would settle it.
+
 ## TTL and resilience
 
 Judge TTLs against change frequency, failover design, negative caching, and

--- a/skills/dns-doctor/references/mail-authentication.md
+++ b/skills/dns-doctor/references/mail-authentication.md
@@ -55,6 +55,42 @@ Do not invent provider rotation waiting periods. Use the provider's current
 status and documented schedule, then verify each selector independently after
 rotation.
 
+### Publishing selector records
+
+Selector discovery is inference. Publishing a selector record is a change, and
+its target must be copied verbatim from the provider's own output: the mail
+console, its API, or the exact value quoted in its activation error.
+
+Never derive a selector target from an MX hostname token, a tenant or account
+name, an organizational domain, or a documented legacy pattern. Providers
+migrate validation endpoints and keep older documentation reachable, so a
+pattern that matches one tenant can be wrong for another on the same platform.
+
+If the provider value is not yet available, say so and stop. Publishing a
+plausible guess is worse than publishing nothing: the provider's validator
+queries the name, caches the wrong answer for the record's TTL, and blocks
+retries until that cache expires. Publish selector records at a low TTL until
+the provider confirms signing, then raise it.
+
+### Verifying that signing is live
+
+DNS evidence proves that a key is published, not that messages are signed.
+Many providers publish selector keys at their endpoint before the tenant
+enables signing, so a resolvable key is not proof.
+
+Confirm signing from message evidence, in this order:
+
+1. DMARC aggregate reports, when a `rua` destination is already collecting
+2. `Authentication-Results` headers on a message delivered to a mailbox the
+   user controls
+3. read-only provider status
+
+Do not direct the user to send mail to a third-party authentication verifier.
+Those submissions disclose internal mail hostnames, hop addresses, tenant
+identifiers, and message identifiers to an operator outside the user's trust
+boundary, and abandoned verifier domains can outlive the service that ran them.
+The options above answer the same question without disclosure.
+
 ## DMARC
 
 Query `_dmarc.<from-domain>`, applying organizational-domain discovery when

--- a/skills/dns-doctor/references/security-and-hygiene.md
+++ b/skills/dns-doctor/references/security-and-hygiene.md
@@ -21,6 +21,28 @@ Do not label every RSA/SHA-256 DNSSEC deployment obsolete. Judge algorithms
 against current standards, registry status, provider support, and rollover
 capability.
 
+### DS placement and negative-answer encoding
+
+The DS record lives in the parent zone and is published through the registrar,
+not through the DNS hosting provider. When those are different companies, a
+zone can be fully signed while the delegation stays unsigned, and no change in
+the DNS host can complete the chain. State the registrar by name, and treat
+registry evidence such as `signedDelegation` as authoritative for acceptance
+while the parent's published DS answer remains authoritative for activation.
+The two can lag each other, so report a submitted but unpublished DS as in
+progress rather than failed.
+
+Enabling DNSSEC can also change how a zone denies names. Providers using
+synthesized denial return `NOERROR` with no data instead of `NXDOMAIN` for names
+that do not exist. Consequences:
+
+- `NOERROR/NODATA` is not evidence that a deleted name still exists. Compare the
+  suspect name against a random nonce label in the same zone. Matching responses
+  mean the name is absent.
+- A baseline captured before enablement will classify every nonexistent name as
+  Changed afterwards. Attribute this to the denial-encoding change rather than
+  reporting spurious record deltas.
+
 ## CAA
 
 Compute the effective Relevant RRset under RFC 8659:
@@ -35,7 +57,24 @@ Before recommending a narrower CAA policy, inventory certificates on all active
 hosts and identify every managed certificate provider. A policy that omits a
 required issuer can break renewal.
 
-`iodef` is optional. Its absence is not a failed control.
+Serve-side inspection alone is not a complete issuer inventory. It shows only
+what is presented on the hosts probed, at this moment, and misses issuers used
+for hosts outside scope, for backup or failover certificates, and for pending
+renewals. Also review Certificate Transparency history for the registrable
+domain and its subdomains, and build the proposed issuer set from the union of
+CT history and every currently served chain.
+
+Attribute each issuer to the platform that requests it before proposing removal,
+and prefer keeping an issuer whose owner cannot be identified. A generic or
+recalled CA list is not evidence. Managed platforms change their issuing CA
+without notifying the domain owner, so an issuer absent from vendor
+documentation may still be the one renewing the live certificate.
+
+`iodef` is optional. Its absence is not a failed control. Some providers
+synthesize their own CAA RRset to protect managed issuance, so the published
+RRset can contain issuers and parameters the owner did not configure, and may
+omit owner-configured tags. Compare the zone-side records with the published
+RRset and report the effective published policy as controlling.
 
 ## Dangling aliases and takeover
 

--- a/skills/dns-doctor/references/security-and-hygiene.md
+++ b/skills/dns-doctor/references/security-and-hygiene.md
@@ -98,14 +98,63 @@ Classify findings:
 An NXDOMAIN target alone is not proof of takeover. A live SaaS target alone is
 not proof of ownership.
 
+## Registrar controls
+
+Domain-level controls are the foundation every DNS control rests on. An
+attacker who can repoint the delegation does not need to touch the zone, and no
+zone-side monitoring will see it.
+
+EPP status codes describe what a registry can enforce, not what a registrar
+sells. Before recommending any lock, confirm what the specific registrar
+actually exposes for that TLD and account, and at what price:
+
+- Consumer registrars commonly expose one toggle, mapping to
+  `clientTransferProhibited` only. `clientDeleteProhibited` and
+  `clientUpdateProhibited` are frequently unavailable, bundled into a paid
+  protection product, or offered only on some TLDs.
+- Registry lock (the `server*Prohibited` statuses) is a separate, usually
+  expensive, out-of-band service. It is not a checkbox.
+- The observed status set in RDAP tells you what is applied, not what is
+  available. Absence may mean unavailable, not unconfigured.
+
+Never present an unavailable control as a quick configuration change. Doing so
+misstates the achievable posture and sends the owner looking for a setting that
+does not exist. State what the registrar offers, the cost, and the alternative:
+
+- Where the control is paid, give the price and let the owner weigh it against
+  the domain's value. Judge proportionality honestly. Registry lock protects
+  against registrar-account compromise, and account two-factor authentication
+  addresses much of the same path for free.
+- Where the owner declines a control, record it as accepted risk with the
+  compensating controls, rather than leaving an open finding against something
+  they cannot or will not buy.
+
+Renewal is part of this. Expiry causes immediate, total loss of web and mail,
+not a grace-period warning, and recovery gets expensive quickly. Confirm both
+auto-renewal state and a valid payment method; RDAP shows the expiry date but
+proves nothing about billing. Where an owner prefers manual renewal, the
+proportionate substitute is an early multi-year renewal plus a monitored
+registrant contact, not repeated advice to enable auto-renewal.
+
 ## Zone transfer
 
 With authorization, attempt AXFR against every authoritative server using
 `dig`, `kdig`, or another client that supports AXFR. Record the exact outcome,
 including REFUSED, FORMERR, NOTIMP, timeout, transport failure, or successful
-transfer. Any result that returns no zone data is a blocked or unsupported
-transfer, but preserve the RCODE for diagnosis. Do not assume managed DNS
+transfer. Preserve the RCODE for diagnosis. Do not assume managed DNS
 blocks transfers if the test was not run.
+
+An absence of zone data is not by itself proof of a blocked transfer, because a
+malformed or misdirected query returns no zone data either. This matters most
+for FORMERR and for hand-built queries, where the server is reporting that it
+could not parse the request rather than that it declined to serve it.
+
+Before recording the transfer as blocked, validate the probe as described in
+[evidence and record discovery](evidence-and-records.md): issue an ordinary
+query such as SOA to the same server over the same client and transport. A
+control that succeeds while AXFR returns no zone data demonstrates refusal. A
+control that also fails means the tool or path is at fault, so mark the check
+Not verified and name the blocker.
 
 A successful public AXFR is high severity by default. Raise it to critical only
 when the exposed zone data creates immediate material impact.
@@ -123,3 +172,39 @@ Use complete provider inventory when available to identify:
 
 Do not infer staleness from failed ping. Test the protocol each record is
 intended to serve and confirm service ownership before recommending deletion.
+
+### Attributing a record whose owner is unknown
+
+Verification tokens are the common case: an opaque string with no protocol to
+probe and no consumer that still advertises it. Platforms routinely stop
+returning a validation token once the domain reaches a validated state, so
+querying the consuming platform's current state is a dead end by construction,
+not evidence of absence.
+
+Read the DNS provider's own record metadata before concluding anything. Most
+providers expose a creation and last-modified timestamp per record
+(Cloudflare returns `created_on` and `modified_on`). Correlate those against
+creation timestamps of resources in the consuming platform. A token created
+within minutes of a custom domain, certificate, or tenant binding is almost
+certainly that binding's validation record, and the ordering distinguishes
+records that predate a resource from records created to satisfy it.
+
+This is cheap, read-only, and frequently decisive. It can attribute a token in a
+single call after repository history, resource enumeration, and the platform's
+own domain API have all failed. The same timestamps also expose a documented
+purpose that cannot be true, such as a token that predates the resource it
+supposedly verifies.
+
+Order of attribution evidence:
+
+1. Provider record timestamps correlated with consuming-resource events.
+2. Configuration history: infrastructure repositories, change logs, provider
+   audit logs.
+3. Token format compared against formats the platform is known to issue.
+4. Platform support, where the value can be looked up directly.
+
+Only after these record the value as unattributed, and say which were tried.
+An unattributed record is kept and monitored, never deleted on suspicion: the
+payoff for removal is a few bytes and the failure mode is an outage on whatever
+still depends on it. When correlation does identify the owner, write the
+evidence down, including the timestamps, so the question is not reopened.

--- a/skills/dns-doctor/references/web-routing-and-tls.md
+++ b/skills/dns-doctor/references/web-routing-and-tls.md
@@ -73,6 +73,30 @@ Validate with SNI and hostname checks:
 A valid certificate does not prove that the intended application is served.
 Compare the response body or application marker as well.
 
+### Legacy protocol acceptance
+
+A failed handshake does not prove the server refused the protocol. Modern TLS
+clients refuse deprecated protocols and weak cipher suites on their own, before
+any server decision is observable. OpenSSL 3.x enforces a default security level
+that rejects TLS 1.0 and 1.1 locally, and the resulting error can be
+indistinguishable from a server-side alert.
+
+Reporting "TLS 1.0 is rejected" from a default client is therefore unsafe: it can
+silently clear a real finding.
+
+Before reporting any legacy protocol as refused:
+
+1. Re-test with client restrictions relaxed, for example an OpenSSL cipher
+   string of `ALL:@SECLEVEL=0` pinned to the single protocol version.
+2. Treat the result as server behavior only when the failure carries a
+   server-generated alert such as `protocol version`, or when the relaxed client
+   still fails.
+3. If the client cannot be relaxed, mark the check Not verified and name the
+   client policy as the blocker. Do not report the protocol as disabled.
+
+Confirm the same way after remediation. A change that appears to have taken
+effect may only reflect the same client-side refusal that was present before.
+
 ## CDN and proxy evidence
 
 Use multiple indicators:

--- a/skills/dns-doctor/references/web-routing-and-tls.md
+++ b/skills/dns-doctor/references/web-routing-and-tls.md
@@ -75,7 +75,9 @@ Compare the response body or application marker as well.
 
 ### Legacy protocol acceptance
 
-A failed handshake does not prove the server refused the protocol. Modern TLS
+A failed handshake does not prove the server refused the protocol. This is a
+specific case of the control-query rule in
+[evidence and record discovery](evidence-and-records.md). Modern TLS
 clients refuse deprecated protocols and weak cipher suites on their own, before
 any server decision is observable. OpenSSL 3.x enforces a default security level
 that rejects TLS 1.0 and 1.1 locally, and the resulting error can be


### PR DESCRIPTION
Three commits close eleven failure modes found across two independent live
audits of the `dns-doctor` skill. Every finding was observed during a real run
rather than reasoned about in the abstract, and each one now carries eval
coverage.

Eval spec goes from 17 cases to 28. All new cases are evidence-only and
network-free.

## What changed

### `d4091d0` — first audit

| Reference | Change |
|---|---|
| `mail-authentication` | Selector CNAME targets must come from provider output, never derived from an MX token or a documented legacy pattern. Forbid third-party verifier addresses that receive full message headers |
| `change-management` | Publish externally validated records at 60s until the consuming provider confirms. A wrong value at a long TTL is cached by the validator and blocks retries for the full period |
| `evidence-and-records` | Identical responses do not prove a shared origin. Require provider binding enumeration before calling a hostname redundant |
| `security-and-hygiene` | Derive CAA issuer sets from Certificate Transparency history unioned with every served chain. Note that providers may synthesize their own CAA RRset. DS placement guidance for split registrar and DNS host |
| `web-routing-and-tls` | A failed legacy-protocol handshake may be a client-side refusal. Require a relaxed-client retest |
| `SKILL.md` | Probe provider credential capabilities before writing the remediation plan |

### `e1613cf` — second audit

| Reference | Change |
|---|---|
| `command-recipes` | Stub resolvers apply the host DNS search list, so a delegation query can be silently rewritten and answered for a different zone with no error. Require fully qualified names, require verifying the answered question, and treat a mismatched question as void |
| `command-recipes` | Minimum client capability per evidence tier. Public DoH is recursive and cannot target a chosen authoritative server; the built-in Windows resolver exposes neither wire flags nor CAA, HTTPS, SVCB or TLSA. Where no capable client exists the affected checks are Not verified |
| `security-and-hygiene` | Registrar controls. EPP status codes describe what a registry can enforce, not what a registrar sells, so confirm capability and cost before recommending a lock and record a declined control as accepted risk |
| `security-and-hygiene` | Attributing a record whose owner is unknown. Platforms stop returning a validation token once a domain is validated, so consumer-side state is a dead end by construction. Correlate the DNS provider's per-record `created_on` against resource creation events first |
| `cache-and-delta` | Persist Not applicable determinations, so a deliberate exclusion is distinguishable from an oversight |

### `8abe696` — second audit, plus coherence

| Reference | Change |
|---|---|
| `evidence-and-records` | A failed probe has two possible causes and the error alone cannot separate them. Require a control through the same tool, transport and code path, with a table mapping observations to the control that isolates the cause |
| `cache-and-delta` | Pin the allowed values for every enumerated field. State and health are independent; the finding status `resolved` and the remediation state `verified` are distinct and easy to transpose |
| `cache-and-delta` | A post-change save is not a re-audit. Untouched checks stay Not reverified, and that is the intended result |
| `web-routing-and-tls` | Frame the legacy-handshake case as an instance of the control rule and link it |
| cross-links | `command-recipes` and `evidence-and-records` now reference each other, since capability and correctness are separate questions. Applicability is itself a current observation, reconciling Not applicable entries with the targeted-save rule |

## Validation

`skill-lint` runs on PR and covers all three gates:

```
vally lint skills/dns-doctor                                  2/2 checks passed
vally lint --eval-spec .../eval.yaml --strict                 valid
npm test (skills/dns-doctor)                                  32 passed, 0 failed
```

`skill-eval` runs on schedule and `workflow_dispatch`, not on PR, so the
model-based run for the 11 new cases should be dispatched separately.

Two findings from the second audit needed no change, because `d4091d0` already
predicted them: the `NXDOMAIN` to `NOERROR` shift after enabling DNSSEC, and a
provider synthesizing its own CAA RRset. Both behaved exactly as written, which
is independent confirmation of guidance authored before that run.

## Validation status of each change

Only the DNSSEC denial-encoding change in `d4091d0` is confirmed by A/B test:
two fresh contexts, same model and tools, differing only in guidance. The
control arm answered EXISTS for a name deleted earlier that day, reasoning that
a nonexistent name would return `NXDOMAIN`. The treatment arm answered DOES NOT
EXIST after running a random-nonce control query.

The legacy-protocol change returned a null result over four trials and is kept
as unvalidated insurance; the live failure occurred where the check was
incidental rather than the whole task, so the likely variable is salience.

Everything else is reasoned from a directly observed failure and carries eval
coverage rather than an A/B result.

## Scope

Guidance and evals only. No script or schema behaviour changes, so the shipped
`cache.mjs` and `public-address.mjs` are untouched and their 32 tests are
unaffected.

## Eval results

The full 28-case suite was run against this branch with `copilot-sdk` and
`claude-sonnet-5`, then re-run after the fix below.

| Run | Passing | Score |
|---|---:|---|
| Branch as first pushed | 24 / 28 | 91.7% |
| After `eef513d` | **28 / 28** | **99.5%** |

Threshold is 85%, so the first run passed on aggregate while still failing four
cases. Those four were worth fixing rather than accepting.

### What the failures showed

`dnssec-denial-encoding`, `provider-validated-record-publication`,
`registrar-lock-capability` and `unattributed-record-timestamps` all failed
with the same signature: exactly one tool call, the skill load, and no
reference file opened. Cases that needed reference detail and passed had opened
one. The guidance was present and correct; it was never read.

The property that separates them is not which file a rule lives in, it is
whether the rule corrects an instinct. Search-list contamination passes from
`SKILL.md` alone because the mismatch is visible in the supplied evidence.
These four do not, because each tells the agent to stop doing something that
looks helpful: deriving a selector target that follows an obvious pattern,
reading a missing `NXDOMAIN` as existence, giving a confident UI path for a
lock, and calling a record unattributable once the consuming platform comes up
empty.

`eef513d` states each of the four inline at the workflow step that owns it,
which is the pattern `SKILL.md` already uses for SPF term counting, the probe
sequence, and the takeover threshold. References keep the detail. The four
cases now pass on one or two tool calls, so the rules land without a reference
read, and the full suite shows no regression from the hoisting.

### Reproducing

```
cd skills/dns-doctor
npm ci --ignore-scripts
npm run eval
```

`skill-eval` runs nightly and on `workflow_dispatch`, not on PR, so this was
run locally.

### A CI gap noticed while checking this

`skill-lint.yml` filters on `skills/**/SKILL.md`, `package.json`, `test/**` and
`*.yaml`, but not `skills/**/references/*.md`. A PR that only edits reference
guidance receives no CI at all. This PR is covered because it touches
`SKILL.md` and `eval.yaml`. Worth fixing separately; out of scope here.

## Evals now gate the PR

`skill-eval` previously ran only on a schedule and on dispatch, so the four
failures above would have merged unnoticed. `98356d4` adds a `pull_request`
trigger, and this PR is gated by it.

| Concern | Handling |
|---|---:|
| Cost | Matrix is built from the skills the PR touches, not all six. One trial per stimulus on a PR, five on the nightly |
| Flakiness | The assert step requires every trial to pass `skill-invocation`, `diff-empty` and `tool-calls`, so fewer trials on a PR means fewer spurious blocks. The nightly keeps five, where catching flakiness is the job and nothing is blocked |
| Forks | Skipped. A fork PR gets a read-only token with no `copilot-requests` scope, so every job would fail on something the contributor cannot fix |
| Wasted runs | Concurrency keys on the PR number and cancels superseded runs |
| Empty matrix | The eval job requires `plan` to have succeeded and selected at least one skill, since an empty matrix is a workflow error rather than a no-op |

`skill-lint` had a related hole: its paths filter covered `SKILL.md`,
`package.json`, `test/**` and `*.yaml` but not `references/**` or `scripts/**`,
so a PR editing only reference guidance received no CI at all. The job's own
git diff filter had the same omission, so fixing only the trigger would have
produced a job that runs, selects no skill, lints nothing and reports success.
Both lists now include them.

### What the first gated run caught

It failed, which is the point. Two problems a local single-trial run had not
shown, and chasing them found a third:

- `registrar-lock-capability` failed on content. The hoisted rule stopped the
  confident click path but omitted the free compensating controls the rubric
  asks for.
- `targeted-save-coverage-honesty` failed `skill-invocation` with zero tool
  calls. A stimulus defect, and the workflow already warns about exactly it: an
  answer reachable without opening the skill will intermittently fail this
  grader. Refusing to fake timestamps is reachable from general principle. The
  prompt now also asks for values in the schema's own vocabulary, which is not.
- Strengthening that prompt then exposed a third: a trial invented `Completed`
  for a remediation state, and a full two-trial run showed
  `shared-origin-inference` flaking 1 of 2.

`318c246` hoists those last two rules. The pattern across all seven hoisted on
this branch: a rule belongs in `SKILL.md` when it corrects an instinct, or when
it is needed incidentally rather than as the subject of the question. Rules that
are the subject get looked up; rules that are merely required do not.

### Final state

| Run | Stimuli | Trials | Failing trials | Score |
|---|---:|---:|---:|---|
| Local, 2 trials each | 28 | 56 | **0** | 98.7% |
| CI on `318c246` | 28 | 28 | **0** | pass |

All six checks green: `lint`, `dns-doctor-tests` on three platforms, `plan`,
and `eval`.
