### PR TITLE
feat(site): scale skills browsing with wider layout, search, and grid/list views

### DIFF
--- a/site/src/components/SkillCard.astro
+++ b/site/src/components/SkillCard.astro
@@ -8,23 +8,29 @@ interface Props {
 }
 const { href, skillId, title, tagline, thumb } = Astro.props;
 const base = import.meta.env.BASE_URL;
-// The install command must use the skill id, not the display title. The title
-// is human-readable and may differ from the id it is installed by.
+// The install command uses the skill id, not the display title. The title is
+// human-readable and may differ from the id it is installed by.
 const install = `install ${skillId} from jongio/skills`;
+// Lowercased haystack the client-side search filters against.
+const search = `${title} ${tagline}`.toLowerCase();
 ---
 
-<article class="skill-card">
+<article class="skill-card" data-search={search}>
   <a class="skill-card__link" href={href}>
     <img class="skill-thumb" src={`${base}${thumb}`} alt={`${title} preview`} loading="lazy" />
     <div class="skill-body">
       <h3>{title}</h3>
-      <p class="muted">{tagline}</p>
-      <span class="skill-more">View skill →</span>
+      <p class="skill-tagline muted">{tagline}</p>
     </div>
   </a>
-  <div class="skill-install">
-    <p class="skill-install__label muted">Install in your agent</p>
-    <pre><code>{install}</code></pre>
+  <div class="skill-foot">
+    <a class="skill-more" href={href}>View skill →</a>
+    <button type="button" class="skill-copy" data-install={install} aria-label={`Copy install command for ${title}`}>
+      <svg class="skill-copy__icon" viewBox="0 0 16 16" width="14" height="14" fill="currentColor" aria-hidden="true">
+        <path d="M10 1.5H6a.5.5 0 0 0-.5.5v1H4A1.5 1.5 0 0 0 2.5 4.5v9A1.5 1.5 0 0 0 4 15h6a1.5 1.5 0 0 0 1.5-1.5v-1h1a1.5 1.5 0 0 0 1.5-1.5v-7A1.5 1.5 0 0 0 12 2.5h-1.5v-1a.5.5 0 0 0-.5-.5Zm0 2v.5a.5.5 0 0 0 .5.5H12v7h-1.5a.5.5 0 0 0-.5.5v1H4v-9h1.5a.5.5 0 0 0 .5-.5V3.5h4Z"/>
+      </svg>
+      <span class="skill-copy__label">Copy install</span>
+    </button>
   </div>
 </article>
 
@@ -42,56 +48,144 @@ const install = `install ${skillId} from jongio/skills`;
     border-color: var(--accent);
     transform: translateY(-2px);
   }
+  /* The base display:flex would otherwise override the UA [hidden] rule, so the
+     search filter (which toggles the hidden attribute) needs this to take. */
+  .skill-card[hidden] {
+    display: none;
+  }
   .skill-card__link {
     text-decoration: none;
     color: inherit;
-    display: block;
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-width: 0;
   }
   .skill-thumb {
     width: 100%;
-    aspect-ratio: 16 / 10;
+    height: 128px;
     object-fit: contain;
     background: var(--bg);
     border-bottom: 1px solid var(--border);
     display: block;
-    padding: 0.75rem;
+    padding: 0.6rem;
+    flex: none;
   }
   .skill-body {
-    padding: 1rem 1.1rem 1.2rem;
+    padding: 0.8rem 0.95rem;
+    flex: 1;
+    min-width: 0;
   }
   .skill-body h3 {
-    margin: 0 0 0.4rem;
-    font-size: 1.1rem;
+    margin: 0 0 0.35rem;
+    font-size: 1rem;
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    overflow-wrap: anywhere;
   }
-  .skill-body p {
-    margin: 0 0 0.8rem;
-    font-size: 0.95rem;
+  .skill-tagline {
+    margin: 0;
+    font-size: 0.9rem;
+    line-height: 1.45;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+  .skill-foot {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    padding: 0.6rem 0.95rem;
+    border-top: 1px solid var(--border);
   }
   .skill-more {
     color: var(--accent);
     font-weight: 600;
-    font-size: 0.92rem;
-  }
-  .skill-install {
-    margin-top: auto;
-    padding: 0.9rem 1.1rem 1.1rem;
-    border-top: 1px solid var(--border);
-  }
-  .skill-install__label {
-    margin: 0 0 0.4rem;
-    font-size: 0.75rem;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    font-weight: 600;
-  }
-  .skill-install pre {
-    margin: 0;
-    background: var(--bg);
-    border: 1px solid var(--border);
-    border-radius: 9px;
-    padding: 0.6rem 0.8rem;
-    overflow-x: auto;
     font-size: 0.88rem;
+    text-decoration: none;
+    white-space: nowrap;
+  }
+  .skill-copy {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.35rem 0.6rem;
+    border-radius: 8px;
+    border: 1px solid var(--border);
+    background: var(--bg);
+    color: var(--muted);
+    font: 600 0.78rem/1 ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+    cursor: pointer;
+    transition: color 0.15s, border-color 0.15s, background 0.15s;
+    white-space: nowrap;
+  }
+  .skill-copy:hover {
+    color: var(--fg);
+    border-color: var(--accent);
+  }
+  .skill-copy.copied {
+    color: #fff;
+    background: var(--accent-solid);
+    border-color: var(--accent-solid);
+  }
+
+  /* List view: the parent grid sets data-view="list". Reflow each card into a
+     compact horizontal row so many skills fit on screen. */
+  :global([data-view="list"]) .skill-card {
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: stretch;
+  }
+  :global([data-view="list"]) .skill-card__link {
+    flex: 1 1 320px;
+    flex-direction: row;
+    align-items: center;
+    min-width: 0;
+  }
+  :global([data-view="list"]) .skill-thumb {
+    width: 96px;
+    height: 68px;
+    border-bottom: none;
+    border-right: 1px solid var(--border);
+    flex: none;
+  }
+  :global([data-view="list"]) .skill-body {
+    padding: 0.55rem 0.9rem;
+  }
+  :global([data-view="list"]) .skill-tagline {
+    -webkit-line-clamp: 1;
+    line-clamp: 1;
+  }
+  :global([data-view="list"]) .skill-foot {
+    border-top: none;
+    border-left: 1px solid var(--border);
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: center;
+    gap: 0.45rem;
+  }
+  /* On narrow viewports the row would cramp, so fall back to a stacked card. */
+  @media (max-width: 560px) {
+    :global([data-view="list"]) .skill-card {
+      flex-direction: column;
+    }
+    :global([data-view="list"]) .skill-card__link {
+      flex-direction: column;
+    }
+    :global([data-view="list"]) .skill-thumb {
+      width: 100%;
+      height: 128px;
+      border-right: none;
+      border-bottom: 1px solid var(--border);
+    }
+    :global([data-view="list"]) .skill-foot {
+      flex-direction: row;
+      align-items: center;
+      justify-content: space-between;
+      border-left: none;
+      border-top: 1px solid var(--border);
+    }
   }
 </style>

--- a/site/src/components/SkillGrid.astro
+++ b/site/src/components/SkillGrid.astro
@@ -1,0 +1,290 @@
+---
+import SkillCard from "./SkillCard.astro";
+
+interface SkillEntry {
+  id: string;
+  data: { title: string; tagline: string; thumb: string };
+}
+interface Props {
+  skills: SkillEntry[];
+  /** Show the live search box. Off for the landing page's curated glance. */
+  search?: boolean;
+}
+const { skills, search = true } = Astro.props;
+const base = import.meta.env.BASE_URL;
+const total = skills.length;
+---
+
+<div class="skill-view">
+  <div class="view-toolbar">
+    {search && (
+      <div class="view-search">
+        <svg class="view-search__icon" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true">
+          <path d="M11.74 10.34a6 6 0 1 0-1.4 1.4l3.2 3.2a1 1 0 0 0 1.42-1.42l-3.22-3.18ZM3 7a4 4 0 1 1 8 0 4 4 0 0 1-8 0Z"/>
+        </svg>
+        <input
+          type="search"
+          class="view-search__input"
+          placeholder="Search skills…"
+          aria-label="Search skills"
+          autocomplete="off"
+          spellcheck="false"
+        />
+      </div>
+    )}
+    <p class="view-count muted" data-total={total} aria-live="polite">{total} skills</p>
+    <div class="view-switch" role="group" aria-label="Choose skill layout">
+      <button
+        type="button"
+        class="view-btn is-active"
+        data-view-set="grid"
+        aria-label="Grid view"
+        aria-pressed="true"
+        title="Grid view"
+      >
+        <svg viewBox="0 0 20 20" width="18" height="18" fill="currentColor" aria-hidden="true">
+          <rect x="2" y="2" width="7" height="7" rx="1.5" />
+          <rect x="11" y="2" width="7" height="7" rx="1.5" />
+          <rect x="2" y="11" width="7" height="7" rx="1.5" />
+          <rect x="11" y="11" width="7" height="7" rx="1.5" />
+        </svg>
+      </button>
+      <button
+        type="button"
+        class="view-btn"
+        data-view-set="list"
+        aria-label="List view"
+        aria-pressed="false"
+        title="List view"
+      >
+        <svg viewBox="0 0 20 20" width="18" height="18" fill="currentColor" aria-hidden="true">
+          <circle cx="3.5" cy="4" r="1.5" />
+          <circle cx="3.5" cy="10" r="1.5" />
+          <circle cx="3.5" cy="16" r="1.5" />
+          <rect x="7" y="3" width="11" height="2" rx="1" />
+          <rect x="7" y="9" width="11" height="2" rx="1" />
+          <rect x="7" y="15" width="11" height="2" rx="1" />
+        </svg>
+      </button>
+    </div>
+  </div>
+
+  <div class="skill-grid" data-view="grid">
+    {skills.map((s) => (
+      <SkillCard
+        href={`${base}catalog/${s.id}/`}
+        skillId={s.id}
+        title={s.data.title}
+        tagline={s.data.tagline}
+        thumb={s.data.thumb}
+      />
+    ))}
+  </div>
+
+  <p class="skill-empty muted" hidden>No skills match your search.</p>
+</div>
+
+<!-- Apply the stored layout before paint so a "list" preference doesn't flash as
+     a grid first. Mirrors the no-flash theme script in Layout.astro. -->
+<script is:inline>
+  (function () {
+    try {
+      var v = localStorage.getItem("skills-view") === "list" ? "list" : "grid";
+      document.querySelectorAll(".skill-grid").forEach(function (g) {
+        g.setAttribute("data-view", v);
+      });
+      document.querySelectorAll(".view-btn").forEach(function (b) {
+        var on = b.getAttribute("data-view-set") === v;
+        b.setAttribute("aria-pressed", on ? "true" : "false");
+        b.classList.toggle("is-active", on);
+      });
+    } catch (e) {}
+  })();
+</script>
+
+<style>
+  .view-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    margin: 0 0 1.25rem;
+    flex-wrap: wrap;
+  }
+  .view-search {
+    position: relative;
+    flex: 1 1 220px;
+    min-width: 180px;
+    display: flex;
+    align-items: center;
+  }
+  .view-search__icon {
+    position: absolute;
+    left: 0.7rem;
+    color: var(--muted);
+    pointer-events: none;
+  }
+  .view-search__input {
+    width: 100%;
+    padding: 0.55rem 0.8rem 0.55rem 2.2rem;
+    border-radius: 9px;
+    border: 1px solid var(--border);
+    background: var(--panel);
+    color: var(--fg);
+    font: inherit;
+    font-size: 0.95rem;
+  }
+  .view-search__input:focus-visible {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 30%, transparent);
+  }
+  .view-count {
+    margin: 0;
+    font-size: 0.85rem;
+    white-space: nowrap;
+  }
+  .view-switch {
+    display: flex;
+    gap: 0.3rem;
+    margin-left: auto;
+  }
+  .view-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 34px;
+    height: 34px;
+    border-radius: 9px;
+    border: 1px solid var(--border);
+    background: var(--panel);
+    color: var(--muted);
+    cursor: pointer;
+    transition: color 0.15s, border-color 0.15s, background 0.15s;
+  }
+  .view-btn:hover {
+    border-color: var(--accent);
+    color: var(--fg);
+  }
+  .view-btn.is-active {
+    color: #fff;
+    background: var(--accent-solid);
+    border-color: var(--accent-solid);
+  }
+  .skill-grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
+  }
+  .skill-grid[data-view="list"] {
+    grid-template-columns: 1fr;
+  }
+  .skill-empty {
+    text-align: center;
+    padding: 2rem 0;
+    font-size: 0.95rem;
+  }
+</style>
+
+<script>
+  // Grid/list layout toggle (persisted) + live search filter + copy-install.
+  // Runs on every page load so it re-binds after Astro view transitions.
+  const KEY = "skills-view";
+
+  function readPref(): "grid" | "list" {
+    try {
+      return localStorage.getItem(KEY) === "list" ? "list" : "grid";
+    } catch {
+      return "grid";
+    }
+  }
+
+  function applyView(view: "grid" | "list") {
+    document.querySelectorAll<HTMLElement>(".skill-grid").forEach((grid) => {
+      grid.setAttribute("data-view", view);
+    });
+    document.querySelectorAll<HTMLElement>(".view-btn").forEach((btn) => {
+      const on = btn.getAttribute("data-view-set") === view;
+      btn.setAttribute("aria-pressed", on ? "true" : "false");
+      btn.classList.toggle("is-active", on);
+    });
+  }
+
+  function runFilter(view: HTMLElement, query: string) {
+    const q = query.trim().toLowerCase();
+    const cards = view.querySelectorAll<HTMLElement>(".skill-card");
+    let shown = 0;
+    cards.forEach((card) => {
+      const hay = card.dataset.search ?? "";
+      const match = q === "" || hay.includes(q);
+      card.hidden = !match;
+      if (match) shown += 1;
+    });
+    const count = view.querySelector<HTMLElement>(".view-count");
+    if (count) {
+      const total = count.dataset.total ?? String(cards.length);
+      count.textContent = q === "" ? `${total} skills` : `${shown} of ${total}`;
+    }
+    const empty = view.querySelector<HTMLElement>(".skill-empty");
+    if (empty) empty.hidden = shown !== 0;
+  }
+
+  function initSkillView() {
+    applyView(readPref());
+
+    document.querySelectorAll<HTMLElement>(".skill-view").forEach((view) => {
+      if (view.dataset.viewReady) return;
+      view.dataset.viewReady = "1";
+
+      // Layout switch
+      view.querySelector(".view-switch")?.addEventListener("click", (e) => {
+        const btn = (e.target as Element | null)?.closest<HTMLElement>("[data-view-set]");
+        if (!btn) return;
+        const next = btn.getAttribute("data-view-set") === "list" ? "list" : "grid";
+        try {
+          localStorage.setItem(KEY, next);
+        } catch {}
+        applyView(next);
+      });
+
+      // Live search
+      const input = view.querySelector<HTMLInputElement>(".view-search__input");
+      input?.addEventListener("input", () => runFilter(view, input.value));
+
+      // Copy install command
+      view.addEventListener("click", async (e) => {
+        const btn = (e.target as Element | null)?.closest<HTMLElement>(".skill-copy");
+        if (!btn) return;
+        const cmd = btn.dataset.install ?? "";
+        try {
+          await navigator.clipboard.writeText(cmd);
+        } catch {
+          const ta = document.createElement("textarea");
+          ta.value = cmd;
+          ta.style.position = "fixed";
+          ta.style.opacity = "0";
+          document.body.appendChild(ta);
+          ta.select();
+          try {
+            document.execCommand("copy");
+          } catch {}
+          ta.remove();
+        }
+        const label = btn.querySelector<HTMLElement>(".skill-copy__label");
+        const prev = label?.textContent ?? "Copy install";
+        if (label) label.textContent = "Copied";
+        btn.classList.add("copied");
+        window.setTimeout(() => {
+          if (label) label.textContent = prev;
+          btn.classList.remove("copied");
+        }, 1600);
+      });
+    });
+  }
+
+  document.addEventListener("astro:page-load", initSkillView);
+  // Apply the stored view before paint on client-side navigations too. Astro
+  // de-dupes the identical inline no-flash script by content, so it only runs on
+  // the first page; astro:after-swap fires pre-paint on every transition and
+  // keeps a "list" preference from flashing as grid. Mirrors Layout.astro.
+  document.addEventListener("astro:after-swap", () => applyView(readPref()));
+</script>

--- a/site/src/layouts/Layout.astro
+++ b/site/src/layouts/Layout.astro
@@ -4,8 +4,9 @@ import { ClientRouter } from "astro:transitions";
 interface Props {
   title?: string;
   description?: string;
+  wide?: boolean;
 }
-const { title = "jongio/skills", description = "Jon Gallant's collection of cross-agent skills for AI coding agents — GitHub Copilot, Claude, and Codex." } = Astro.props;
+const { title = "jongio/skills", description = "Jon Gallant's collection of cross-agent skills for AI coding agents — GitHub Copilot, Claude, and Codex.", wide = false } = Astro.props;
 const base = import.meta.env.BASE_URL;
 const repo = "jongio/skills";
 const ogImage = new URL(`${base}images/og.svg`, Astro.site ?? "https://jongio.github.io");
@@ -86,6 +87,7 @@ const ogImage = new URL(`${base}images/og.svg`, Astro.site ?? "https://jongio.gi
       }
       .icon-btn:hover { border-color: var(--accent); }
       .wrap { max-width: 760px; margin: 0 auto; padding: clamp(1.5rem, 5vw, 3.5rem) 1.25rem; }
+      .wrap.wide { max-width: 1200px; }
       .card { background: var(--panel); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem 1.4rem; margin: 1rem 0; }
       .card h2 { margin: 0 0 0.5rem; font-size: 1.2rem; }
       .muted { color: var(--muted); }
@@ -120,7 +122,7 @@ const ogImage = new URL(`${base}images/og.svg`, Astro.site ?? "https://jongio.gi
         </a>
       </div>
     </header>
-    <main class="wrap"><slot /></main>
+    <main class:list={["wrap", { wide }]}><slot /></main>
 
     <script>
       const SUN = '<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>';
@@ -154,7 +156,7 @@ const ogImage = new URL(`${base}images/og.svg`, Astro.site ?? "https://jongio.gi
     <script>
       // Add a "Copy" button to every authored code block.
       function enhanceCopy() {
-        const blocks = document.querySelectorAll(".card pre, .prose pre, .skill-install pre");
+        const blocks = document.querySelectorAll(".card pre, .prose pre");
         blocks.forEach((pre) => {
           if (pre.dataset.copyReady) return;
           const code = pre.querySelector("code");

--- a/site/src/pages/catalog/index.astro
+++ b/site/src/pages/catalog/index.astro
@@ -1,35 +1,17 @@
 ---
 import Layout from "../../layouts/Layout.astro";
-import SkillCard from "../../components/SkillCard.astro";
+import SkillGrid from "../../components/SkillGrid.astro";
 import { getCollection } from "astro:content";
 
-const base = import.meta.env.BASE_URL;
 const skills = (await getCollection("skills")).sort(
   (a, b) => a.data.order - b.data.order,
 );
 ---
 
-<Layout title="Skills · jongio/skills" description="The skills in jongio/skills — install any one, or the whole repo.">
+<Layout wide title="Skills · jongio/skills" description="The skills in jongio/skills — install any one, or the whole repo.">
   <header style="text-align:center;margin-bottom:1.75rem;">
     <h1 style="font-size:clamp(1.75rem,5vw,2.5rem);margin:0 0 .5rem;">Skills</h1>
-    <p class="muted">{skills.length} skills · install one, or the whole repo.</p>
+    <p class="muted">Search, switch layouts, and install any one, or the whole repo.</p>
   </header>
-  <div class="grid">
-    {skills.map((s) => (
-      <SkillCard
-        href={`${base}catalog/${s.id}/`}
-        skillId={s.id}
-        title={s.data.title}
-        tagline={s.data.tagline}
-        thumb={s.data.thumb}
-      />
-    ))}
-  </div>
+  <SkillGrid skills={skills} />
 </Layout>
-
-<style>
-  .grid {
-    display: grid; gap: 1rem;
-    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  }
-</style>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -1,6 +1,6 @@
 ---
 import Layout from "../layouts/Layout.astro";
-import SkillCard from "../components/SkillCard.astro";
+import SkillGrid from "../components/SkillGrid.astro";
 import { getCollection } from "astro:content";
 
 const base = import.meta.env.BASE_URL;
@@ -9,7 +9,7 @@ const skills = (await getCollection("skills")).sort(
 );
 ---
 
-<Layout>
+<Layout wide>
   <header class="hero">
     <p class="eyebrow">Cross-agent skills · GitHub Copilot · Claude · Codex</p>
     <h1>jongio/skills</h1>
@@ -26,21 +26,14 @@ const skills = (await getCollection("skills")).sort(
   </header>
 
   <section>
-    <h2 class="section-title">Skills</h2>
-    <div class="grid">
-      {skills.map((s) => (
-        <SkillCard
-          href={`${base}catalog/${s.id}/`}
-          skillId={s.id}
-          title={s.data.title}
-          tagline={s.data.tagline}
-          thumb={s.data.thumb}
-        />
-      ))}
+    <div class="section-head">
+      <h2 class="section-title">Skills</h2>
+      <a class="section-link" href={`${base}catalog/`}>Browse all →</a>
     </div>
+    <SkillGrid skills={skills} search={false} />
   </section>
 
-  <section class="card">
+  <section class="card install-card">
     <h2>Install</h2>
     <p class="muted">Pick whichever fits your setup.</p>
     <h3>1 · Ask your agent</h3>
@@ -97,10 +90,13 @@ copilot plugin install create-canvas-app@jongio-skills</code></pre>
     border-radius: 9px; padding: 0.7rem 1rem;
   }
   .section-title { font-size: 1.4rem; margin: 0 0 1rem; }
-  .grid {
-    display: grid; gap: 1rem; margin-bottom: 2rem;
-    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  .section-head {
+    display: flex; align-items: baseline; justify-content: space-between;
+    gap: 1rem; margin-bottom: 1rem;
   }
+  .section-head .section-title { margin: 0; }
+  .section-link { font-weight: 600; font-size: 0.92rem; white-space: nowrap; text-decoration: none; }
+  .install-card { max-width: 860px; margin-left: auto; margin-right: auto; }
   .card pre {
     background: var(--bg); border: 1px solid var(--border); border-radius: 9px;
     padding: 0.7rem 0.9rem; overflow-x: auto;


### PR DESCRIPTION
## Summary

Overhauls the homepage and catalog so the site scales as skills are added. Previously the 760px column fit only 1-2 columns and each card carried a full install code block, so you saw about one skill at a time. Now browse pages are wider, cards are compact, and the catalog is searchable.

## What changed

- **Wider browse layout**: opt-in `wide` prop on `Layout` widens the content column to 1200px for the homepage and catalog (4 dense columns). Prose pages (skill detail, about) stay narrow for readability.
- **Compact `SkillCard`**: smaller fixed-height thumbnail, tagline clamped to 2 lines, and the always-open install code block replaced by a one-click **Copy install** button. Cards are roughly half the previous height.
- **New reusable `SkillGrid`**: a toolbar with a live **search** filter (title + tagline), an `aria-live` result count ("1 of 8"), an empty state, and a **grid/list view switcher** whose choice persists in `localStorage`. The stored layout is applied before paint (inline script + `astro:after-swap`) so a "list" preference never flashes as grid across view transitions.
- **List view**: dense row layout (small thumb, title, one-line tagline, actions on the right) with a stacked fallback on narrow screens.
- **Home**: stays a curated landing (grid, no search) with a "Browse all" link; install guide constrained to a readable width.

## Verification

- `astro build` clean (11 pages).
- Browser-verified in a production preview at 1280px and 390px: 4-column density, search filter (checked by computed display, not just the `hidden` property), copy-install to clipboard, view toggle + persistence across reload and pages, mobile stacking. Zero console errors.
- Independent review caught one bug where the search set the `hidden` attribute but `display: flex` overrode the UA `[hidden]` rule, leaving filtered cards visible. Fixed with `.skill-card[hidden] { display: none }` and re-verified.